### PR TITLE
Issue 287: Fix missing SPARK_Mode in generic Write procedures in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,17 +213,17 @@ procedure Main is
    Context : RFLX.TLV.Message.Context;
    Data : RFLX.RFLX_Builtin_Types.Bytes (RFLX.RFLX_Builtin_Types.Index'First .. RFLX.RFLX_Builtin_Types.Index'First + 2**14);
 
-   function Data_Length (Length : RFLX.RFLX_Builtin_Types.Length) return Boolean is
+   function Valid_Data_Length (Length : RFLX.RFLX_Builtin_Types.Length) return Boolean is
       (Length <= Data'Length);
 
    procedure Write_Data (Buffer : out RFLX.RFLX_Builtin_Types.Bytes) with
-      Pre => Data_Length (Buffer'Length)
+      Pre => Valid_Data_Length (Buffer'Length)
    is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
    end Write_Data;
 
-   procedure Set_Value is new RFLX.TLV.Message.Set_Value (Write_Data, Data_Length);
+   procedure Set_Value is new RFLX.TLV.Message.Set_Value (Write_Data, Valid_Data_Length);
 begin
    --  Generating message
    RFLX.TLV.Message.Initialize (Context, Buffer);

--- a/README.md
+++ b/README.md
@@ -213,12 +213,17 @@ procedure Main is
    Context : RFLX.TLV.Message.Context;
    Data : RFLX.RFLX_Builtin_Types.Bytes (RFLX.RFLX_Builtin_Types.Index'First .. RFLX.RFLX_Builtin_Types.Index'First + 2**14);
 
-   procedure Write_Data (Buffer : out RFLX.RFLX_Builtin_Types.Bytes) is
+   function Data_Length (Length : RFLX.RFLX_Builtin_Types.Length) return Boolean is
+      (Length <= Data'Length);
+
+   procedure Write_Data (Buffer : out RFLX.RFLX_Builtin_Types.Bytes) with
+      Pre => Data_Length (Buffer'Length)
+   is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
    end Write_Data;
 
-   procedure Set_Value is new RFLX.TLV.Message.Set_Value (Write_Data);
+   procedure Set_Value is new RFLX.TLV.Message.Set_Value (Write_Data, Data_Length);
 begin
    --  Generating message
    RFLX.TLV.Message.Initialize (Context, Buffer);

--- a/generated/rflx-arrays-generic_inner_message.ads
+++ b/generated/rflx-arrays-generic_inner_message.ads
@@ -216,6 +216,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
+      with function Check_Length_Payload (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -223,7 +224,10 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0
+       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -241,7 +245,9 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-arrays-generic_inner_message.ads
+++ b/generated/rflx-arrays-generic_inner_message.ads
@@ -216,7 +216,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
-      with function Check_Length_Payload (Length : Types.Length) return Boolean;
+      with function Valid_Length (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -225,9 +225,9 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0
-       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Field_Length (Ctx, F_Payload) / Types.Byte'Size)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -246,8 +246,8 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-ethernet-generic_frame.ads
+++ b/generated/rflx-ethernet-generic_frame.ads
@@ -415,7 +415,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
-      with function Check_Length_Payload (Length : Types.Length) return Boolean;
+      with function Valid_Length (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -424,9 +424,9 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload), Field_Length (Ctx, F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0
-       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Field_Length (Ctx, F_Payload) / Types.Byte'Size)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -442,7 +442,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
-      with function Check_Length_Payload (Length : Types.Length) return Boolean;
+      with function Valid_Length (Length : Types.Length) return Boolean;
    procedure Set_Bounded_Payload (Ctx : in out Context; Length : Types.Bit_Length) with
      Pre =>
        not Ctx'Constrained
@@ -454,9 +454,9 @@ is
        and then (Field_First (Ctx, F_Payload) + Length) <= Types.Bit_Index'Last / 2
        and then ((Valid (Ctx, F_Type_Length)
                   and Get_Type_Length (Ctx) >= 1536))
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Length mod 8 = 0
-       and then Check_Length_Payload (Types.Length (Length / 8)),
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Length mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Length / Types.Byte'Size)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -478,8 +478,8 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload), Field_Length (Ctx, F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -504,8 +504,8 @@ is
        and then (Field_First (Ctx, F_Payload) + Length) <= Types.Bit_Index'Last / 2
        and then ((Valid (Ctx, F_Type_Length)
                   and Get_Type_Length (Ctx) >= 1536))
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Length mod 8 = 0,
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Length mod Types.Byte'Size = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-ethernet-generic_frame.ads
+++ b/generated/rflx-ethernet-generic_frame.ads
@@ -415,6 +415,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
+      with function Check_Length_Payload (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -422,7 +423,10 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload), Field_Length (Ctx, F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0
+       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -438,6 +442,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
+      with function Check_Length_Payload (Length : Types.Length) return Boolean;
    procedure Set_Bounded_Payload (Ctx : in out Context; Length : Types.Bit_Length) with
      Pre =>
        not Ctx'Constrained
@@ -448,7 +453,10 @@ is
        and then Available_Space (Ctx, F_Payload) >= Length
        and then (Field_First (Ctx, F_Payload) + Length) <= Types.Bit_Index'Last / 2
        and then ((Valid (Ctx, F_Type_Length)
-                  and Get_Type_Length (Ctx) >= 1536)),
+                  and Get_Type_Length (Ctx) >= 1536))
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Length mod 8 = 0
+       and then Check_Length_Payload (Types.Length (Length / 8)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -469,7 +477,9 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload), Field_Length (Ctx, F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -493,7 +503,9 @@ is
        and then Available_Space (Ctx, F_Payload) >= Length
        and then (Field_First (Ctx, F_Payload) + Length) <= Types.Bit_Index'Last / 2
        and then ((Valid (Ctx, F_Type_Length)
-                  and Get_Type_Length (Ctx) >= 1536)),
+                  and Get_Type_Length (Ctx) >= 1536))
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Length mod 8 = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-expression-generic_message.ads
+++ b/generated/rflx-expression-generic_message.ads
@@ -188,7 +188,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
-      with function Check_Length_Payload (Length : Types.Length) return Boolean;
+      with function Valid_Length (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -197,9 +197,9 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0
-       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Field_Length (Ctx, F_Payload) / Types.Byte'Size)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -217,8 +217,8 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-expression-generic_message.ads
+++ b/generated/rflx-expression-generic_message.ads
@@ -188,6 +188,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
+      with function Check_Length_Payload (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -195,7 +196,10 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0
+       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -212,7 +216,9 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-ipv4-generic_option.ads
+++ b/generated/rflx-ipv4-generic_option.ads
@@ -338,6 +338,7 @@ is
 
    generic
       with procedure Process_Option_Data (Option_Data : out Types.Bytes);
+      with function Check_Length_Option_Data (Length : Types.Length) return Boolean;
    procedure Set_Option_Data (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -345,7 +346,10 @@ is
        and then Valid_Next (Ctx, F_Option_Data)
        and then Field_Last (Ctx, F_Option_Data) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Option_Data))
-       and then Available_Space (Ctx, F_Option_Data) >= Field_Length (Ctx, F_Option_Data),
+       and then Available_Space (Ctx, F_Option_Data) >= Field_Length (Ctx, F_Option_Data)
+       and then Field_First (Ctx, F_Option_Data) mod 8 = 1
+       and then Field_Length (Ctx, F_Option_Data) mod 8 = 0
+       and then Check_Length_Option_Data (Types.Length (Field_Length (Ctx, F_Option_Data) / 8)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -366,7 +370,9 @@ is
        and then Valid_Next (Ctx, F_Option_Data)
        and then Field_Last (Ctx, F_Option_Data) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Option_Data))
-       and then Available_Space (Ctx, F_Option_Data) >= Field_Length (Ctx, F_Option_Data),
+       and then Available_Space (Ctx, F_Option_Data) >= Field_Length (Ctx, F_Option_Data)
+       and then Field_First (Ctx, F_Option_Data) mod 8 = 1
+       and then Field_Length (Ctx, F_Option_Data) mod 8 = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-ipv4-generic_option.ads
+++ b/generated/rflx-ipv4-generic_option.ads
@@ -338,7 +338,7 @@ is
 
    generic
       with procedure Process_Option_Data (Option_Data : out Types.Bytes);
-      with function Check_Length_Option_Data (Length : Types.Length) return Boolean;
+      with function Valid_Length (Length : Types.Length) return Boolean;
    procedure Set_Option_Data (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -347,9 +347,9 @@ is
        and then Field_Last (Ctx, F_Option_Data) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Option_Data))
        and then Available_Space (Ctx, F_Option_Data) >= Field_Length (Ctx, F_Option_Data)
-       and then Field_First (Ctx, F_Option_Data) mod 8 = 1
-       and then Field_Length (Ctx, F_Option_Data) mod 8 = 0
-       and then Check_Length_Option_Data (Types.Length (Field_Length (Ctx, F_Option_Data) / 8)),
+       and then Field_First (Ctx, F_Option_Data) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Option_Data) mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Field_Length (Ctx, F_Option_Data) / Types.Byte'Size)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -371,8 +371,8 @@ is
        and then Field_Last (Ctx, F_Option_Data) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Option_Data))
        and then Available_Space (Ctx, F_Option_Data) >= Field_Length (Ctx, F_Option_Data)
-       and then Field_First (Ctx, F_Option_Data) mod 8 = 1
-       and then Field_Length (Ctx, F_Option_Data) mod 8 = 0,
+       and then Field_First (Ctx, F_Option_Data) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Option_Data) mod Types.Byte'Size = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-ipv4-generic_packet.ads
+++ b/generated/rflx-ipv4-generic_packet.ads
@@ -964,7 +964,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
-      with function Check_Length_Payload (Length : Types.Length) return Boolean;
+      with function Valid_Length (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -973,9 +973,9 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0
-       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Field_Length (Ctx, F_Payload) / Types.Byte'Size)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -1008,8 +1008,8 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-ipv4-generic_packet.ads
+++ b/generated/rflx-ipv4-generic_packet.ads
@@ -964,6 +964,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
+      with function Check_Length_Payload (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -971,7 +972,10 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0
+       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -1003,7 +1007,9 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-tlv-generic_message.ads
+++ b/generated/rflx-tlv-generic_message.ads
@@ -250,7 +250,7 @@ is
 
    generic
       with procedure Process_Value (Value : out Types.Bytes);
-      with function Check_Length_Value (Length : Types.Length) return Boolean;
+      with function Valid_Length (Length : Types.Length) return Boolean;
    procedure Set_Value (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -259,9 +259,9 @@ is
        and then Field_Last (Ctx, F_Value) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Value))
        and then Available_Space (Ctx, F_Value) >= Field_Length (Ctx, F_Value)
-       and then Field_First (Ctx, F_Value) mod 8 = 1
-       and then Field_Length (Ctx, F_Value) mod 8 = 0
-       and then Check_Length_Value (Types.Length (Field_Length (Ctx, F_Value) / 8)),
+       and then Field_First (Ctx, F_Value) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Value) mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Field_Length (Ctx, F_Value) / Types.Byte'Size)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -281,8 +281,8 @@ is
        and then Field_Last (Ctx, F_Value) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Value))
        and then Available_Space (Ctx, F_Value) >= Field_Length (Ctx, F_Value)
