### PR TITLE
Issue 298: Enums with identical literals not always detected

### DIFF
--- a/rflx/model.py
+++ b/rflx/model.py
@@ -292,7 +292,7 @@ class Enumeration(Scalar):
             for i2, e2 in enumerate(literals):
                 if i2 < i1 and e1[0] == e2[0]:
                     self.error.append(
-                        f'duplicate element "{e1[0]}"',
+                        f'duplicate literal "{e1[0]}"',
                         Subsystem.MODEL,
                         Severity.ERROR,
                         e1[0].location if isinstance(e1[0], ID) else self.location,

--- a/rflx/model.py
+++ b/rflx/model.py
@@ -1574,6 +1574,7 @@ class Refinement(Type):
 class Model(Base):
     def __init__(self, types: Sequence[Type]) -> None:
         self.types = types
+        self.__check_types()
 
     @property
     def messages(self) -> Sequence[Message]:
@@ -1582,6 +1583,62 @@ class Model(Base):
     @property
     def refinements(self) -> Sequence[Refinement]:
         return [m for m in self.types if isinstance(m, Refinement)]
+
+    def __check_types(self) -> None:
+        error = RecordFluxError()
+        for e1, e2 in [
+            (e1, e2)
+            for i1, e1 in enumerate(self.types)
+            for i2, e2 in enumerate(self.types)
+            if (
+                isinstance(e1, Enumeration)
+                and isinstance(e2, Enumeration)
+                and i1 < i2
+                and (
+                    e1.package == e2.package
+                    or e1.package == BUILTINS_PACKAGE
+                    or e2.package == BUILTINS_PACKAGE
+                )
+            )
+        ]:
+            identical_literals = set(e2.literals) & set(e1.literals)
+
+            if identical_literals:
+                literals_message = ", ".join([f"{l}" for l in sorted(identical_literals)])
+                error.append(
+                    f"conflicting literals: {literals_message}",
+                    Subsystem.MODEL,
+                    Severity.ERROR,
+                    e2.location,
+                )
+                error.extend(
+                    [
+                        (
+                            f'previous occurrence of "{l}"',
+                            Subsystem.MODEL,
+                            Severity.INFO,
+                            l.location,
+                        )
+                        for l in sorted(identical_literals)
+                    ]
+                )
+
+        literals = {l: t for t in self.types if isinstance(t, Enumeration) for l in t.literals}
+        type_set = {t.identifier.name for t in self.types}
+        name_conflicts = [n for n in literals.keys() if n in type_set]
+        for name in sorted(name_conflicts):
+            error.append(
+                f'literal conflicts with type "{name}"',
+                Subsystem.MODEL,
+                Severity.ERROR,
+                name.location,
+            )
+            type_location = [t.location for t in self.types if t.identifier.name == name][0]
+            error.append(
+                "conflicting type declaration", Subsystem.MODEL, Severity.INFO, type_location,
+            )
+
+        error.propagate()
 
 
 def qualified_literals(types: Mapping[Field, Type], package: ID) -> Dict[ID, Enumeration]:

--- a/rflx/parser/grammar.py
+++ b/rflx/parser/grammar.py
@@ -588,20 +588,6 @@ def parse_aspects(string: str, location: int, tokens: ParseResults) -> Dict[str,
 
 @fatalexceptions
 def parse_type(string: str, location: int, tokens: ParseResults) -> Type:
-    def check_conflicts(tokens: ParseResults, error: RecordFluxError) -> None:
-        for i1, e1 in enumerate(tokens):
-            for i2, e2 in enumerate(tokens):
-                if i2 < i1 and e1[0] == e2[0]:
-                    error.append(
-                        f'duplicate element "{e1[0]}"',
-                        Subsystem.MODEL,
-                        Severity.ERROR,
-                        e1[0].location,
-                    )
-                    error.append(
-                        "previous occurrence", Subsystem.MODEL, Severity.INFO, e2[0].location
-                    )
-
     package = ID("__PACKAGE__")
     name = tokens[1]
 
@@ -619,14 +605,13 @@ def parse_type(string: str, location: int, tokens: ParseResults) -> Type:
     if tokens[3] == "null message":
         return MessageSpec(identifier, [], locn)
     if tokens[3] == "(":
-        elements = dict(tokens[4:-3])
+        elements = tokens[4:-3]
         aspects = tokens[-2]
         if "always_valid" not in aspects:
             aspects["always_valid"] = False
         enumeration = Enumeration(
             identifier, elements, aspects["size"], aspects["always_valid"], locn
         )
-        check_conflicts(tokens[4:-3], enumeration.error)
         return enumeration
     if tokens[3] == "new":
         return DerivationSpec(identifier, tokens[4], locn)

--- a/tests/models.py
+++ b/tests/models.py
@@ -34,7 +34,9 @@ from rflx.model import (
 NULL_MESSAGE = Message("Null.Message", [], {})
 NULL_MODEL = Model([NULL_MESSAGE])
 
-TLV_TAG = Enumeration("TLV.Tag", {"Msg_Data": Number(1), "Msg_Error": Number(3)}, Number(2), False)
+TLV_TAG = Enumeration(
+    "TLV.Tag", [("Msg_Data", Number(1)), ("Msg_Error", Number(3))], Number(2), False
+)
 TLV_LENGTH = ModularInteger("TLV.Length", Pow(Number(2), Number(14)))
 TLV_MESSAGE = Message(
     "TLV.Message",
@@ -117,7 +119,7 @@ ETHERNET_MODEL = Model(
 
 ENUMERATION_PRIORITY = Enumeration(
     "Enumeration.Priority",
-    {"LOW": Number(1), "MEDIUM": Number(4), "HIGH": Number(7)},
+    [("LOW", Number(1)), ("MEDIUM", Number(4)), ("HIGH", Number(7))],
     Number(3),
     True,
 )
@@ -134,12 +136,15 @@ ARRAYS_MODULAR_VECTOR = Array("Arrays.Modular_Vector", ARRAYS_MODULAR_INTEGER)
 ARRAYS_RANGE_INTEGER = RangeInteger("Arrays.Range_Integer", Number(1), Number(100), Number(8))
 ARRAYS_RANGE_VECTOR = Array("Arrays.Range_Vector", ARRAYS_RANGE_INTEGER)
 ARRAYS_ENUMERATION = Enumeration(
-    "Arrays.Enumeration", {"ZERO": Number(0), "ONE": Number(1), "TWO": Number(2)}, Number(8), False,
+    "Arrays.Enumeration",
+    [("ZERO", Number(0)), ("ONE", Number(1)), ("TWO", Number(2))],
+    Number(8),
+    False,
 )
 ARRAYS_ENUMERATION_VECTOR = Array("Arrays.Enumeration_Vector", ARRAYS_ENUMERATION)
 ARRAYS_AV_ENUMERATION = Enumeration(
     "Arrays.AV_Enumeration",
-    {"AV_ZERO": Number(0), "AV_ONE": Number(1), "AV_TWO": Number(2)},
+    [("AV_ZERO", Number(0)), ("AV_ONE", Number(1)), ("AV_TWO", Number(2))],
     Number(8),
     True,
 )
@@ -215,5 +220,8 @@ DERIVATION_MODEL = Model([*ARRAYS_MODEL.types, DERIVATION_MESSAGE])
 MODULAR_INTEGER = ModularInteger("P.Modular", Number(256))
 RANGE_INTEGER = RangeInteger("P.Range", Number(1), Number(100), Number(8))
 ENUMERATION = Enumeration(
-    "P.Enumeration", {"ZERO": Number(0), "ONE": Number(1), "TWO": Number(2)}, Number(8), False,
+    "P.Enumeration",
+    [("ZERO", Number(0)), ("ONE", Number(1)), ("TWO", Number(2))],
+    Number(8),
+    False,
 )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,6 +26,7 @@ from rflx.expression import (
 from rflx.identifier import ID
 from rflx.model import (
     BOOLEAN,
+    BUILTIN_TYPES,
     FINAL,
     INITIAL,
     Array,
@@ -34,6 +35,7 @@ from rflx.model import (
     Field,
     Link,
     Message,
+    Model,
     ModularInteger,
     Opaque,
     RangeInteger,
@@ -136,6 +138,11 @@ M_SMPL_REF_DERI = UnprovenDerivedMessage(
 def assert_type_error(instance: Type, regex: str) -> None:
     with pytest.raises(RecordFluxError, match=regex):
         instance.error.propagate()
+
+
+def assert_model_error(types: Sequence[Type], regex: str) -> None:
+    with pytest.raises(RecordFluxError, match=regex):
+        Model([*BUILTIN_TYPES.values(), *types])
 
 
 def assert_message_model_error(
@@ -1206,4 +1213,83 @@ def test_invalid_enumeration_type_multiple_duplicate_elements() -> None:
         r"<stdin>:3:27: model: info: previous occurrence\n"
         r'<stdin>:3:42: model: error: duplicate element "Bar"\n'
         r"<stdin>:3:32: model: info: previous occurrence",
+    )
+
+
+def test_conflicting_literal_builtin_type() -> None:
+    assert_model_error(
+        [
+            Enumeration(
+                "P.T",
+                [
+                    (ID("E1", Location((3, 27))), Number(1)),
+                    (ID("Boolean", Location((3, 31))), Number(2)),
+                ],
+                Number(8),
+                False,
+            ),
+        ],
+        r'<stdin>:3:31: model: error: literal conflicts with type "Boolean"\n'
+        r"__BUILTINS__:0:0: model: info: conflicting type declaration",
+    )
+
+
+def test_name_conflict_between_literal_and_type() -> None:
+    assert_model_error(
+        [
+            Enumeration(
+                "P.T",
+                [
+                    (ID("Foo", Location((3, 27))), Number(1)),
+                    (ID("Bar", Location((3, 32))), Number(2)),
+                ],
+                Number(1),
+                False,
+            ),
+            ModularInteger("T.Foo", Number(256), Location((4, 16))),
+            ModularInteger("T.Bar", Number(256), Location((5, 16))),
+        ],
+        r'<stdin>:3:32: model: error: literal conflicts with type "Bar"\n'
+        r"<stdin>:5:16: model: info: conflicting type declaration\n"
+        r'<stdin>:3:27: model: error: literal conflicts with type "Foo"\n'
+        r"<stdin>:4:16: model: info: conflicting type declaration",
+    )
+
+
+def test_invalid_enumeration_type_builtin_literals() -> None:
+    assert_model_error(
+        [
+            Enumeration(
+                "P.T",
+                [("True", Number(1)), ("False", Number(2))],
+                Number(1),
+                False,
+                Location((3, 16)),
+            ),
+        ],
+        r"<stdin>:3:16: model: error: conflicting literals: False, True\n"
+        r'__BUILTINS__:0:0: model: info: previous occurrence of "False"\n'
+        r'__BUILTINS__:0:0: model: info: previous occurrence of "True"',
+    )
+
+
+def test_invalid_enumeration_type_identical_literals() -> None:
+    assert_model_error(
+        [
+            Enumeration(
+                "P.T1",
+                [("Foo", Number(1)), (ID("Bar", Location((3, 33))), Number(2))],
+                Number(1),
+                False,
+            ),
+            Enumeration(
+                "P.T2",
+                [("Bar", Number(1)), ("Baz", Number(2))],
+                Number(1),
+                False,
+                Location((4, 16)),
+            ),
+        ],
+        r"<stdin>:4:16: model: error: conflicting literals: Bar\n"
+        r'<stdin>:3:33: model: info: previous occurrence of "Bar"',
     )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1191,7 +1191,7 @@ def test_invalid_enumeration_type_duplicate_elements() -> None:
             Number(1),
             False,
         ),
-        r'<stdin>:3:32: model: error: duplicate element "Foo"\n'
+        r'<stdin>:3:32: model: error: duplicate literal "Foo"\n'
         r"<stdin>:3:27: model: info: previous occurrence",
     )
 
@@ -1209,9 +1209,9 @@ def test_invalid_enumeration_type_multiple_duplicate_elements() -> None:
             Number(2),
             False,
         ),
-        r'<stdin>:3:37: model: error: duplicate element "Foo"\n'
+        r'<stdin>:3:37: model: error: duplicate literal "Foo"\n'
         r"<stdin>:3:27: model: info: previous occurrence\n"
-        r'<stdin>:3:42: model: error: duplicate element "Bar"\n'
+        r'<stdin>:3:42: model: error: duplicate literal "Bar"\n'
         r"<stdin>:3:32: model: info: previous occurrence",
     )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -436,32 +436,6 @@ def test_invalid_enumeration_type_size() -> None:
     )
 
 
-def test_invalid_enumeration_type_duplicate_elements() -> None:
-    assert_error_string(
-        """
-            package Test is
-               type T is (Foo, Foo) with Size => 1;
-            end Test;
-        """,
-        r'<stdin>:3:32: model: error: duplicate element "Foo"\n'
-        r"<stdin>:3:27: model: info: previous occurrence",
-    )
-
-
-def test_invalid_enumeration_type_multiple_duplicate_elements() -> None:
-    assert_error_string(
-        """
-            package Test is
-               type T is (Foo, Bar, Foo, Bar) with Size => 1;
-            end Test;
-        """,
-        r'<stdin>:3:37: model: error: duplicate element "Foo"\n'
-        r"<stdin>:3:27: model: info: previous occurrence\n"
-        r'<stdin>:3:42: model: error: duplicate element "Bar"\n'
-        r"<stdin>:3:32: model: info: previous occurrence",
-    )
-
-
 def test_invalid_enumeration_type_duplicate_values() -> None:
     assert_error_string(
         """
@@ -840,24 +814,27 @@ def test_enumeration_type_spec() -> None:
                 [
                     Enumeration(
                         "__PACKAGE__.Day",
-                        {
-                            "Mon": Number(1),
-                            "Tue": Number(2),
-                            "Wed": Number(3),
-                            "Thu": Number(4),
-                            "Fri": Number(5),
-                            "Sat": Number(6),
-                            "Sun": Number(7),
-                        },
+                        [
+                            ("Mon", Number(1)),
+                            ("Tue", Number(2)),
+                            ("Wed", Number(3)),
+                            ("Thu", Number(4)),
+                            ("Fri", Number(5)),
+                            ("Sat", Number(6)),
+                            ("Sun", Number(7)),
+                        ],
                         Number(3),
                         False,
                     ),
                     Enumeration(
-                        "__PACKAGE__.Gender", {"M": Number(0), "F": Number(1)}, Number(1), False,
+                        "__PACKAGE__.Gender",
+                        [("M", Number(0)), ("F", Number(1))],
+                        Number(1),
+                        False,
                     ),
                     Enumeration(
                         "__PACKAGE__.Priority",
-                        {"LOW": Number(1), "MEDIUM": Number(4), "HIGH": Number(7)},
+                        [("LOW", Number(1)), ("MEDIUM", Number(4)), ("HIGH", Number(7))],
                         Number(3),
                         True,
                     ),

--- a/tests/test_pyrflx.py
+++ b/tests/test_pyrflx.py
@@ -642,7 +642,7 @@ def test_value_range() -> None:
 
 def test_value_enum() -> None:
     # pylint: disable=pointless-statement
-    enumtype = Enumeration("Test.Enum", {"One": Number(1), "Two": Number(2)}, Number(8), False)
+    enumtype = Enumeration("Test.Enum", [("One", Number(1)), ("Two", Number(2))], Number(8), False)
     enumvalue = EnumValue(enumtype)
     assert not enumvalue.initialized
     with pytest.raises(NotInitializedError, match="value not initialized"):
@@ -680,7 +680,7 @@ def test_value_opaque() -> None:
 def test_value_equal() -> None:
     # pylint: disable=comparison-with-itself
     ov = OpaqueValue(Opaque())
-    enumtype = Enumeration("Test.Enum", {"One": Number(1), "Two": Number(2)}, Number(8), False)
+    enumtype = Enumeration("Test.Enum", [("One", Number(1)), ("Two", Number(2))], Number(8), False)
     ev = EnumValue(enumtype)
     rangetype = RangeInteger("Test.Int", Number(8), Number(16), Number(8))
     rv = IntegerValue(rangetype)
@@ -787,7 +787,9 @@ def test_value_parse_from_bitstring(tlv: MessageValue) -> None:
     intval.parse(b"\x02")
     assert intval.value == 2
     enumval = EnumValue(
-        Enumeration("Test.Enum", {"something": Number(1), "other": Number(2)}, Number(2), False,)
+        Enumeration(
+            "Test.Enum", [("something", Number(1)), ("other", Number(2))], Number(2), False,
+        )
     )
     enumval.parse(b"\x01")
     assert enumval.value == "something"
@@ -851,7 +853,9 @@ def test_array_preserve_value() -> None:
     intval = IntegerValue(ModularInteger("Test.Int", Number(256)))
     intval.assign(1)
     enumval = EnumValue(
-        Enumeration("Test.Enum", {"something": Number(1), "other": Number(2)}, Number(2), False,)
+        Enumeration(
+            "Test.Enum", [("something", Number(1)), ("other", Number(2))], Number(2), False,
+        )
     )
     enumval.assign("something")
     type_array = ArrayValue(Array("Test.Array", ModularInteger("Test.Mod_Int", Number(256))))
@@ -878,7 +882,9 @@ def test_array_assign_incorrect_values(
 
     intval = IntegerValue(ModularInteger("Test.Int", Number(256)))
     enumval = EnumValue(
-        Enumeration("Test.Enum", {"something": Number(1), "other": Number(2)}, Number(2), False,)
+        Enumeration(
+            "Test.Enum", [("something", Number(1)), ("other", Number(2))], Number(2), False,
+        )
     )
     enumval.assign("something")
     with pytest.raises(ValueError, match="cannot assign EnumValue to an array of ModularInteger"):

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -341,17 +341,17 @@ def test_invalid_type_condition_enum() -> None:
     ]
     e1 = Enumeration(
         "P.E1",
-        {"E1": Number(1), "E2": Number(2), "E3": Number(3)},
+        [("E1", Number(1)), ("E2", Number(2)), ("E3", Number(3))],
         Number(8),
         False,
-        location=Location((10, 4)),
+        Location((10, 4)),
     )
     e2 = Enumeration(
         "P.E2",
-        {"E4": Number(1), "E5": Number(2), "E6": Number(3)},
+        [("E4", Number(1)), ("E5", Number(2)), ("E6", Number(3))],
         Number(8),
         False,
-        location=Location((11, 4)),
+        Location((11, 4)),
     )
     types = {
         Field("F1"): e1,


### PR DESCRIPTION
- Store enumeration elements as `Sequence[Tuple[StrID, Number]]` so we can check conflicts in `model.Model`
- Move conflict detection for enumeration literals into model

There are still a few checks in the parser which should be done in the model. We should open a different ticket for this, though.