### PR TITLE
Improve layout of graph labels

### DIFF
--- a/rflx/graph.py
+++ b/rflx/graph.py
@@ -33,7 +33,7 @@ class Graph:
         """Return pydot graph representation of message."""
         result = Dot(graph_name=self.__message.full_name)
         result.set_graph_defaults(
-            splines="ortho", ranksep="0.8 equally", pad="0.5", truecolor="true", bgcolor="#00000000"
+            splines="true", ranksep="0.1 equally", pad="0.1", truecolor="true", bgcolor="#00000000"
         )
         result.set_edge_defaults(fontname="Fira Code", fontcolor="#6f6f6f", color="#6f6f6f")
         result.set_node_defaults(
@@ -50,9 +50,23 @@ class Graph:
         )
         for f in self.__message.fields:
             result.add_node(Node(name=f.name))
-        for l in self.__message.structure:
-            label = self.__edge_label(l).replace("\n", "  \n  ")
-            result.add_edge(Edge(src=l.source.name, dst=l.target.name, xlabel=f"  {label}  "))
+        for i, l in enumerate(self.__message.structure):
+            intermediate_node = f"intermediate_{i}"
+            result.add_node(
+                Node(
+                    name=intermediate_node,
+                    label=self.__edge_label(l),
+                    style="",
+                    fontname="Fira Code",
+                    fontcolor="#6f6f6f",
+                    color="#6f6f6f",
+                    penwidth="0",
+                    width="0",
+                    height="0",
+                )
+            )
+            result.add_edge(Edge(src=l.source.name, dst=intermediate_node, arrowhead="none"))
+            result.add_edge(Edge(src=intermediate_node, dst=l.target.name, minlen="1"))
         result.add_node(
             Node(name="Final", fillcolor="#6f6f6f", shape="circle", width="0.5", label="")
         )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -24,8 +24,10 @@ def test_graph_object() -> None:
     )
     g = Graph(m).get
     assert [(e.get_source(), e.get_destination()) for e in g.get_edges()] == [
-        ("Initial", "X"),
-        ("X", "Final"),
+        ("Initial", "intermediate_0"),
+        ("intermediate_0", "X"),
+        ("X", "intermediate_1"),
+        ("intermediate_1", "Final"),
     ]
     assert [n.get_name() for n in g.get_nodes()] == [
         "graph",
@@ -33,6 +35,8 @@ def test_graph_object() -> None:
         "node",
         "Initial",
         "X",
+        "intermediate_0",
+        "intermediate_1",
         "Final",
     ]
 
@@ -41,12 +45,16 @@ def test_empty_message_graph() -> None:
     m = Message("P.M", [], {})
     expected = """
         digraph "P.M" {
-            graph [bgcolor="#00000000", pad="0.5", ranksep="0.8 equally", splines=ortho, truecolor=true];
+            graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true,
+                   truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code"];
             node [color="#6f6f6f", fillcolor="#009641", fontcolor="#ffffff", fontname=Arimo,
                   shape=box, style="rounded,filled", width="1.5"];
             Initial [fillcolor="#ffffff", label="", shape=circle, width="0.5"];
-            Initial -> Final [xlabel="  (⊤, 0, ⋆)  "];
+            intermediate_0 [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", height=0,
+                     label="(⊤, 0, ⋆)", penwidth=0, style="", width=0];
+            Initial -> intermediate_0 [arrowhead=none];
+            intermediate_0 -> Final [minlen=1];
             Final [fillcolor="#6f6f6f", label="", shape=circle, width="0.5"];
         }
         """