-       and then Field_First (Ctx, F_Value) mod 8 = 1
-       and then Field_Length (Ctx, F_Value) mod 8 = 0,
+       and then Field_First (Ctx, F_Value) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Value) mod Types.Byte'Size = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-tlv-generic_message.ads
+++ b/generated/rflx-tlv-generic_message.ads
@@ -250,6 +250,7 @@ is
 
    generic
       with procedure Process_Value (Value : out Types.Bytes);
+      with function Check_Length_Value (Length : Types.Length) return Boolean;
    procedure Set_Value (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -257,7 +258,10 @@ is
        and then Valid_Next (Ctx, F_Value)
        and then Field_Last (Ctx, F_Value) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Value))
-       and then Available_Space (Ctx, F_Value) >= Field_Length (Ctx, F_Value),
+       and then Available_Space (Ctx, F_Value) >= Field_Length (Ctx, F_Value)
+       and then Field_First (Ctx, F_Value) mod 8 = 1
+       and then Field_Length (Ctx, F_Value) mod 8 = 0
+       and then Check_Length_Value (Types.Length (Field_Length (Ctx, F_Value) / 8)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -276,7 +280,9 @@ is
        and then Valid_Next (Ctx, F_Value)
        and then Field_Last (Ctx, F_Value) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Value))
