### PR TITLE
Use argparse version action

### DIFF
--- a/rflx/cli.py
+++ b/rflx/cli.py
@@ -22,7 +22,7 @@ def main(argv: List[str]) -> Union[int, str]:
     parser.add_argument(
         "-q", "--quiet", action="store_true", help="disable logging to standard output"
     )
-    parser.add_argument("--version", action="store_true")
+    parser.add_argument("--version", action="version", version=__version__)
 
     subparsers = parser.add_subparsers(dest="subcommand")
 
@@ -67,10 +67,6 @@ def main(argv: List[str]) -> Union[int, str]:
     parser_graph.set_defaults(func=graph)
 
     args = parser.parse_args(argv[1:])
-
-    if args.version:
-        print(__version__)
-        return 0
 
     if not args.subcommand:
         parser.print_usage()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,10 +21,6 @@ def test_main_help() -> None:
         cli.main(["rflx", "-h"])
 
 
-def test_main_version() -> None:
-    assert cli.main(["rflx", "--version"]) == 0
-
-
 def test_main_check() -> None:
     assert cli.main(["rflx", "check", "specs/tlv.rflx"]) == 0
 


### PR DESCRIPTION
Argparse has a specific [version action](https://docs.python.org/dev/library/argparse.html#action) to print the version. I think we should use it instead of implementing it by our own.