@@ -63,14 +71,21 @@ def test_dot_graph() -> None:
     )
     expected = """
         digraph "P.M" {
-            graph [bgcolor="#00000000", pad="0.5", ranksep="0.8 equally", splines=ortho, truecolor=true];
+            graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true,
+                   truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code"];
             node [color="#6f6f6f", fillcolor="#009641", fontcolor="#ffffff", fontname=Arimo,
                   shape=box, style="rounded,filled", width="1.5"];
             Initial [fillcolor="#ffffff", label="", shape=circle, width="0.5"];
             X;
-            Initial -> X [xlabel="  (⊤, 32, ⋆)  "];
-            X -> Final [xlabel="  (⊤, 0, ⋆)  "];
+            intermediate_0 [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", height=0,
+                            label="(⊤, 32, ⋆)", penwidth=0, style="", width=0];
+            Initial -> intermediate_0 [arrowhead=none];
+            intermediate_0 -> X [minlen=1];
+            intermediate_1 [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", height=0,
+                            label="(⊤, 0, ⋆)", penwidth=0, style="", width=0];
+            X -> intermediate_1 [arrowhead=none];
+            intermediate_1 -> Final [minlen=1];
             Final [fillcolor="#6f6f6f", label="", shape=circle, width="0.5"];
         }
         """
@@ -90,14 +105,20 @@ def test_dot_graph_with_condition() -> None:
     )
     expected = """
         digraph "P.M" {
-            graph [bgcolor="#00000000", pad="0.5", ranksep="0.8 equally", splines=ortho, truecolor=true];
+            graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true, truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code"];
             node [color="#6f6f6f", fillcolor="#009641", fontcolor="#ffffff", fontname=Arimo,
-                  shape=box, style="rounded,filled", width="1.5"];
+                 shape=box, style="rounded,filled", width="1.5"];
             Initial [fillcolor="#ffffff", label="", shape=circle, width="0.5"];
             X;
-            Initial -> X [xlabel="  (⊤, 32, ⋆)  "];
-            X -> Final [xlabel="  (X > 100, 0, ⋆)  "];
+            intermediate_0 [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", height=0,
+                            label="(⊤, 32, ⋆)", penwidth=0, style="", width=0];
+            Initial -> intermediate_0 [arrowhead=none];
+            intermediate_0 -> X [minlen=1];
+            intermediate_1 [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", height=0,
+                            label="(X > 100, 0, ⋆)", penwidth=0, style="", width=0];
+            X -> intermediate_1 [arrowhead=none];
+            intermediate_1 -> Final [minlen=1];
             Final [fillcolor="#6f6f6f", label="", shape=circle, width="0.5"];
         }
         """
@@ -118,15 +139,25 @@ def test_dot_graph_with_double_edge() -> None:
     )
     expected = """
         digraph "P.M" {
-            graph [bgcolor="#00000000", pad="0.5", ranksep="0.8 equally", splines=ortho, truecolor=true];
+            graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true,
+                   truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code"];
             node [color="#6f6f6f", fillcolor="#009641", fontcolor="#ffffff", fontname=Arimo,
                   shape=box, style="rounded,filled", width="1.5"];
             Initial [fillcolor="#ffffff", label="", shape=circle, width="0.5"];
             X;
-            Initial -> X [xlabel="  (⊤, 32, ⋆)  "];
-            X -> Final [xlabel="  (X > 100, 0, ⋆)  "];
-            X -> Final [xlabel="  (X < 50, 0, ⋆)  "];
+            intermediate_0 [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", height=0,
+                            label="(⊤, 32, ⋆)", penwidth=0, style="", width=0];
+            Initial -> intermediate_0 [arrowhead=none];
+            intermediate_0 -> X [minlen=1];
+            intermediate_1 [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", height=0,
+                            label="(X > 100, 0, ⋆)", penwidth=0, style="", width=0];
+            X -> intermediate_1 [arrowhead=none];
+            intermediate_1 -> Final [minlen=1];
+            intermediate_2 [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", height=0,
+                            label="(X < 50, 0, ⋆)", penwidth=0, style="", width=0];
+            X -> intermediate_2 [arrowhead=none];
+            intermediate_2 -> Final [minlen=1];
             Final [fillcolor="#6f6f6f", label="", shape=circle, width="0.5"];
         }
         """


### PR DESCRIPTION
Prevent graph labels from overlapping by setting them as an additional intermediate node. We had to abandon the orthogonal layout in favor of a spline-based one, as otherwise the pseudo-labels would be visually disconnected.