-       and then Available_Space (Ctx, F_Value) >= Field_Length (Ctx, F_Value),
+       and then Available_Space (Ctx, F_Value) >= Field_Length (Ctx, F_Value)
+       and then Field_First (Ctx, F_Value) mod 8 = 1
+       and then Field_Length (Ctx, F_Value) mod 8 = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-udp-generic_datagram.ads
+++ b/generated/rflx-udp-generic_datagram.ads
@@ -318,7 +318,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
-      with function Check_Length_Payload (Length : Types.Length) return Boolean;
+      with function Valid_Length (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -327,9 +327,9 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0
-       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Field_Length (Ctx, F_Payload) / Types.Byte'Size)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -351,8 +351,8 @@ is
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
        and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
-       and then Field_First (Ctx, F_Payload) mod 8 = 1
-       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
+       and then Field_First (Ctx, F_Payload) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Payload) mod Types.Byte'Size = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/generated/rflx-udp-generic_datagram.ads
+++ b/generated/rflx-udp-generic_datagram.ads
@@ -318,6 +318,7 @@ is
 
    generic
       with procedure Process_Payload (Payload : out Types.Bytes);
+      with function Check_Length_Payload (Length : Types.Length) return Boolean;
    procedure Set_Payload (Ctx : in out Context) with
      Pre =>
        not Ctx'Constrained
