### PR TITLE
Reduce number of verification tests to prevent timeout in CI

### DIFF
--- a/tests/property/test_generator.py
+++ b/tests/property/test_generator.py
@@ -23,7 +23,7 @@ def test_code_compilation(model: Model) -> None:
 @settings(
     deadline=None,
     suppress_health_check=[HealthCheck.too_slow],
-    max_examples=math.ceil(settings.default.max_examples / 100),
+    max_examples=math.ceil(settings.default.max_examples / 200),
 )
 def test_code_verification(model: Model) -> None:
     utils.assert_provable_code(model)


### PR DESCRIPTION
The verification tests led to timeouts in the nightly tests, as they take more than six hours.

https://github.com/Componolit/RecordFlux/runs/951950096?check_suite_focus=true