### PR TITLE
Issue 336: Underflow not detected for range length field

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=100
-known_third_party=pytest,z3,pydotplus
+known_third_party=icontract,pydotplus,pyparsing,pytest,z3

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,3 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=100
+known_third_party=pytest,z3,pydotplus

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-lines
 from copy import deepcopy
-from typing import Mapping, Sequence
+from typing import Sequence
 
 import pytest
 
@@ -48,7 +48,7 @@ from rflx.model import (
     UnprovenMessage,
 )
 from tests.models import ENUMERATION, ETHERNET_FRAME, MODULAR_INTEGER, RANGE_INTEGER
-from tests.utils import assert_equal
+from tests.utils import assert_equal, assert_message_model_error
 
 M_NO_REF = UnprovenMessage(
     "P.No_Ref",
@@ -146,13 +146,6 @@ def assert_type_error(instance: Type, regex: str) -> None:
 def assert_model_error(types: Sequence[Type], regex: str) -> None:
     with pytest.raises(RecordFluxError, match=regex):
         Model([*BUILTIN_TYPES.values(), *types])
-
-
-def assert_message_model_error(
-    structure: Sequence[Link], types: Mapping[Field, Type], regex: str
-) -> None:
-    with pytest.raises(RecordFluxError, match=regex):
-        Message("P.M", structure, types, Location((10, 8)))
 
 
 def assert_message(actual: Message, expected: Message, msg: str = None) -> None:
@@ -414,6 +407,7 @@ def test_message_ambiguous_first_field() -> None:
         '^<stdin>:10:8: model: error: ambiguous first field in "P.M"\n'
         "<stdin>:2:6: model: info: duplicate\n"
         "<stdin>:3:6: model: info: duplicate",
+        Location((10, 8)),
     )
 
 
@@ -549,12 +543,13 @@ def test_message_cycle() -> None:
     assert_message_model_error(
         structure,
         types,
-        '^<stdin>:10:8: model: error: structure of "P.M" contains cycle'
+        '^<stdin>:10:8: model: error: structure of "P.M" contains cycle',
         # ISSUE: Componolit/RecordFlux#256
         # '\n'
         # '<stdin>:3:5: model: info: field "X" links to "Y"\n'
         # '<stdin>:4:5: model: info: field "Y" links to "Z"\n'
         # '<stdin>:5:5: model: info: field "Z" links to "X"\n',
+        Location((10, 8)),
     )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1520,20 +1520,3 @@ def test_opaque_length_valid_multiple_of_8_dynamic_cond() -> None:
         ],
         {Field("L"): MODULAR_INTEGER, Field("O"): Opaque()},
     )
-
-
-def test_length_range_underflow() -> None:
-    with pytest.raises(
-        RecordFluxError,
-        match=r'^<stdin>:44:3: model: error: negative length for field "O" [(]L -> O[)]$',
-    ):
-        o = Field(ID("O", location=Location((44, 3))))
-        Message(
-            "P.M",
-            [
-                Link(INITIAL, Field("L")),
-                Link(Field("L"), o, length=Mul(Number(8), Sub(Variable("L"), Number(50))),),
-                Link(o, FINAL),
-            ],
-            {Field("L"): RangeInteger("P.Len", Number(40), Number(1500), Number(16)), o: Opaque()},
-        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1520,3 +1520,20 @@ def test_opaque_length_valid_multiple_of_8_dynamic_cond() -> None:
         ],
         {Field("L"): MODULAR_INTEGER, Field("O"): Opaque()},
     )
+
+
+def test_length_range_underflow() -> None:
+    with pytest.raises(
+        RecordFluxError,
+        match=r'^<stdin>:44:3: model: error: negative length for field "O" [(]L -> O[)]$',
+    ):
+        o = Field(ID("O", location=Location((44, 3))))
+        Message(
+            "P.M",
+            [
+                Link(INITIAL, Field("L")),
+                Link(Field("L"), o, length=Mul(Number(8), Sub(Variable("L"), Number(50))),),
+                Link(o, FINAL),
+            ],
+            {Field("L"): RangeInteger("P.Len", Number(40), Number(1500), Number(16)), o: Opaque()},
+        )

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,9 +1,7 @@
 # pylint: disable=too-many-lines
-from typing import Any, Mapping, Sequence
+from typing import Any
 