@@ -325,7 +326,10 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0
+       and then Check_Length_Payload (Types.Length (Field_Length (Ctx, F_Payload) / 8)),
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old
@@ -346,7 +350,9 @@ is
        and then Valid_Next (Ctx, F_Payload)
        and then Field_Last (Ctx, F_Payload) <= Types.Bit_Index'Last / 2
        and then Field_Condition (Ctx, (Fld => F_Payload))
-       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload),
+       and then Available_Space (Ctx, F_Payload) >= Field_Length (Ctx, F_Payload)
+       and then Field_First (Ctx, F_Payload) mod 8 = 1
+       and then Field_Length (Ctx, F_Payload) mod 8 = 0,
      Post =>
        Has_Buffer (Ctx)
        and Ctx.Buffer_First = Ctx.Buffer_First'Old

--- a/rflx/generator/generator.py
+++ b/rflx/generator/generator.py
@@ -48,6 +48,7 @@ from rflx.expression import (
     Or,
     Range,
     Selected,
+    Size,
     Slice,
     Variable,
 )
@@ -400,9 +401,7 @@ class GeneratorGenerator:
                 ),
                 FormalSubprogramDeclaration(
                     FunctionSpecification(
-                        f"Check_Length_{field.name}",
-                        "Boolean",
-                        [Parameter(["Length"], const.TYPES_LENGTH)],
+                        "Valid_Length", "Boolean", [Parameter(["Length"], const.TYPES_LENGTH)],
                     )
                 ),
             ]
@@ -417,7 +416,7 @@ class GeneratorGenerator:
                                 *self.setter_preconditions(f),
                                 *self.unbounded_composite_setter_preconditions(message, f),
                                 Call(
-                                    f"Check_Length_{f.name}",
+                                    "Valid_Length",
                                     [
                                         Call(
                                             const.TYPES_LENGTH,
@@ -427,7 +426,7 @@ class GeneratorGenerator:
                                                         "Field_Length",
                                                         [Variable("Ctx"), Variable(f.affixed_name)],
                                                     ),
-                                                    Number(8),
+                                                    Size(const.TYPES_BYTE),
                                                 ),
                                             ],
                                         ),
