### PR TITLE
Make subcommand required instead of manually checking

### DIFF
--- a/rflx/cli.py
+++ b/rflx/cli.py
@@ -28,6 +28,7 @@ def main(argv: List[str]) -> Union[int, str]:
     parser.add_argument("--version", action="version", version=__version__)
 
     subparsers = parser.add_subparsers(dest="subcommand")
+    subparsers.required = True
 
     parser_check = subparsers.add_parser("check", help="check specification")
     parser_check.add_argument(
@@ -87,10 +88,6 @@ def main(argv: List[str]) -> Union[int, str]:
     parser_session.set_defaults(func=session)
 
     args = parser.parse_args(argv[1:])
-
-    if not args.subcommand:
-        parser.print_usage()
-        return 2
 
     if args.quiet:
         logging.disable(logging.CRITICAL)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,10 +13,6 @@ def raise_model_error() -> None:
     fail("TEST", Subsystem.MODEL, Severity.ERROR, Location((8, 22)))
 
 
-def test_main_noarg() -> None:
-    assert cli.main(["rflx"]) == 2
-
-
 def test_main_help() -> None:
     with pytest.raises(SystemExit):
         cli.main(["rflx", "-h"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,11 @@ def raise_model_error() -> None:
     fail("TEST", Subsystem.MODEL, Severity.ERROR, Location((8, 22)))
 
 
+def test_main_noarg() -> None:
+    with pytest.raises(SystemExit, match="^2$"):
+        cli.main(["rflx"])
+
+
 def test_main_help() -> None:
     with pytest.raises(SystemExit):
         cli.main(["rflx", "-h"])


### PR DESCRIPTION
Instead of checking if a subcommand was set manually it is possible to make a subcommand required.