### PR TITLE
Issue 328: Fix code generation and other issues

### DIFF
--- a/rflx/generator/common.py
+++ b/rflx/generator/common.py
@@ -125,13 +125,6 @@ def substitution(
                 )
                 return equal_call if isinstance(expression, Equal) else Not(equal_call)
 
-        literals = [
-            l
-            for t in message.types.values()
-            if isinstance(t, Enumeration)
-            for l in t.literals.keys()
-        ]
-
         def field_value(field: Field) -> Expr:
             if public:
                 return Call(f"Get_{field.name}", [Variable("Ctx")])
@@ -147,12 +140,7 @@ def substitution(
             if (
                 isinstance(expression.left, Variable)
                 and Field(expression.left.name) in message.fields
-                and (
-                    isinstance(expression.right, Number)
-                    or (
-                        isinstance(expression.right, Variable) and expression.right.name in literals
-                    )
-                )
+                and isinstance(expression.right, Number)
             ):
                 return expression.__class__(
                     field_value(Field(expression.left.name)), expression.right
@@ -160,10 +148,7 @@ def substitution(
             if (
                 isinstance(expression.right, Variable)
                 and Field(expression.right.name) in message.fields
-                and (
-                    isinstance(expression.left, Number)
-                    or (isinstance(expression.left, Variable) and expression.left.name in literals)
-                )
+                and isinstance(expression.left, Number)
             ):
                 return expression.__class__(
                     expression.left, field_value(Field(expression.right.name))

--- a/rflx/generator/common.py
+++ b/rflx/generator/common.py
@@ -32,6 +32,7 @@ from rflx.expression import (
     Mod,
     Name,
     NamedAggregate,
+    Not,
     NotEqual,
     Number,
     Or,
@@ -87,6 +88,7 @@ def substitution(
                 field = Field(expression.right.name)
                 aggregate = byte_aggregate(expression.left)
             if field and aggregate:
+                assert field in message.fields
                 if embedded:
                     return Equal(
                         Indexed(
@@ -118,7 +120,10 @@ def substitution(
                         ),
                         aggregate,
                     )
-                return Call("Equal", [Variable("Ctx"), Variable(field.affixed_name), aggregate])
+                equal_call = Call(
+                    "Equal", [Variable("Ctx"), Variable(field.affixed_name), aggregate]
+                )
+                return equal_call if isinstance(expression, Equal) else Not(equal_call)
 
         literals = [
             l

--- a/rflx/model.py
+++ b/rflx/model.py
@@ -903,12 +903,6 @@ class AbstractMessage(Type):
                     return literals[expr.identifier]
                 if Field(expr.name) in self.types:
                     return self.types[Field(expr.name)]
-                self.error.append(
-                    'undefined variable "{expr.identifier}" referenced',
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    expr.location,
-                )
                 return None
 
             lefttype = resolve_type(left)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Tuple
 
 import pytest
 
@@ -200,6 +200,35 @@ def test_substitution_relation_aggregate(
     assert_equal(
         relation(left, right).substituted(common.substitution(TLV_MESSAGE)),
         equal_call if relation == expr.Equal else expr.Not(equal_call),
+    )
+
+
+@pytest.mark.parametrize(
+    "expressions,expected",
+    [
+        (
+            (expr.Variable("Length"), expr.Number(1)),
+            (expr.Call("Get_Length", [expr.Variable("Ctx")]), expr.Number(1)),
+        ),
+        (
+            (expr.Number(1), expr.Variable("Length")),
+            (expr.Number(1), expr.Call("Get_Length", [expr.Variable("Ctx")])),
+        ),
+        ((expr.Number(1), expr.Variable("Unknown")), (expr.Number(1), expr.Variable("Unknown"))),
+    ],
+)
+@pytest.mark.parametrize(
+    "relation",
+    [expr.Less, expr.LessEqual, expr.Equal, expr.GreaterEqual, expr.Greater, expr.NotEqual],
+)
+def test_substitution_relation_scalar(
+    relation: Callable[[expr.Expr, expr.Expr], expr.Relation],
+    expressions: Tuple[expr.Expr, expr.Expr],
+    expected: Tuple[expr.Expr, expr.Expr],
+) -> None:
+    assert_equal(
+        relation(*expressions).substituted(common.substitution(TLV_MESSAGE, public=True)),
+        relation(*expected),
     )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -754,7 +754,7 @@ def test_message_nonexistent_variable() -> None:
 
     types = {Field("F1"): enum_type, Field("F2"): mod_type}
     assert_message_model_error(
-        structure, types, '^<stdin>:444:55: model: error: undefined variable "Val3" referenced',
+        structure, types, '^<stdin>:444:55: model: error: undefined variable "Val3" referenced$',
     )
 
 


### PR DESCRIPTION
Besides fixing #328, this will remove useless code introduced while fixing #320 and remove a duplicate, incorrectly formatted error message.

Lessons learned:
- Always write unit tests
- Match the complete error message, not just the beginning

Close #328