@@ -451,11 +450,11 @@ class GeneratorGenerator:
                                 *self.setter_preconditions(f),
                                 *self.bounded_composite_setter_preconditions(message, f),
                                 Call(
-                                    f"Check_Length_{f.name}",
+                                    "Valid_Length",
                                     [
                                         Call(
                                             const.TYPES_LENGTH,
-                                            [Div(Variable("Length"), Number(8))],
+                                            [Div(Variable("Length"), Size(const.TYPES_BYTE))],
                                         )
                                     ],
                                 ),
@@ -683,14 +682,15 @@ class GeneratorGenerator:
             common.sufficient_space_for_field_condition(Variable(field.affixed_name)),
             Equal(
                 Mod(
-                    Call("Field_First", [Variable("Ctx"), Variable(field.affixed_name)]), Number(8)
+                    Call("Field_First", [Variable("Ctx"), Variable(field.affixed_name)]),
+                    Size(const.TYPES_BYTE),
                 ),
                 Number(1),
             ),
             Equal(
                 Mod(
                     Call("Field_Length", [Variable("Ctx"), Variable(field.affixed_name)]),
-                    Number(8),
+                    Size(const.TYPES_BYTE),
                 ),
                 Number(0),
             ),
@@ -737,11 +737,12 @@ class GeneratorGenerator:
             ),
             Equal(
                 Mod(
-                    Call("Field_First", [Variable("Ctx"), Variable(field.affixed_name)]), Number(8)
+                    Call("Field_First", [Variable("Ctx"), Variable(field.affixed_name)]),
+                    Size(const.TYPES_BYTE),
                 ),
                 Number(1),
             ),
-            Equal(Mod(Variable("Length"), Number(8)), Number(0),),
+            Equal(Mod(Variable("Length"), Size(const.TYPES_BYTE)), Number(0),),
         ]
 
 

--- a/test.gpr
+++ b/test.gpr
@@ -44,9 +44,9 @@ project Test is
             for Proof_Switches ("rflx-custom_types_tests.adb") use ("--steps=2000");
             for Proof_Switches ("rflx-derivation-tests.adb") use ("--steps=4000");
             for Proof_Switches ("rflx-ethernet-tests.adb") use ("--steps=2000");
-            for Proof_Switches ("rflx-in_ethernet-tests.adb") use ("--steps=64000");
-            for Proof_Switches ("rflx-in_ipv4-tests.adb") use ("--steps=98000");
-            for Proof_Switches ("rflx-ipv4-tests.adb") use ("--steps=48000");
+            for Proof_Switches ("rflx-in_ethernet-tests.adb") use ("--steps=100000");
+            for Proof_Switches ("rflx-in_ipv4-tests.adb") use ("--steps=126000");
+            for Proof_Switches ("rflx-ipv4-tests.adb") use ("--steps=66000");
       end case;
    end Prove;
 

--- a/tests/rflx-arrays-tests.adb
+++ b/tests/rflx-arrays-tests.adb
@@ -25,7 +25,13 @@ package body RFLX.Arrays.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 1) :=
      (others => 0);
 