-import pytest
-
-from rflx.error import Location, RecordFluxError
+from rflx.error import Location
 from rflx.expression import (
     Add,
     Aggregate,
@@ -33,17 +31,9 @@ from rflx.model import (
     ModularInteger,
     Opaque,
     RangeInteger,
-    Type,
 )
 from tests.models import ARRAYS_MODULAR_VECTOR, ENUMERATION, MODULAR_INTEGER, RANGE_INTEGER
-
-
-def assert_message_model_error(
-    structure: Sequence[Link], types: Mapping[Field, Type], regex: str
-) -> None:
-    with pytest.raises(RecordFluxError, match=regex):
-        message = Message("P.M", structure, types)
-        message.error.propagate()
+from tests.utils import assert_message_model_error
 
 
 def test_exclusive_valid() -> None:
@@ -507,20 +497,18 @@ def test_invalid_negative_field_length_modular() -> None:
 
 
 def test_invalid_negative_field_length_range_integer() -> None:
-    with pytest.raises(
-        RecordFluxError,
-        match=r'^<stdin>:44:3: model: error: negative length for field "O" [(]L -> O[)]$',
-    ):
-        o = Field(ID("O", location=Location((44, 3))))
-        Message(
-            "P.M",
-            [
-                Link(INITIAL, Field("L")),
-                Link(Field("L"), o, length=Mul(Number(8), Sub(Variable("L"), Number(50))),),
-                Link(o, FINAL),
-            ],
-            {Field("L"): RANGE_INTEGER, o: Opaque()},
-        )
+    o = Field(ID("O", location=Location((44, 3))))
+    structure = [
+        Link(INITIAL, Field("L")),
+        Link(Field("L"), o, length=Mul(Number(8), Sub(Variable("L"), Number(50))),),
+        Link(o, FINAL),
+    ]
+    types = {Field("L"): RANGE_INTEGER, o: Opaque()}
+    assert_message_model_error(
+        structure,
+        types,
+        r'^<stdin>:44:3: model: error: negative length for field "O" [(]L -> O[)]$',
+    )
 
 
 def test_payload_no_length() -> None:

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -502,13 +502,7 @@ def test_invalid_negative_field_length() -> None:
         Field("F2"): Opaque(),
     }
     assert_message_model_error(
-        structure,
-        types,
-        r"^"
-        r'model: error: negative length for field "F2" [(]F1 -> F2[)]\n'
-        r'model: info: unsatisfied "F1 < 256"\n'
-        r'model: info: unsatisfied "F1 - 300 >= 0"'
-        r"$",
+        structure, types, r"^" r'model: error: negative length for field "F2" [(]F1 -> F2[)]' r"$",
     )
 
 
@@ -638,7 +632,7 @@ def test_field_after_message_start(monkeypatch: Any) -> None:
         structure,
         types,
         r"^"
-        r'model: error: negative length for field "F2" [(]F1 -> F2[)]\n'
+        r'model: error: negative start for field "F2" [(]F1 -> F2[)]\n'
         r'model: info: unsatisfied "Message\'First - 1000 >= Message\'First"'
         r"$",
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,17 @@
-from typing import Any
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from rflx.error import Location, RecordFluxError
+from rflx.model import Field, Link, Message, Type
 
 
 def assert_equal(left: Any, right: Any) -> None:
     assert left == right
+
+
+def assert_message_model_error(
+    structure: Sequence[Link], types: Mapping[Field, Type], regex: str, location: Location = None
+) -> None:
+    with pytest.raises(RecordFluxError, match=regex):
+        Message("P.M", structure, types, location)


### PR DESCRIPTION
This fixes cases where negative fields length were not detected. The reason was a misconception of what we (need to) proof here. The attempted proof we had in the code so far was something like (`H1` and `H2` being the constraints from the range type):

```
H1: Length >= 40
H2: Length <= 1500
GOAL: Length - 50 >= 0
```

We then checked whether a solution could be found:

```Python
if proof.result != ProofResult.sat:
   ... # Error
```

What this does is checking whether **one** solution exists for the goal, which is clearly the case for `Length >= 50`. What we actually want and what is implemented now is proving that `Length - 50 < 0` is unsatisfiable.

Why wouldn't our tests detect this issue? The error message for a different check (that the start of the field is non-negative) was apparently copied from the length check, but not changed. In addition to the length issue, the test case also had a negative start which triggered that second erroneous error message. As it looked as expected, the ineffectiveness of the length check remained unnoticed. The non-negative test was apparently also copied and checked for the wrong message. Hence, the invalid message remained unnoticed.

Lessons learned:

1. Don't copy and paste tests (without careful review)
2. Don't copy and paste checks (without careful review)
3. Proofs show that "there exists one solution" for your formula - if you want to show that a formula never is true, show that its negation is unsatisfiable
4. We need to review the other checks we do regarding 3.

Other changes:

Since upgrading to `isort 4.3.21` via `pip3` on Debian, third-party packages are not detected anymore. As a result, `isort` erroneously removes a lot of whitespace. I added our third-party libs to the `isort` config, which solves the issue for now and also is more robust if a dependency is not installed.

Close #336 