### PR TITLE
Increase minimum required version of icontract

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black
 coverage
 flake8
-icontract >=2.3.2
+icontract >=2.3.4
 isort
 mypy
 pydotplus


### PR DESCRIPTION
Because of a bug in icontract 2.3.3 our automated tests failed last night. This issue is fixed in version 2.3.4, which also provides a significant performance improvement.