-   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) is
+   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+      (L <= Data'Length);
+
+   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
+      SPARK_Mode,
+      Pre => Data_Length (Buffer'Length)
+   is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
    end Write_Data;
@@ -999,7 +1005,7 @@ package body RFLX.Arrays.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new Arrays.Inner_Message.Set_Payload (Write_Data);
+      procedure Set_Payload is new Arrays.Inner_Message.Set_Payload (Write_Data, Data_Length);
       Expected         : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(5, 1, 3, 2, 4, 6);
       Buffer           : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(0, 0, 0, 0, 0, 0);
       Context          : Arrays.Messages_Message.Context;

--- a/tests/rflx-arrays-tests.adb
+++ b/tests/rflx-arrays-tests.adb
@@ -25,12 +25,12 @@ package body RFLX.Arrays.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 1) :=
      (others => 0);
 
-   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+   function Valid_Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
       (L <= Data'Length);
 
    procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
       SPARK_Mode,
-      Pre => Data_Length (Buffer'Length)
+      Pre => Valid_Data_Length (Buffer'Length)
    is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
@@ -1005,7 +1005,7 @@ package body RFLX.Arrays.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new Arrays.Inner_Message.Set_Payload (Write_Data, Data_Length);
+      procedure Set_Payload is new Arrays.Inner_Message.Set_Payload (Write_Data, Valid_Data_Length);
       Expected         : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(5, 1, 3, 2, 4, 6);
       Buffer           : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(0, 0, 0, 0, 0, 0);
       Context          : Arrays.Messages_Message.Context;

--- a/tests/rflx-ethernet-tests.adb
+++ b/tests/rflx-ethernet-tests.adb
@@ -26,7 +26,13 @@ package body RFLX.Ethernet.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 46) :=
      (others => 0);
 
-   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) is
+   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+      (L <= Data'Length);
+
+   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
+      SPARK_Mode,
+      Pre => Data_Length (Buffer'Length)
+   is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
    end Write_Data;
@@ -307,7 +313,7 @@ package body RFLX.Ethernet.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data);
+      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_ipv4_udp.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 2000 - 1 => 0);
@@ -341,7 +347,7 @@ package body RFLX.Ethernet.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new Ethernet.Frame.Set_Payload (Write_Data);
+      procedure Set_Payload is new Ethernet.Frame.Set_Payload (Write_Data, Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_802.3.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 2000 - 1 => 0);
@@ -375,7 +381,7 @@ package body RFLX.Ethernet.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data);
+      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_vlan_tag.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 2000 - 1 => 0);
@@ -421,7 +427,7 @@ package body RFLX.Ethernet.Tests is
       --  Simulate a type/length/TPID value that is determined at runtime
       function Dynamic_Type_Length is new Identity (Ethernet.Type_Length);
 
-      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data);
+      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_vlan_tag.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 2000 - 1 => 0);

--- a/tests/rflx-ethernet-tests.adb
+++ b/tests/rflx-ethernet-tests.adb
@@ -26,12 +26,12 @@ package body RFLX.Ethernet.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 46) :=
      (others => 0);
 
-   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+   function Valid_Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
       (L <= Data'Length);
 
    procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
       SPARK_Mode,
-      Pre => Data_Length (Buffer'Length)
+      Pre => Valid_Data_Length (Buffer'Length)
    is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
@@ -313,7 +313,7 @@ package body RFLX.Ethernet.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Data_Length);
+      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Valid_Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_ipv4_udp.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 2000 - 1 => 0);
@@ -347,7 +347,7 @@ package body RFLX.Ethernet.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new Ethernet.Frame.Set_Payload (Write_Data, Data_Length);
+      procedure Set_Payload is new Ethernet.Frame.Set_Payload (Write_Data, Valid_Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_802.3.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 2000 - 1 => 0);
@@ -381,7 +381,7 @@ package body RFLX.Ethernet.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Data_Length);
+      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Valid_Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_vlan_tag.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 2000 - 1 => 0);
@@ -427,7 +427,7 @@ package body RFLX.Ethernet.Tests is
       --  Simulate a type/length/TPID value that is determined at runtime
       function Dynamic_Type_Length is new Identity (Ethernet.Type_Length);
 
-      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Data_Length);
+      procedure Set_Bounded_Payload is new Ethernet.Frame.Set_Bounded_Payload (Write_Data, Valid_Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_vlan_tag.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 2000 - 1 => 0);

--- a/tests/rflx-in_ethernet-tests.adb
+++ b/tests/rflx-in_ethernet-tests.adb
@@ -21,7 +21,13 @@ package body RFLX.In_Ethernet.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 25) :=
      (others => 0);
 
-   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) is
+   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+      (L <= Data'Length);
+
+   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
+      SPARK_Mode,
+      Pre => Data_Length (Buffer'Length)
+   is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
    end Write_Data;
@@ -67,7 +73,7 @@ package body RFLX.In_Ethernet.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new IPv4.Packet.Set_Payload (Write_Data);
+      procedure Set_Payload is new IPv4.Packet.Set_Payload (Write_Data, Data_Length);
       Expected               : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_ipv4_udp.raw");
       Buffer                 : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First

--- a/tests/rflx-in_ethernet-tests.adb
+++ b/tests/rflx-in_ethernet-tests.adb
@@ -21,12 +21,12 @@ package body RFLX.In_Ethernet.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 25) :=
      (others => 0);
 
-   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+   function Valid_Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
       (L <= Data'Length);
 
    procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
       SPARK_Mode,
-      Pre => Data_Length (Buffer'Length)
+      Pre => Valid_Data_Length (Buffer'Length)
    is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
@@ -73,7 +73,7 @@ package body RFLX.In_Ethernet.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new IPv4.Packet.Set_Payload (Write_Data, Data_Length);
+      procedure Set_Payload is new IPv4.Packet.Set_Payload (Write_Data, Valid_Data_Length);
       Expected               : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_ipv4_udp.raw");
       Buffer                 : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First

--- a/tests/rflx-in_ipv4-tests.adb
+++ b/tests/rflx-in_ipv4-tests.adb
@@ -23,7 +23,13 @@ package body RFLX.In_IPv4.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 25) :=
      (others => 0);
 
-   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) is
+   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+      (L <= Data'Length);
+
+   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
+      SPARK_Mode,
+      Pre => Data_Length (Buffer'Length)
+   is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
    end Write_Data;
@@ -121,7 +127,7 @@ package body RFLX.In_IPv4.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new UDP.Datagram.Set_Payload (Write_Data);
+      procedure Set_Payload is new UDP.Datagram.Set_Payload (Write_Data, Data_Length);
       Expected               : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_ipv4_udp.raw");
       Buffer                 : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First

--- a/tests/rflx-in_ipv4-tests.adb
+++ b/tests/rflx-in_ipv4-tests.adb
@@ -23,12 +23,12 @@ package body RFLX.In_IPv4.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 25) :=
      (others => 0);
 
-   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+   function Valid_Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
       (L <= Data'Length);
 
    procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
       SPARK_Mode,
-      Pre => Data_Length (Buffer'Length)
+      Pre => Valid_Data_Length (Buffer'Length)
    is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
@@ -127,7 +127,7 @@ package body RFLX.In_IPv4.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new UDP.Datagram.Set_Payload (Write_Data, Data_Length);
+      procedure Set_Payload is new UDP.Datagram.Set_Payload (Write_Data, Valid_Data_Length);
       Expected               : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ethernet_ipv4_udp.raw");
       Buffer                 : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First

--- a/tests/rflx-ipv4-tests.adb
+++ b/tests/rflx-ipv4-tests.adb
@@ -40,12 +40,12 @@ package body RFLX.IPv4.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 23) :=
      (others => 0);
 
-   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+   function Valid_Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
       (L <= Data'Length);
 
    procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
       SPARK_Mode,
-      Pre => Data_Length (Buffer'Length)
+      Pre => Valid_Data_Length (Buffer'Length)
    is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
@@ -293,7 +293,7 @@ package body RFLX.IPv4.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new IPv4.Packet.Set_Payload (Write_Data, Data_Length);
+      procedure Set_Payload is new IPv4.Packet.Set_Payload (Write_Data, Valid_Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ipv4_udp.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First
@@ -338,7 +338,7 @@ package body RFLX.IPv4.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Option_Data is new IPv4.Option.Set_Option_Data (Write_Data, Data_Length);
+      procedure Set_Option_Data is new IPv4.Option.Set_Option_Data (Write_Data, Valid_Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(68, 3, 42);
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(0, 0, 0);
       Context  : IPv4.Option.Context;

--- a/tests/rflx-ipv4-tests.adb
+++ b/tests/rflx-ipv4-tests.adb
@@ -40,7 +40,13 @@ package body RFLX.IPv4.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 23) :=
      (others => 0);
 
-   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) is
+   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+      (L <= Data'Length);
+
+   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
+      SPARK_Mode,
+      Pre => Data_Length (Buffer'Length)
+   is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
    end Write_Data;
@@ -287,7 +293,7 @@ package body RFLX.IPv4.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Payload is new IPv4.Packet.Set_Payload (Write_Data);
+      procedure Set_Payload is new IPv4.Packet.Set_Payload (Write_Data, Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := Read_File_Ptr ("tests/ipv4_udp.raw");
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr :=
         new RFLX_Builtin_Types.Bytes'(RFLX_Builtin_Types.Index'First
@@ -332,7 +338,7 @@ package body RFLX.IPv4.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Option_Data is new IPv4.Option.Set_Option_Data (Write_Data);
+      procedure Set_Option_Data is new IPv4.Option.Set_Option_Data (Write_Data, Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(68, 3, 42);
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(0, 0, 0);
       Context  : IPv4.Option.Context;

--- a/tests/rflx-tlv-tests.adb
+++ b/tests/rflx-tlv-tests.adb
@@ -27,7 +27,13 @@ package body RFLX.TLV.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 3) :=
      (others => 0);
 
-   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) is
+   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+      (L <= Data'Length);
+
+   procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
+      SPARK_Mode,
+      Pre => Data_Length (Buffer'Length)
+   is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
    end Write_Data;
@@ -145,7 +151,7 @@ package body RFLX.TLV.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Value is new TLV.Message.Set_Value (Write_Data);
+      procedure Set_Value is new TLV.Message.Set_Value (Write_Data, Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(64, 4, 0, 0, 0, 0);
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(0, 0, 0, 0, 0, 0);
       Context  : TLV.Message.Context;
@@ -175,7 +181,7 @@ package body RFLX.TLV.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Value is new TLV.Message.Set_Value (Write_Data);
+      procedure Set_Value is new TLV.Message.Set_Value (Write_Data, Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(64, 0);
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(0, 0);
       Context  : TLV.Message.Context;

--- a/tests/rflx-tlv-tests.adb
+++ b/tests/rflx-tlv-tests.adb
@@ -27,12 +27,12 @@ package body RFLX.TLV.Tests is
    Data : RFLX_Builtin_Types.Bytes (RFLX_Builtin_Types.Index'First .. RFLX_Builtin_Types.Index'First + 3) :=
      (others => 0);
 
-   function Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
+   function Valid_Data_Length (L : RFLX_Builtin_Types.Length) return Boolean is
       (L <= Data'Length);
 
    procedure Write_Data (Buffer : out RFLX_Builtin_Types.Bytes) with
       SPARK_Mode,
-      Pre => Data_Length (Buffer'Length)
+      Pre => Valid_Data_Length (Buffer'Length)
    is
    begin
       Buffer := Data (Data'First .. Data'First + Buffer'Length - 1);
@@ -151,7 +151,7 @@ package body RFLX.TLV.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Value is new TLV.Message.Set_Value (Write_Data, Data_Length);
+      procedure Set_Value is new TLV.Message.Set_Value (Write_Data, Valid_Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(64, 4, 0, 0, 0, 0);
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(0, 0, 0, 0, 0, 0);
       Context  : TLV.Message.Context;
@@ -181,7 +181,7 @@ package body RFLX.TLV.Tests is
      SPARK_Mode, Pre => True
    is
       pragma Unreferenced (T);
-      procedure Set_Value is new TLV.Message.Set_Value (Write_Data, Data_Length);
+      procedure Set_Value is new TLV.Message.Set_Value (Write_Data, Valid_Data_Length);
       Expected : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(64, 0);
       Buffer   : RFLX_Builtin_Types.Bytes_Ptr := new RFLX_Builtin_Types.Bytes'(0, 0);
       Context  : TLV.Message.Context;


### PR DESCRIPTION
 - Allow proving length properties in composite setters