### PR TITLE
RecordFuzz-specific adaptions

### DIFF
--- a/generated/rflx-icmp-generic_message.adb
+++ b/generated/rflx-icmp-generic_message.adb
@@ -1,0 +1,3335 @@
+pragma Style_Checks ("N3aAbcdefhiIklnOprStux");
+
+package body RFLX.ICMP.Generic_Message with
+  SPARK_Mode
+is
+
+   procedure Initialize (Ctx : out Context; Buffer : in out Types.Bytes_Ptr) is
+   begin
+      Initialize (Ctx, Buffer, Types.First_Bit_Index (Buffer'First), Types.Last_Bit_Index (Buffer'Last));
+   end Initialize;
+
+   procedure Initialize (Ctx : out Context; Buffer : in out Types.Bytes_Ptr; First, Last : Types.Bit_Index) is
+      Buffer_First : constant Types.Index := Buffer'First;
+      Buffer_Last : constant Types.Index := Buffer'Last;
+   begin
+      Ctx := (Buffer_First, Buffer_Last, First, Last, Buffer, (F_Tag => (State => S_Invalid, Predecessor => F_Initial), others => (State => S_Invalid, Predecessor => F_Final)));
+      Buffer := null;
+   end Initialize;
+
+   function Initialized (Ctx : Context) return Boolean is
+     (Valid_Next (Ctx, F_Tag)
+      and then Available_Space (Ctx, F_Tag) = Types.Last_Bit_Index (Ctx.Buffer_Last) - Ctx.First + 1
+      and then Invalid (Ctx, F_Tag)
+      and then Invalid (Ctx, F_Code_Destination_Unreachable)
+      and then Invalid (Ctx, F_Code_Redirect)
+      and then Invalid (Ctx, F_Code_Time_Exceeded)
+      and then Invalid (Ctx, F_Code_Zero)
+      and then Invalid (Ctx, F_Checksum)
+      and then Invalid (Ctx, F_Gateway_Internet_Address)
+      and then Invalid (Ctx, F_Identifier)
+      and then Invalid (Ctx, F_Pointer)
+      and then Invalid (Ctx, F_Unused_32)
+      and then Invalid (Ctx, F_Sequence_Number)
+      and then Invalid (Ctx, F_Unused_24)
+      and then Invalid (Ctx, F_Originate_Timestamp)
+      and then Invalid (Ctx, F_Data)
+      and then Invalid (Ctx, F_Receive_Timestamp)
+      and then Invalid (Ctx, F_Transmit_Timestamp));
+
+   procedure Take_Buffer (Ctx : in out Context; Buffer : out Types.Bytes_Ptr) is
+   begin
+      Buffer := Ctx.Buffer;
+      Ctx.Buffer := null;
+   end Take_Buffer;
+
+   function Has_Buffer (Ctx : Context) return Boolean is
+     (Ctx.Buffer /= null);
+
+   function Message_Last (Ctx : Context) return Types.Bit_Index is
+     ((if
+          Structural_Valid (Ctx.Cursors (F_Data))
+       then
+          Ctx.Cursors (F_Data).Last
+       elsif
+          Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply)))
+       then
+          Ctx.Cursors (F_Sequence_Number).Last
+       elsif
+          Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+       then
+          Ctx.Cursors (F_Transmit_Timestamp).Last
+       else
+          Types.Unreachable_Bit_Length));
+
+   function Path_Condition (Ctx : Context; Fld : Field) return Boolean is
+     ((case Ctx.Cursors (Fld).Predecessor is
+          when F_Initial =>
+             (case Fld is
+                 when F_Tag =>
+                    True,
+                 when others =>
+                    False),
+          when F_Tag =>
+             (case Fld is
+                 when F_Code_Destination_Unreachable =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable)),
+                 when F_Code_Redirect =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect)),
+                 when F_Code_Time_Exceeded =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded)),
+                 when F_Code_Zero =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)),
+                 when others =>
+                    False),
+          when F_Code_Destination_Unreachable | F_Code_Redirect | F_Code_Time_Exceeded | F_Code_Zero =>
+             (case Fld is
+                 when F_Checksum =>
+                    True,
+                 when others =>
+                    False),
+          when F_Checksum =>
+             (case Fld is
+                 when F_Gateway_Internet_Address =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect)),
+                 when F_Identifier =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)),
+                 when F_Pointer =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem)),
+                 when F_Unused_32 =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)),
+                 when others =>
+                    False),
+          when F_Gateway_Internet_Address =>
+             (case Fld is
+                 when F_Data =>
+                    True,
+                 when others =>
+                    False),
+          when F_Identifier =>
+             (case Fld is
+                 when F_Sequence_Number =>
+                    True,
+                 when others =>
+                    False),
+          when F_Pointer =>
+             (case Fld is
+                 when F_Unused_24 =>
+                    True,
+                 when others =>
+                    False),
+          when F_Unused_32 =>
+             (case Fld is
+                 when F_Data =>
+                    True,
+                 when others =>
+                    False),
+          when F_Sequence_Number =>
+             (case Fld is
+                 when F_Data =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)),
+                 when F_Originate_Timestamp =>
+                    Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)),
+                 when others =>
+                    False),
+          when F_Unused_24 =>
+             (case Fld is
+                 when F_Data =>
+                    True,
+                 when others =>
+                    False),
+          when F_Originate_Timestamp =>
+             (case Fld is
+                 when F_Receive_Timestamp =>
+                    True,
+                 when others =>
+                    False),
+          when F_Data =>
+             False,
+          when F_Receive_Timestamp =>
+             (case Fld is
+                 when F_Transmit_Timestamp =>
+                    True,
+                 when others =>
+                    False),
+          when F_Transmit_Timestamp | F_Final =>
+             False));
+
+   function Field_Condition (Ctx : Context; Val : Field_Dependent_Value) return Boolean is
+     ((case Val.Fld is
+          when F_Initial =>
+             True,
+          when F_Tag =>
+             Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Redirect))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Information_Request))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+             or Types.U64 (Val.Tag_Value) = Types.U64 (To_Base (Echo_Request)),
+          when F_Code_Destination_Unreachable | F_Code_Redirect | F_Code_Time_Exceeded | F_Code_Zero =>
+             True,
+          when F_Checksum =>
+             Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)),
+          when F_Gateway_Internet_Address | F_Identifier | F_Pointer | F_Unused_32 =>
+             True,
+          when F_Sequence_Number =>
+             Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)),
+          when F_Unused_24 | F_Originate_Timestamp | F_Data | F_Receive_Timestamp | F_Transmit_Timestamp =>
+             True,
+          when F_Final =>
+             False));
+
+   function Field_Length (Ctx : Context; Fld : Field) return Types.Bit_Length is
+     ((case Ctx.Cursors (Fld).Predecessor is
+          when F_Initial =>
+             (case Fld is
+                 when F_Tag =>
+                    RFLX.ICMP.Tag_Base'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Tag =>
+             (case Fld is
+                 when F_Code_Destination_Unreachable =>
+                    RFLX.ICMP.Code_Destination_Unreachable_Base'Size,
+                 when F_Code_Redirect =>
+                    RFLX.ICMP.Code_Redirect_Base'Size,
+                 when F_Code_Time_Exceeded =>
+                    RFLX.ICMP.Code_Time_Exceeded_Base'Size,
+                 when F_Code_Zero =>
+                    RFLX.ICMP.Code_Zero_Base'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Code_Destination_Unreachable | F_Code_Redirect | F_Code_Time_Exceeded | F_Code_Zero =>
+             (case Fld is
+                 when F_Checksum =>
+                    RFLX.ICMP.Checksum'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Checksum =>
+             (case Fld is
+                 when F_Gateway_Internet_Address =>
+                    RFLX.ICMP.Gateway_Internet_Address'Size,
+                 when F_Identifier =>
+                    RFLX.ICMP.Identifier'Size,
+                 when F_Pointer =>
+                    RFLX.ICMP.Pointer'Size,
+                 when F_Unused_32 =>
+                    RFLX.ICMP.Unused_32_Base'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Gateway_Internet_Address =>
+             (case Fld is
+                 when F_Data =>
+                    224,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Identifier =>
+             (case Fld is
+                 when F_Sequence_Number =>
+                    RFLX.ICMP.Sequence_Number'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Pointer =>
+             (case Fld is
+                 when F_Unused_24 =>
+                    RFLX.ICMP.Unused_24_Base'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Unused_32 =>
+             (case Fld is
+                 when F_Data =>
+                    224,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Sequence_Number =>
+             (case Fld is
+                 when F_Data =>
+                    Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last,
+                 when F_Originate_Timestamp =>
+                    RFLX.ICMP.Timestamp'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Unused_24 =>
+             (case Fld is
+                 when F_Data =>
+                    224,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Originate_Timestamp =>
+             (case Fld is
+                 when F_Receive_Timestamp =>
+                    RFLX.ICMP.Timestamp'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Data =>
+             0,
+          when F_Receive_Timestamp =>
+             (case Fld is
+                 when F_Transmit_Timestamp =>
+                    RFLX.ICMP.Timestamp'Size,
+                 when others =>
+                    Types.Unreachable_Bit_Length),
+          when F_Transmit_Timestamp | F_Final =>
+             0));
+
+   function Field_First (Ctx : Context; Fld : Field) return Types.Bit_Index is
+     ((case Fld is
+          when F_Tag =>
+             Ctx.First,
+          when F_Code_Destination_Unreachable =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Tag
+                 and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Code_Redirect =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Tag
+                 and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Code_Time_Exceeded =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Tag
+                 and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Code_Zero =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Tag
+                 and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Checksum =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Code_Destination_Unreachable
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              elsif
+                 Ctx.Cursors (Fld).Predecessor = F_Code_Redirect
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              elsif
+                 Ctx.Cursors (Fld).Predecessor = F_Code_Time_Exceeded
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              elsif
+                 Ctx.Cursors (Fld).Predecessor = F_Code_Zero
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Gateway_Internet_Address =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Checksum
+                 and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Identifier =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Checksum
+                 and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Pointer =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Checksum
+                 and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Unused_32 =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Checksum
+                 and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Sequence_Number =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Identifier
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Unused_24 =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Pointer
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Originate_Timestamp =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Sequence_Number
+                 and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Data =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Gateway_Internet_Address
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              elsif
+                 Ctx.Cursors (Fld).Predecessor = F_Sequence_Number
+                 and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                           or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              elsif
+                 Ctx.Cursors (Fld).Predecessor = F_Unused_24
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              elsif
+                 Ctx.Cursors (Fld).Predecessor = F_Unused_32
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Receive_Timestamp =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Originate_Timestamp
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length),
+          when F_Transmit_Timestamp =>
+             (if
+                 Ctx.Cursors (Fld).Predecessor = F_Receive_Timestamp
+              then
+                 Ctx.Cursors (Ctx.Cursors (Fld).Predecessor).Last + 1
+              else
+                 Types.Unreachable_Bit_Length)));
+
+   function Field_Last (Ctx : Context; Fld : Field) return Types.Bit_Index is
+     (Field_First (Ctx, Fld) + Field_Length (Ctx, Fld) - 1);
+
+   function Predecessor (Ctx : Context; Fld : Virtual_Field) return Virtual_Field is
+     ((case Fld is
+          when F_Initial =>
+             F_Initial,
+          when others =>
+             Ctx.Cursors (Fld).Predecessor));
+
+   function Successor (Ctx : Context; Fld : Field) return Virtual_Field is
+     ((case Fld is
+          when F_Tag =>
+             (if
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+              then
+                 F_Code_Destination_Unreachable
+              elsif
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+              then
+                 F_Code_Redirect
+              elsif
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+              then
+                 F_Code_Time_Exceeded
+              elsif
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+              then
+                 F_Code_Zero
+              else
+                 F_Initial),
+          when F_Code_Destination_Unreachable | F_Code_Redirect | F_Code_Time_Exceeded | F_Code_Zero =>
+             F_Checksum,
+          when F_Checksum =>
+             (if
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+              then
+                 F_Gateway_Internet_Address
+              elsif
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+              then
+                 F_Identifier
+              elsif
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+              then
+                 F_Pointer
+              elsif
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+              then
+                 F_Unused_32
+              else
+                 F_Initial),
+          when F_Gateway_Internet_Address =>
+             F_Data,
+          when F_Identifier =>
+             F_Sequence_Number,
+          when F_Pointer =>
+             F_Unused_24,
+          when F_Unused_32 =>
+             F_Data,
+          when F_Sequence_Number =>
+             (if
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+              then
+                 F_Data
+              elsif
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+              then
+                 F_Final
+              elsif
+                 Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                 or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+              then
+                 F_Originate_Timestamp
+              else
+                 F_Initial),
+          when F_Unused_24 =>
+             F_Data,
+          when F_Originate_Timestamp =>
+             F_Receive_Timestamp,
+          when F_Data =>
+             F_Final,
+          when F_Receive_Timestamp =>
+             F_Transmit_Timestamp,
+          when F_Transmit_Timestamp =>
+             F_Final))
+    with
+     Pre =>
+       Has_Buffer (Ctx)
+       and Structural_Valid (Ctx, Fld)
+       and Valid_Predecessor (Ctx, Fld);
+
+   function Valid_Predecessor (Ctx : Context; Fld : Virtual_Field) return Boolean is
+     ((case Fld is
+          when F_Initial =>
+             True,
+          when F_Tag =>
+             Ctx.Cursors (Fld).Predecessor = F_Initial,
+          when F_Code_Destination_Unreachable | F_Code_Redirect | F_Code_Time_Exceeded | F_Code_Zero =>
+             (Valid (Ctx.Cursors (F_Tag))
+              and Ctx.Cursors (Fld).Predecessor = F_Tag),
+          when F_Checksum =>
+             (Valid (Ctx.Cursors (F_Code_Destination_Unreachable))
+              and Ctx.Cursors (Fld).Predecessor = F_Code_Destination_Unreachable)
+             or (Valid (Ctx.Cursors (F_Code_Redirect))
+                 and Ctx.Cursors (Fld).Predecessor = F_Code_Redirect)
+             or (Valid (Ctx.Cursors (F_Code_Time_Exceeded))
+                 and Ctx.Cursors (Fld).Predecessor = F_Code_Time_Exceeded)
+             or (Valid (Ctx.Cursors (F_Code_Zero))
+                 and Ctx.Cursors (Fld).Predecessor = F_Code_Zero),
+          when F_Gateway_Internet_Address | F_Identifier | F_Pointer | F_Unused_32 =>
+             (Valid (Ctx.Cursors (F_Checksum))
+              and Ctx.Cursors (Fld).Predecessor = F_Checksum),
+          when F_Sequence_Number =>
+             (Valid (Ctx.Cursors (F_Identifier))
+              and Ctx.Cursors (Fld).Predecessor = F_Identifier),
+          when F_Unused_24 =>
+             (Valid (Ctx.Cursors (F_Pointer))
+              and Ctx.Cursors (Fld).Predecessor = F_Pointer),
+          when F_Originate_Timestamp =>
+             (Valid (Ctx.Cursors (F_Sequence_Number))
+              and Ctx.Cursors (Fld).Predecessor = F_Sequence_Number),
+          when F_Data =>
+             (Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+              and Ctx.Cursors (Fld).Predecessor = F_Gateway_Internet_Address)
+             or (Valid (Ctx.Cursors (F_Sequence_Number))
+                 and Ctx.Cursors (Fld).Predecessor = F_Sequence_Number)
+             or (Valid (Ctx.Cursors (F_Unused_24))
+                 and Ctx.Cursors (Fld).Predecessor = F_Unused_24)
+             or (Valid (Ctx.Cursors (F_Unused_32))
+                 and Ctx.Cursors (Fld).Predecessor = F_Unused_32),
+          when F_Receive_Timestamp =>
+             (Valid (Ctx.Cursors (F_Originate_Timestamp))
+              and Ctx.Cursors (Fld).Predecessor = F_Originate_Timestamp),
+          when F_Transmit_Timestamp =>
+             (Valid (Ctx.Cursors (F_Receive_Timestamp))
+              and Ctx.Cursors (Fld).Predecessor = F_Receive_Timestamp),
+          when F_Final =>
+             (Structural_Valid (Ctx.Cursors (F_Data))
+              and Ctx.Cursors (Fld).Predecessor = F_Data)
+             or (Valid (Ctx.Cursors (F_Sequence_Number))
+                 and Ctx.Cursors (Fld).Predecessor = F_Sequence_Number)
+             or (Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                 and Ctx.Cursors (Fld).Predecessor = F_Transmit_Timestamp)));
+
+   function Invalid_Successor (Ctx : Context; Fld : Field) return Boolean is
+     ((case Fld is
+          when F_Tag =>
+             Invalid (Ctx.Cursors (F_Code_Destination_Unreachable))
+             and Invalid (Ctx.Cursors (F_Code_Redirect))
+             and Invalid (Ctx.Cursors (F_Code_Time_Exceeded))
+             and Invalid (Ctx.Cursors (F_Code_Zero)),
+          when F_Code_Destination_Unreachable | F_Code_Redirect | F_Code_Time_Exceeded | F_Code_Zero =>
+             Invalid (Ctx.Cursors (F_Checksum)),
+          when F_Checksum =>
+             Invalid (Ctx.Cursors (F_Gateway_Internet_Address))
+             and Invalid (Ctx.Cursors (F_Identifier))
+             and Invalid (Ctx.Cursors (F_Pointer))
+             and Invalid (Ctx.Cursors (F_Unused_32)),
+          when F_Gateway_Internet_Address =>
+             Invalid (Ctx.Cursors (F_Data)),
+          when F_Identifier =>
+             Invalid (Ctx.Cursors (F_Sequence_Number)),
+          when F_Pointer =>
+             Invalid (Ctx.Cursors (F_Unused_24)),
+          when F_Unused_32 =>
+             Invalid (Ctx.Cursors (F_Data)),
+          when F_Sequence_Number =>
+             Invalid (Ctx.Cursors (F_Data))
+             and Invalid (Ctx.Cursors (F_Originate_Timestamp)),
+          when F_Unused_24 =>
+             Invalid (Ctx.Cursors (F_Data)),
+          when F_Originate_Timestamp =>
+             Invalid (Ctx.Cursors (F_Receive_Timestamp)),
+          when F_Data =>
+             True,
+          when F_Receive_Timestamp =>
+             Invalid (Ctx.Cursors (F_Transmit_Timestamp)),
+          when F_Transmit_Timestamp =>
+             True));
+
+   function Valid_Next (Ctx : Context; Fld : Field) return Boolean is
+     (Valid_Predecessor (Ctx, Fld)
+      and then Path_Condition (Ctx, Fld));
+
+   function Available_Space (Ctx : Context; Fld : Field) return Types.Bit_Length is
+     (Types.Last_Bit_Index (Ctx.Buffer_Last) - Field_First (Ctx, Fld) + 1);
+
+   function Sufficient_Buffer_Length (Ctx : Context; Fld : Field) return Boolean is
+     (Ctx.Buffer /= null
+      and Ctx.First <= Types.Bit_Index'Last / 2
+      and Field_First (Ctx, Fld) <= Types.Bit_Index'Last / 2
+      and Field_Length (Ctx, Fld) >= 0
+      and Field_Length (Ctx, Fld) <= Types.Bit_Length'Last / 2
+      and Field_First (Ctx, Fld) + Field_Length (Ctx, Fld) <= Types.Bit_Length'Last / 2
+      and Ctx.First <= Field_First (Ctx, Fld)
+      and Ctx.Last >= Field_Last (Ctx, Fld))
+    with
+     Pre =>
+       Has_Buffer (Ctx)
+       and Valid_Next (Ctx, Fld);
+
+   function Equal (Ctx : Context; Fld : Field; Data : Types.Bytes) return Boolean is
+     (Sufficient_Buffer_Length (Ctx, Fld)
+      and then (case Fld is
+                   when F_Data =>
+                      Ctx.Buffer.all (Types.Byte_Index (Field_First (Ctx, Fld)) .. Types.Byte_Index (Field_Last (Ctx, Fld))) = Data,
+                   when others =>
+                      False));
+
+   procedure Reset_Dependent_Fields (Ctx : in out Context; Fld : Field) with
+     Pre =>
+       Valid_Next (Ctx, Fld),
+     Post =>
+       Valid_Next (Ctx, Fld)
+       and Invalid (Ctx.Cursors (Fld))
+       and Invalid_Successor (Ctx, Fld)
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Ctx.Last = Ctx.Last'Old
+       and Ctx.Cursors (Fld).Predecessor = Ctx.Cursors (Fld).Predecessor'Old
+       and Has_Buffer (Ctx) = Has_Buffer (Ctx)'Old
+       and Field_First (Ctx, Fld) = Field_First (Ctx, Fld)'Old
+       and Field_Length (Ctx, Fld) = Field_Length (Ctx, Fld)'Old
+       and (case Fld is
+               when F_Tag =>
+                  Invalid (Ctx, F_Tag)
+                  and Invalid (Ctx, F_Code_Destination_Unreachable)
+                  and Invalid (Ctx, F_Code_Redirect)
+                  and Invalid (Ctx, F_Code_Time_Exceeded)
+                  and Invalid (Ctx, F_Code_Zero)
+                  and Invalid (Ctx, F_Checksum)
+                  and Invalid (Ctx, F_Gateway_Internet_Address)
+                  and Invalid (Ctx, F_Identifier)
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Code_Destination_Unreachable =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Invalid (Ctx, F_Code_Destination_Unreachable)
+                  and Invalid (Ctx, F_Code_Redirect)
+                  and Invalid (Ctx, F_Code_Time_Exceeded)
+                  and Invalid (Ctx, F_Code_Zero)
+                  and Invalid (Ctx, F_Checksum)
+                  and Invalid (Ctx, F_Gateway_Internet_Address)
+                  and Invalid (Ctx, F_Identifier)
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Code_Redirect =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Invalid (Ctx, F_Code_Redirect)
+                  and Invalid (Ctx, F_Code_Time_Exceeded)
+                  and Invalid (Ctx, F_Code_Zero)
+                  and Invalid (Ctx, F_Checksum)
+                  and Invalid (Ctx, F_Gateway_Internet_Address)
+                  and Invalid (Ctx, F_Identifier)
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Code_Time_Exceeded =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Invalid (Ctx, F_Code_Time_Exceeded)
+                  and Invalid (Ctx, F_Code_Zero)
+                  and Invalid (Ctx, F_Checksum)
+                  and Invalid (Ctx, F_Gateway_Internet_Address)
+                  and Invalid (Ctx, F_Identifier)
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Code_Zero =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Invalid (Ctx, F_Code_Zero)
+                  and Invalid (Ctx, F_Checksum)
+                  and Invalid (Ctx, F_Gateway_Internet_Address)
+                  and Invalid (Ctx, F_Identifier)
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Checksum =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Invalid (Ctx, F_Checksum)
+                  and Invalid (Ctx, F_Gateway_Internet_Address)
+                  and Invalid (Ctx, F_Identifier)
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Gateway_Internet_Address =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Invalid (Ctx, F_Gateway_Internet_Address)
+                  and Invalid (Ctx, F_Identifier)
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Identifier =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Invalid (Ctx, F_Identifier)
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Pointer =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Ctx.Cursors (F_Identifier) = Ctx.Cursors (F_Identifier)'Old
+                  and Invalid (Ctx, F_Pointer)
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Unused_32 =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Ctx.Cursors (F_Identifier) = Ctx.Cursors (F_Identifier)'Old
+                  and Ctx.Cursors (F_Pointer) = Ctx.Cursors (F_Pointer)'Old
+                  and Invalid (Ctx, F_Unused_32)
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Sequence_Number =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Ctx.Cursors (F_Identifier) = Ctx.Cursors (F_Identifier)'Old
+                  and Ctx.Cursors (F_Pointer) = Ctx.Cursors (F_Pointer)'Old
+                  and Ctx.Cursors (F_Unused_32) = Ctx.Cursors (F_Unused_32)'Old
+                  and Invalid (Ctx, F_Sequence_Number)
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Unused_24 =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Ctx.Cursors (F_Identifier) = Ctx.Cursors (F_Identifier)'Old
+                  and Ctx.Cursors (F_Pointer) = Ctx.Cursors (F_Pointer)'Old
+                  and Ctx.Cursors (F_Unused_32) = Ctx.Cursors (F_Unused_32)'Old
+                  and Ctx.Cursors (F_Sequence_Number) = Ctx.Cursors (F_Sequence_Number)'Old
+                  and Invalid (Ctx, F_Unused_24)
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Originate_Timestamp =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Ctx.Cursors (F_Identifier) = Ctx.Cursors (F_Identifier)'Old
+                  and Ctx.Cursors (F_Pointer) = Ctx.Cursors (F_Pointer)'Old
+                  and Ctx.Cursors (F_Unused_32) = Ctx.Cursors (F_Unused_32)'Old
+                  and Ctx.Cursors (F_Sequence_Number) = Ctx.Cursors (F_Sequence_Number)'Old
+                  and Ctx.Cursors (F_Unused_24) = Ctx.Cursors (F_Unused_24)'Old
+                  and Invalid (Ctx, F_Originate_Timestamp)
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Data =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Ctx.Cursors (F_Identifier) = Ctx.Cursors (F_Identifier)'Old
+                  and Ctx.Cursors (F_Pointer) = Ctx.Cursors (F_Pointer)'Old
+                  and Ctx.Cursors (F_Unused_32) = Ctx.Cursors (F_Unused_32)'Old
+                  and Ctx.Cursors (F_Sequence_Number) = Ctx.Cursors (F_Sequence_Number)'Old
+                  and Ctx.Cursors (F_Unused_24) = Ctx.Cursors (F_Unused_24)'Old
+                  and Ctx.Cursors (F_Originate_Timestamp) = Ctx.Cursors (F_Originate_Timestamp)'Old
+                  and Invalid (Ctx, F_Data)
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Receive_Timestamp =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Ctx.Cursors (F_Identifier) = Ctx.Cursors (F_Identifier)'Old
+                  and Ctx.Cursors (F_Pointer) = Ctx.Cursors (F_Pointer)'Old
+                  and Ctx.Cursors (F_Unused_32) = Ctx.Cursors (F_Unused_32)'Old
+                  and Ctx.Cursors (F_Sequence_Number) = Ctx.Cursors (F_Sequence_Number)'Old
+                  and Ctx.Cursors (F_Unused_24) = Ctx.Cursors (F_Unused_24)'Old
+                  and Ctx.Cursors (F_Originate_Timestamp) = Ctx.Cursors (F_Originate_Timestamp)'Old
+                  and Ctx.Cursors (F_Data) = Ctx.Cursors (F_Data)'Old
+                  and Invalid (Ctx, F_Receive_Timestamp)
+                  and Invalid (Ctx, F_Transmit_Timestamp),
+               when F_Transmit_Timestamp =>
+                  Ctx.Cursors (F_Tag) = Ctx.Cursors (F_Tag)'Old
+                  and Ctx.Cursors (F_Code_Destination_Unreachable) = Ctx.Cursors (F_Code_Destination_Unreachable)'Old
+                  and Ctx.Cursors (F_Code_Redirect) = Ctx.Cursors (F_Code_Redirect)'Old
+                  and Ctx.Cursors (F_Code_Time_Exceeded) = Ctx.Cursors (F_Code_Time_Exceeded)'Old
+                  and Ctx.Cursors (F_Code_Zero) = Ctx.Cursors (F_Code_Zero)'Old
+                  and Ctx.Cursors (F_Checksum) = Ctx.Cursors (F_Checksum)'Old
+                  and Ctx.Cursors (F_Gateway_Internet_Address) = Ctx.Cursors (F_Gateway_Internet_Address)'Old
+                  and Ctx.Cursors (F_Identifier) = Ctx.Cursors (F_Identifier)'Old
+                  and Ctx.Cursors (F_Pointer) = Ctx.Cursors (F_Pointer)'Old
+                  and Ctx.Cursors (F_Unused_32) = Ctx.Cursors (F_Unused_32)'Old
+                  and Ctx.Cursors (F_Sequence_Number) = Ctx.Cursors (F_Sequence_Number)'Old
+                  and Ctx.Cursors (F_Unused_24) = Ctx.Cursors (F_Unused_24)'Old
+                  and Ctx.Cursors (F_Originate_Timestamp) = Ctx.Cursors (F_Originate_Timestamp)'Old
+                  and Ctx.Cursors (F_Data) = Ctx.Cursors (F_Data)'Old
+                  and Ctx.Cursors (F_Receive_Timestamp) = Ctx.Cursors (F_Receive_Timestamp)'Old
+                  and Invalid (Ctx, F_Transmit_Timestamp))
+   is
+      First : constant Types.Bit_Length := Field_First (Ctx, Fld) with
+        Ghost;
+      Length : constant Types.Bit_Length := Field_Length (Ctx, Fld) with
+        Ghost;
+   begin
+      pragma Assert (Field_First (Ctx, Fld) = First
+                     and Field_Length (Ctx, Fld) = Length);
+      case Fld is
+         when F_Tag =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Identifier) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Gateway_Internet_Address) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Checksum) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Zero) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Time_Exceeded) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Redirect) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Destination_Unreachable) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Tag) := (S_Invalid, Ctx.Cursors (F_Tag).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Code_Destination_Unreachable =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Identifier) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Gateway_Internet_Address) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Checksum) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Zero) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Time_Exceeded) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Redirect) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Destination_Unreachable) := (S_Invalid, Ctx.Cursors (F_Code_Destination_Unreachable).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Code_Redirect =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Identifier) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Gateway_Internet_Address) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Checksum) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Zero) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Time_Exceeded) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Redirect) := (S_Invalid, Ctx.Cursors (F_Code_Redirect).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Code_Time_Exceeded =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Identifier) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Gateway_Internet_Address) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Checksum) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Zero) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Time_Exceeded) := (S_Invalid, Ctx.Cursors (F_Code_Time_Exceeded).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Code_Zero =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Identifier) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Gateway_Internet_Address) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Checksum) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Code_Zero) := (S_Invalid, Ctx.Cursors (F_Code_Zero).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Checksum =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Identifier) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Gateway_Internet_Address) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Checksum) := (S_Invalid, Ctx.Cursors (F_Checksum).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Gateway_Internet_Address =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Identifier) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Gateway_Internet_Address) := (S_Invalid, Ctx.Cursors (F_Gateway_Internet_Address).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Identifier =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Identifier) := (S_Invalid, Ctx.Cursors (F_Identifier).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Pointer =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Pointer) := (S_Invalid, Ctx.Cursors (F_Pointer).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Unused_32 =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_32) := (S_Invalid, Ctx.Cursors (F_Unused_32).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Sequence_Number =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Sequence_Number) := (S_Invalid, Ctx.Cursors (F_Sequence_Number).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Unused_24 =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Unused_24) := (S_Invalid, Ctx.Cursors (F_Unused_24).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Originate_Timestamp =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Originate_Timestamp) := (S_Invalid, Ctx.Cursors (F_Originate_Timestamp).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Data =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Data) := (S_Invalid, Ctx.Cursors (F_Data).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Receive_Timestamp =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, F_Final);
+            Ctx.Cursors (F_Receive_Timestamp) := (S_Invalid, Ctx.Cursors (F_Receive_Timestamp).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+         when F_Transmit_Timestamp =>
+            Ctx.Cursors (F_Transmit_Timestamp) := (S_Invalid, Ctx.Cursors (F_Transmit_Timestamp).Predecessor);
+            pragma Assert (Field_First (Ctx, Fld) = First
+                           and Field_Length (Ctx, Fld) = Length);
+      end case;
+   end Reset_Dependent_Fields;
+
+   function Composite_Field (Fld : Field) return Boolean is
+     ((case Fld is
+          when F_Tag | F_Code_Destination_Unreachable | F_Code_Redirect | F_Code_Time_Exceeded | F_Code_Zero | F_Checksum | F_Gateway_Internet_Address | F_Identifier | F_Pointer | F_Unused_32 | F_Sequence_Number | F_Unused_24 | F_Originate_Timestamp =>
+             False,
+          when F_Data =>
+             True,
+          when F_Receive_Timestamp | F_Transmit_Timestamp =>
+             False));
+
+   function Get_Field_Value (Ctx : Context; Fld : Field) return Field_Dependent_Value with
+     Pre =>
+       Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, Fld)
+       and then Sufficient_Buffer_Length (Ctx, Fld),
+     Post =>
+       Get_Field_Value'Result.Fld = Fld
+   is
+      First : constant Types.Bit_Index := Field_First (Ctx, Fld);
+      Last : constant Types.Bit_Index := Field_Last (Ctx, Fld);
+      function Buffer_First return Types.Index is
+        (Types.Byte_Index (First));
+      function Buffer_Last return Types.Index is
+        (Types.Byte_Index (Last));
+      function Offset return Types.Offset is
+        (Types.Offset ((8 - Last mod 8) mod 8));
+      function Extract is new Types.Extract (RFLX.ICMP.Tag_Base);
+      function Extract is new Types.Extract (RFLX.ICMP.Code_Destination_Unreachable_Base);
+      function Extract is new Types.Extract (RFLX.ICMP.Code_Redirect_Base);
+      function Extract is new Types.Extract (RFLX.ICMP.Code_Time_Exceeded_Base);
+      function Extract is new Types.Extract (RFLX.ICMP.Code_Zero_Base);
+      function Extract is new Types.Extract (RFLX.ICMP.Checksum);
+      function Extract is new Types.Extract (RFLX.ICMP.Gateway_Internet_Address);
+      function Extract is new Types.Extract (RFLX.ICMP.Identifier);
+      function Extract is new Types.Extract (RFLX.ICMP.Pointer);
+      function Extract is new Types.Extract (RFLX.ICMP.Unused_32_Base);
+      function Extract is new Types.Extract (RFLX.ICMP.Sequence_Number);
+      function Extract is new Types.Extract (RFLX.ICMP.Unused_24_Base);
+      function Extract is new Types.Extract (RFLX.ICMP.Timestamp);
+   begin
+      return ((case Fld is
+                  when F_Tag =>
+                     (Fld => F_Tag, Tag_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Code_Destination_Unreachable =>
+                     (Fld => F_Code_Destination_Unreachable, Code_Destination_Unreachable_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Code_Redirect =>
+                     (Fld => F_Code_Redirect, Code_Redirect_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Code_Time_Exceeded =>
+                     (Fld => F_Code_Time_Exceeded, Code_Time_Exceeded_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Code_Zero =>
+                     (Fld => F_Code_Zero, Code_Zero_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Checksum =>
+                     (Fld => F_Checksum, Checksum_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Gateway_Internet_Address =>
+                     (Fld => F_Gateway_Internet_Address, Gateway_Internet_Address_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Identifier =>
+                     (Fld => F_Identifier, Identifier_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Pointer =>
+                     (Fld => F_Pointer, Pointer_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Unused_32 =>
+                     (Fld => F_Unused_32, Unused_32_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Sequence_Number =>
+                     (Fld => F_Sequence_Number, Sequence_Number_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Unused_24 =>
+                     (Fld => F_Unused_24, Unused_24_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Originate_Timestamp =>
+                     (Fld => F_Originate_Timestamp, Originate_Timestamp_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Data =>
+                     (Fld => F_Data),
+                  when F_Receive_Timestamp =>
+                     (Fld => F_Receive_Timestamp, Receive_Timestamp_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset)),
+                  when F_Transmit_Timestamp =>
+                     (Fld => F_Transmit_Timestamp, Transmit_Timestamp_Value => Extract (Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset))));
+   end Get_Field_Value;
+
+   procedure Verify (Ctx : in out Context; Fld : Field) is
+      Value : Field_Dependent_Value;
+   begin
+      if
+        Has_Buffer (Ctx)
+        and then Invalid (Ctx.Cursors (Fld))
+        and then Valid_Predecessor (Ctx, Fld)
+        and then Path_Condition (Ctx, Fld)
+      then
+         if Sufficient_Buffer_Length (Ctx, Fld) then
+            Value := Get_Field_Value (Ctx, Fld);
+            if
+              Valid_Value (Value)
+              and Field_Condition (Ctx, Value)
+            then
+               if Composite_Field (Fld) then
+                  Ctx.Cursors (Fld) := (State => S_Structural_Valid, First => Field_First (Ctx, Fld), Last => Field_Last (Ctx, Fld), Value => Value, Predecessor => Ctx.Cursors (Fld).Predecessor);
+               else
+                  Ctx.Cursors (Fld) := (State => S_Valid, First => Field_First (Ctx, Fld), Last => Field_Last (Ctx, Fld), Value => Value, Predecessor => Ctx.Cursors (Fld).Predecessor);
+               end if;
+               pragma Assert ((if
+                                  Structural_Valid (Ctx.Cursors (F_Tag))
+                               then
+                                  Ctx.Cursors (F_Tag).Last - Ctx.Cursors (F_Tag).First + 1 = RFLX.ICMP.Tag_Base'Size
+                                  and then Ctx.Cursors (F_Tag).Predecessor = F_Initial
+                                  and then Ctx.Cursors (F_Tag).First = Ctx.First
+                                  and then (if
+                                               Structural_Valid (Ctx.Cursors (F_Code_Destination_Unreachable))
+                                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                            then
+                                               Ctx.Cursors (F_Code_Destination_Unreachable).Last - Ctx.Cursors (F_Code_Destination_Unreachable).First + 1 = RFLX.ICMP.Code_Destination_Unreachable_Base'Size
+                                               and then Ctx.Cursors (F_Code_Destination_Unreachable).Predecessor = F_Tag
+                                               and then Ctx.Cursors (F_Code_Destination_Unreachable).First = Ctx.Cursors (F_Tag).Last + 1
+                                               and then (if
+                                                            Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                         then
+                                                            Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                            and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Destination_Unreachable
+                                                            and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Destination_Unreachable).Last + 1
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                         and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                                      then
+                                                                         Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                         and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                      and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                                      and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                         and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                                      then
+                                                                         Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                         and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                                      and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                                      and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                                   and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                                   and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                                   and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                                   and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                   and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                                   and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                                   and then (if
+                                                                                                                Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                             then
+                                                                                                                Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                                and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                                and then (if
+                                                                                                                             Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                          then
+                                                                                                                             Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                             and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                             and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                         and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                                      then
+                                                                         Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                         and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                                      and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                                      and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                                   and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                                   and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                         and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                                      then
+                                                                         Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                         and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                      and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                                      and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                                  and then (if
+                                               Structural_Valid (Ctx.Cursors (F_Code_Redirect))
+                                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                            then
+                                               Ctx.Cursors (F_Code_Redirect).Last - Ctx.Cursors (F_Code_Redirect).First + 1 = RFLX.ICMP.Code_Redirect_Base'Size
+                                               and then Ctx.Cursors (F_Code_Redirect).Predecessor = F_Tag
+                                               and then Ctx.Cursors (F_Code_Redirect).First = Ctx.Cursors (F_Tag).Last + 1
+                                               and then (if
+                                                            Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                         then
+                                                            Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                            and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Redirect
+                                                            and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Redirect).Last + 1
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                         and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                                      then
+                                                                         Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                         and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                      and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                                      and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                         and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                                      then
+                                                                         Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                         and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                                      and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                                      and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                                   and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                                   and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                                   and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                                   and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                   and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                                   and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                                   and then (if
+                                                                                                                Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                             then
+                                                                                                                Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                                and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                                and then (if
+                                                                                                                             Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                          then
+                                                                                                                             Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                             and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                             and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                         and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                                      then
+                                                                         Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                         and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                                      and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                                      and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                                   and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                                   and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                         and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                                      then
+                                                                         Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                         and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                      and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                                      and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                                  and then (if
+                                               Structural_Valid (Ctx.Cursors (F_Code_Time_Exceeded))
+                                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                            then
+                                               Ctx.Cursors (F_Code_Time_Exceeded).Last - Ctx.Cursors (F_Code_Time_Exceeded).First + 1 = RFLX.ICMP.Code_Time_Exceeded_Base'Size
+                                               and then Ctx.Cursors (F_Code_Time_Exceeded).Predecessor = F_Tag
+                                               and then Ctx.Cursors (F_Code_Time_Exceeded).First = Ctx.Cursors (F_Tag).Last + 1
+                                               and then (if
+                                                            Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                         then
+                                                            Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                            and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Time_Exceeded
+                                                            and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Time_Exceeded).Last + 1
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                         and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                                      then
+                                                                         Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                         and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                      and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                                      and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                         and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                                      then
+                                                                         Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                         and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                                      and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                                      and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                                   and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                                   and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                                   and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                                   and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                   and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                                   and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                                   and then (if
+                                                                                                                Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                             then
+                                                                                                                Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                                and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                                and then (if
+                                                                                                                             Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                          then
+                                                                                                                             Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                             and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                             and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                         and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                                      then
+                                                                         Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                         and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                                      and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                                      and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                                   and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                                   and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                         and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                                      then
+                                                                         Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                         and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                      and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                                      and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                                  and then (if
+                                               Structural_Valid (Ctx.Cursors (F_Code_Zero))
+                                               and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                            then
+                                               Ctx.Cursors (F_Code_Zero).Last - Ctx.Cursors (F_Code_Zero).First + 1 = RFLX.ICMP.Code_Zero_Base'Size
+                                               and then Ctx.Cursors (F_Code_Zero).Predecessor = F_Tag
+                                               and then Ctx.Cursors (F_Code_Zero).First = Ctx.Cursors (F_Tag).Last + 1
+                                               and then (if
+                                                            Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                         then
+                                                            Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                            and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Zero
+                                                            and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Zero).Last + 1
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                         and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                                      then
+                                                                         Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                         and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                      and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                                      and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                         and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                                      then
+                                                                         Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                         and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                                      and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                                      and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                                   and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                                   and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                                   and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                                   and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                             or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                   and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                                   and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                                   and then (if
+                                                                                                                Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                             then
+                                                                                                                Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                                and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                                and then (if
+                                                                                                                             Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                          then
+                                                                                                                             Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                             and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                             and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                         and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                                      then
+                                                                         Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                         and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                                      and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                                      and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                                      and then (if
+                                                                                                   Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                                then
+                                                                                                   Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                                   and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                                   and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                            and then (if
+                                                                         Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                         and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                                   or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                                      then
+                                                                         Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                         and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                         and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                         and then (if
+                                                                                      Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                   then
+                                                                                      Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                      and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                                      and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))));
+               if Fld = F_Tag then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Code_Destination_Unreachable then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Code_Redirect then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Code_Time_Exceeded then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Code_Zero then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Checksum then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Gateway_Internet_Address then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Identifier then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Pointer then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Unused_32 then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Sequence_Number then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Unused_24 then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Originate_Timestamp then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Data then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Receive_Timestamp then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               elsif Fld = F_Transmit_Timestamp then
+                  Ctx.Cursors (Successor (Ctx, Fld)) := (State => S_Invalid, Predecessor => Fld);
+               end if;
+            else
+               Ctx.Cursors (Fld) := (State => S_Invalid, Predecessor => F_Final);
+            end if;
+         else
+            Ctx.Cursors (Fld) := (State => S_Incomplete, Predecessor => F_Final);
+         end if;
+      end if;
+   end Verify;
+
+   procedure Verify_Message (Ctx : in out Context) is
+   begin
+      Verify (Ctx, F_Tag);
+      Verify (Ctx, F_Code_Destination_Unreachable);
+      Verify (Ctx, F_Code_Redirect);
+      Verify (Ctx, F_Code_Time_Exceeded);
+      Verify (Ctx, F_Code_Zero);
+      Verify (Ctx, F_Checksum);
+      Verify (Ctx, F_Gateway_Internet_Address);
+      Verify (Ctx, F_Identifier);
+      Verify (Ctx, F_Pointer);
+      Verify (Ctx, F_Unused_32);
+      Verify (Ctx, F_Sequence_Number);
+      Verify (Ctx, F_Unused_24);
+      Verify (Ctx, F_Originate_Timestamp);
+      Verify (Ctx, F_Data);
+      Verify (Ctx, F_Receive_Timestamp);
+      Verify (Ctx, F_Transmit_Timestamp);
+   end Verify_Message;
+
+   function Present (Ctx : Context; Fld : Field) return Boolean is
+     (Structural_Valid (Ctx.Cursors (Fld))
+      and then Ctx.Cursors (Fld).First < Ctx.Cursors (Fld).Last + 1);
+
+   function Structural_Valid (Ctx : Context; Fld : Field) return Boolean is
+     ((Ctx.Cursors (Fld).State = S_Valid
+       or Ctx.Cursors (Fld).State = S_Structural_Valid));
+
+   function Valid (Ctx : Context; Fld : Field) return Boolean is
+     (Ctx.Cursors (Fld).State = S_Valid
+      and then Ctx.Cursors (Fld).First < Ctx.Cursors (Fld).Last + 1);
+
+   function Incomplete (Ctx : Context; Fld : Field) return Boolean is
+     (Ctx.Cursors (Fld).State = S_Incomplete);
+
+   function Invalid (Ctx : Context; Fld : Field) return Boolean is
+     (Ctx.Cursors (Fld).State = S_Invalid
+      or Ctx.Cursors (Fld).State = S_Incomplete);
+
+   function Structural_Valid_Message (Ctx : Context) return Boolean is
+     (Valid (Ctx, F_Tag)
+      and then ((Valid (Ctx, F_Code_Destination_Unreachable)
+                 and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                 and then Valid (Ctx, F_Checksum)
+                 and then ((Valid (Ctx, F_Gateway_Internet_Address)
+                            and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                            and then Structural_Valid (Ctx, F_Data))
+                           or (Valid (Ctx, F_Identifier)
+                               and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                               and then Valid (Ctx, F_Sequence_Number)
+                               and then ((Structural_Valid (Ctx, F_Data)
+                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                                         or (Valid (Ctx, F_Originate_Timestamp)
+                                             and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                       or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                             and then Valid (Ctx, F_Receive_Timestamp)
+                                             and then Valid (Ctx, F_Transmit_Timestamp))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))))
+                           or (Valid (Ctx, F_Pointer)
+                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                               and then Valid (Ctx, F_Unused_24)
+                               and then Structural_Valid (Ctx, F_Data))
+                           or (Valid (Ctx, F_Unused_32)
+                               and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                               and then Structural_Valid (Ctx, F_Data))))
+                or (Valid (Ctx, F_Code_Redirect)
+                    and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                    and then Valid (Ctx, F_Checksum)
+                    and then ((Valid (Ctx, F_Gateway_Internet_Address)
+                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                               and then Structural_Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Identifier)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                  and then Valid (Ctx, F_Sequence_Number)
+                                  and then ((Structural_Valid (Ctx, F_Data)
+                                             and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                       or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                                            or (Valid (Ctx, F_Originate_Timestamp)
+                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                and then Valid (Ctx, F_Receive_Timestamp)
+                                                and then Valid (Ctx, F_Transmit_Timestamp))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))))
+                              or (Valid (Ctx, F_Pointer)
+                                  and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                  and then Valid (Ctx, F_Unused_24)
+                                  and then Structural_Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Unused_32)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                  and then Structural_Valid (Ctx, F_Data))))
+                or (Valid (Ctx, F_Code_Time_Exceeded)
+                    and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                    and then Valid (Ctx, F_Checksum)
+                    and then ((Valid (Ctx, F_Gateway_Internet_Address)
+                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                               and then Structural_Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Identifier)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                  and then Valid (Ctx, F_Sequence_Number)
+                                  and then ((Structural_Valid (Ctx, F_Data)
+                                             and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                       or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                                            or (Valid (Ctx, F_Originate_Timestamp)
+                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                and then Valid (Ctx, F_Receive_Timestamp)
+                                                and then Valid (Ctx, F_Transmit_Timestamp))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))))
+                              or (Valid (Ctx, F_Pointer)
+                                  and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                  and then Valid (Ctx, F_Unused_24)
+                                  and then Structural_Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Unused_32)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                  and then Structural_Valid (Ctx, F_Data))))
+                or (Valid (Ctx, F_Code_Zero)
+                    and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                    and then Valid (Ctx, F_Checksum)
+                    and then ((Valid (Ctx, F_Gateway_Internet_Address)
+                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                               and then Structural_Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Identifier)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                  and then Valid (Ctx, F_Sequence_Number)
+                                  and then ((Structural_Valid (Ctx, F_Data)
+                                             and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                       or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                                            or (Valid (Ctx, F_Originate_Timestamp)
+                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                and then Valid (Ctx, F_Receive_Timestamp)
+                                                and then Valid (Ctx, F_Transmit_Timestamp))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))))
+                              or (Valid (Ctx, F_Pointer)
+                                  and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                  and then Valid (Ctx, F_Unused_24)
+                                  and then Structural_Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Unused_32)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                  and then Structural_Valid (Ctx, F_Data))))));
+
+   function Valid_Message (Ctx : Context) return Boolean is
+     (Valid (Ctx, F_Tag)
+      and then ((Valid (Ctx, F_Code_Destination_Unreachable)
+                 and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                 and then Valid (Ctx, F_Checksum)
+                 and then ((Valid (Ctx, F_Gateway_Internet_Address)
+                            and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                            and then Valid (Ctx, F_Data))
+                           or (Valid (Ctx, F_Identifier)
+                               and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                               and then Valid (Ctx, F_Sequence_Number)
+                               and then ((Valid (Ctx, F_Data)
+                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                                         or (Valid (Ctx, F_Originate_Timestamp)
+                                             and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                       or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                             and then Valid (Ctx, F_Receive_Timestamp)
+                                             and then Valid (Ctx, F_Transmit_Timestamp))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))))
+                           or (Valid (Ctx, F_Pointer)
+                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                               and then Valid (Ctx, F_Unused_24)
+                               and then Valid (Ctx, F_Data))
+                           or (Valid (Ctx, F_Unused_32)
+                               and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                         or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                               and then Valid (Ctx, F_Data))))
+                or (Valid (Ctx, F_Code_Redirect)
+                    and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                    and then Valid (Ctx, F_Checksum)
+                    and then ((Valid (Ctx, F_Gateway_Internet_Address)
+                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                               and then Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Identifier)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                  and then Valid (Ctx, F_Sequence_Number)
+                                  and then ((Valid (Ctx, F_Data)
+                                             and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                       or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                                            or (Valid (Ctx, F_Originate_Timestamp)
+                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                and then Valid (Ctx, F_Receive_Timestamp)
+                                                and then Valid (Ctx, F_Transmit_Timestamp))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))))
+                              or (Valid (Ctx, F_Pointer)
+                                  and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                  and then Valid (Ctx, F_Unused_24)
+                                  and then Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Unused_32)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                  and then Valid (Ctx, F_Data))))
+                or (Valid (Ctx, F_Code_Time_Exceeded)
+                    and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                    and then Valid (Ctx, F_Checksum)
+                    and then ((Valid (Ctx, F_Gateway_Internet_Address)
+                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                               and then Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Identifier)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                  and then Valid (Ctx, F_Sequence_Number)
+                                  and then ((Valid (Ctx, F_Data)
+                                             and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                       or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                                            or (Valid (Ctx, F_Originate_Timestamp)
+                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                and then Valid (Ctx, F_Receive_Timestamp)
+                                                and then Valid (Ctx, F_Transmit_Timestamp))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))))
+                              or (Valid (Ctx, F_Pointer)
+                                  and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                  and then Valid (Ctx, F_Unused_24)
+                                  and then Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Unused_32)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                  and then Valid (Ctx, F_Data))))
+                or (Valid (Ctx, F_Code_Zero)
+                    and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                              or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                    and then Valid (Ctx, F_Checksum)
+                    and then ((Valid (Ctx, F_Gateway_Internet_Address)
+                               and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                               and then Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Identifier)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                  and then Valid (Ctx, F_Sequence_Number)
+                                  and then ((Valid (Ctx, F_Data)
+                                             and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                       or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                                            or (Valid (Ctx, F_Originate_Timestamp)
+                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                and then Valid (Ctx, F_Receive_Timestamp)
+                                                and then Valid (Ctx, F_Transmit_Timestamp))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))))
+                              or (Valid (Ctx, F_Pointer)
+                                  and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                  and then Valid (Ctx, F_Unused_24)
+                                  and then Valid (Ctx, F_Data))
+                              or (Valid (Ctx, F_Unused_32)
+                                  and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                            or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                  and then Valid (Ctx, F_Data))))));
+
+   function Incomplete_Message (Ctx : Context) return Boolean is
+     (Incomplete (Ctx, F_Tag)
+      or Incomplete (Ctx, F_Code_Destination_Unreachable)
+      or Incomplete (Ctx, F_Code_Redirect)
+      or Incomplete (Ctx, F_Code_Time_Exceeded)
+      or Incomplete (Ctx, F_Code_Zero)
+      or Incomplete (Ctx, F_Checksum)
+      or Incomplete (Ctx, F_Gateway_Internet_Address)
+      or Incomplete (Ctx, F_Identifier)
+      or Incomplete (Ctx, F_Pointer)
+      or Incomplete (Ctx, F_Unused_32)
+      or Incomplete (Ctx, F_Sequence_Number)
+      or Incomplete (Ctx, F_Unused_24)
+      or Incomplete (Ctx, F_Originate_Timestamp)
+      or Incomplete (Ctx, F_Data)
+      or Incomplete (Ctx, F_Receive_Timestamp)
+      or Incomplete (Ctx, F_Transmit_Timestamp));
+
+   function Get_Tag (Ctx : Context) return RFLX.ICMP.Tag is
+     (To_Actual (Ctx.Cursors (F_Tag).Value.Tag_Value));
+
+   function Get_Code_Destination_Unreachable (Ctx : Context) return RFLX.ICMP.Code_Destination_Unreachable is
+     (To_Actual (Ctx.Cursors (F_Code_Destination_Unreachable).Value.Code_Destination_Unreachable_Value));
+
+   function Get_Code_Redirect (Ctx : Context) return RFLX.ICMP.Code_Redirect is
+     (To_Actual (Ctx.Cursors (F_Code_Redirect).Value.Code_Redirect_Value));
+
+   function Get_Code_Time_Exceeded (Ctx : Context) return RFLX.ICMP.Code_Time_Exceeded is
+     (To_Actual (Ctx.Cursors (F_Code_Time_Exceeded).Value.Code_Time_Exceeded_Value));
+
+   function Get_Code_Zero (Ctx : Context) return RFLX.ICMP.Code_Zero is
+     (To_Actual (Ctx.Cursors (F_Code_Zero).Value.Code_Zero_Value));
+
+   function Get_Checksum (Ctx : Context) return RFLX.ICMP.Checksum is
+     (To_Actual (Ctx.Cursors (F_Checksum).Value.Checksum_Value));
+
+   function Get_Gateway_Internet_Address (Ctx : Context) return RFLX.ICMP.Gateway_Internet_Address is
+     (To_Actual (Ctx.Cursors (F_Gateway_Internet_Address).Value.Gateway_Internet_Address_Value));
+
+   function Get_Identifier (Ctx : Context) return RFLX.ICMP.Identifier is
+     (To_Actual (Ctx.Cursors (F_Identifier).Value.Identifier_Value));
+
+   function Get_Pointer (Ctx : Context) return RFLX.ICMP.Pointer is
+     (To_Actual (Ctx.Cursors (F_Pointer).Value.Pointer_Value));
+
+   function Get_Unused_32 (Ctx : Context) return RFLX.ICMP.Unused_32 is
+     (To_Actual (Ctx.Cursors (F_Unused_32).Value.Unused_32_Value));
+
+   function Get_Sequence_Number (Ctx : Context) return RFLX.ICMP.Sequence_Number is
+     (To_Actual (Ctx.Cursors (F_Sequence_Number).Value.Sequence_Number_Value));
+
+   function Get_Unused_24 (Ctx : Context) return RFLX.ICMP.Unused_24 is
+     (To_Actual (Ctx.Cursors (F_Unused_24).Value.Unused_24_Value));
+
+   function Get_Originate_Timestamp (Ctx : Context) return RFLX.ICMP.Timestamp is
+     (To_Actual (Ctx.Cursors (F_Originate_Timestamp).Value.Originate_Timestamp_Value));
+
+   function Get_Receive_Timestamp (Ctx : Context) return RFLX.ICMP.Timestamp is
+     (To_Actual (Ctx.Cursors (F_Receive_Timestamp).Value.Receive_Timestamp_Value));
+
+   function Get_Transmit_Timestamp (Ctx : Context) return RFLX.ICMP.Timestamp is
+     (To_Actual (Ctx.Cursors (F_Transmit_Timestamp).Value.Transmit_Timestamp_Value));
+
+   procedure Get_Data (Ctx : Context) is
+      First : constant Types.Index := Types.Byte_Index (Ctx.Cursors (F_Data).First);
+      Last : constant Types.Index := Types.Byte_Index (Ctx.Cursors (F_Data).Last);
+   begin
+      Process_Data (Ctx.Buffer.all (First .. Last));
+   end Get_Data;
+
+   procedure Set_Field_Value (Ctx : in out Context; Val : Field_Dependent_Value; Fst, Lst : out Types.Bit_Index) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Val.Fld in Field'Range
+       and then Valid_Next (Ctx, Val.Fld)
+       and then Available_Space (Ctx, Val.Fld) >= Field_Length (Ctx, Val.Fld)
+       and then (for all F in Field'Range =>
+                    (if
+                        Structural_Valid (Ctx.Cursors (F))
+                     then
+                        Ctx.Cursors (F).Last <= Field_Last (Ctx, Val.Fld))),
+     Post =>
+       Has_Buffer (Ctx)
+       and Fst = Field_First (Ctx, Val.Fld)
+       and Lst = Field_Last (Ctx, Val.Fld)
+       and Fst >= Ctx.First
+       and Fst <= Lst + 1
+       and Types.Byte_Index (Lst) <= Ctx.Buffer_Last
+       and (for all F in Field'Range =>
+               (if
+                   Structural_Valid (Ctx.Cursors (F))
+                then
+                   Ctx.Cursors (F).Last <= Lst))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Ctx.Cursors = Ctx.Cursors'Old
+   is
+      First : constant Types.Bit_Index := Field_First (Ctx, Val.Fld);
+      Last : constant Types.Bit_Index := Field_Last (Ctx, Val.Fld);
+      function Buffer_First return Types.Index is
+        (Types.Byte_Index (First));
+      function Buffer_Last return Types.Index is
+        (Types.Byte_Index (Last));
+      function Offset return Types.Offset is
+        (Types.Offset ((8 - Last mod 8) mod 8));
+      procedure Insert is new Types.Insert (RFLX.ICMP.Tag_Base);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Code_Destination_Unreachable_Base);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Code_Redirect_Base);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Code_Time_Exceeded_Base);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Code_Zero_Base);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Checksum);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Gateway_Internet_Address);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Identifier);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Pointer);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Unused_32_Base);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Sequence_Number);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Unused_24_Base);
+      procedure Insert is new Types.Insert (RFLX.ICMP.Timestamp);
+   begin
+      Fst := First;
+      Lst := Last;
+      case Val.Fld is
+         when F_Initial =>
+            null;
+         when F_Tag =>
+            Insert (Val.Tag_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Code_Destination_Unreachable =>
+            Insert (Val.Code_Destination_Unreachable_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Code_Redirect =>
+            Insert (Val.Code_Redirect_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Code_Time_Exceeded =>
+            Insert (Val.Code_Time_Exceeded_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Code_Zero =>
+            Insert (Val.Code_Zero_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Checksum =>
+            Insert (Val.Checksum_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Gateway_Internet_Address =>
+            Insert (Val.Gateway_Internet_Address_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Identifier =>
+            Insert (Val.Identifier_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Pointer =>
+            Insert (Val.Pointer_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Unused_32 =>
+            Insert (Val.Unused_32_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Sequence_Number =>
+            Insert (Val.Sequence_Number_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Unused_24 =>
+            Insert (Val.Unused_24_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Originate_Timestamp =>
+            Insert (Val.Originate_Timestamp_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Data =>
+            null;
+         when F_Receive_Timestamp =>
+            Insert (Val.Receive_Timestamp_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Transmit_Timestamp =>
+            Insert (Val.Transmit_Timestamp_Value, Ctx.Buffer.all (Buffer_First .. Buffer_Last), Offset);
+         when F_Final =>
+            null;
+      end case;
+   end Set_Field_Value;
+
+   procedure Set_Tag (Ctx : in out Context; Val : RFLX.ICMP.Tag) is
+      Field_Value : constant Field_Dependent_Value := (F_Tag, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Tag);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Tag) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Tag).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Tag)) := (State => S_Invalid, Predecessor => F_Tag);
+   end Set_Tag;
+
+   procedure Set_Code_Destination_Unreachable (Ctx : in out Context; Val : RFLX.ICMP.Code_Destination_Unreachable) is
+      Field_Value : constant Field_Dependent_Value := (F_Code_Destination_Unreachable, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Code_Destination_Unreachable);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Code_Destination_Unreachable) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Code_Destination_Unreachable).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Code_Destination_Unreachable)) := (State => S_Invalid, Predecessor => F_Code_Destination_Unreachable);
+   end Set_Code_Destination_Unreachable;
+
+   procedure Set_Code_Redirect (Ctx : in out Context; Val : RFLX.ICMP.Code_Redirect) is
+      Field_Value : constant Field_Dependent_Value := (F_Code_Redirect, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Code_Redirect);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Code_Redirect) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Code_Redirect).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Code_Redirect)) := (State => S_Invalid, Predecessor => F_Code_Redirect);
+   end Set_Code_Redirect;
+
+   procedure Set_Code_Time_Exceeded (Ctx : in out Context; Val : RFLX.ICMP.Code_Time_Exceeded) is
+      Field_Value : constant Field_Dependent_Value := (F_Code_Time_Exceeded, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Code_Time_Exceeded);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Code_Time_Exceeded) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Code_Time_Exceeded).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Code_Time_Exceeded)) := (State => S_Invalid, Predecessor => F_Code_Time_Exceeded);
+   end Set_Code_Time_Exceeded;
+
+   procedure Set_Code_Zero (Ctx : in out Context; Val : RFLX.ICMP.Code_Zero) is
+      Field_Value : constant Field_Dependent_Value := (F_Code_Zero, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Code_Zero);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Code_Zero) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Code_Zero).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Code_Zero)) := (State => S_Invalid, Predecessor => F_Code_Zero);
+   end Set_Code_Zero;
+
+   procedure Set_Checksum (Ctx : in out Context; Val : RFLX.ICMP.Checksum) is
+      Field_Value : constant Field_Dependent_Value := (F_Checksum, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Checksum);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Checksum) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Checksum).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Checksum)) := (State => S_Invalid, Predecessor => F_Checksum);
+   end Set_Checksum;
+
+   procedure Set_Gateway_Internet_Address (Ctx : in out Context; Val : RFLX.ICMP.Gateway_Internet_Address) is
+      Field_Value : constant Field_Dependent_Value := (F_Gateway_Internet_Address, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Gateway_Internet_Address);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Gateway_Internet_Address) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Gateway_Internet_Address).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Gateway_Internet_Address)) := (State => S_Invalid, Predecessor => F_Gateway_Internet_Address);
+   end Set_Gateway_Internet_Address;
+
+   procedure Set_Identifier (Ctx : in out Context; Val : RFLX.ICMP.Identifier) is
+      Field_Value : constant Field_Dependent_Value := (F_Identifier, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Identifier);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Identifier) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Identifier).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Identifier)) := (State => S_Invalid, Predecessor => F_Identifier);
+   end Set_Identifier;
+
+   procedure Set_Pointer (Ctx : in out Context; Val : RFLX.ICMP.Pointer) is
+      Field_Value : constant Field_Dependent_Value := (F_Pointer, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Pointer);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Pointer) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Pointer).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Pointer)) := (State => S_Invalid, Predecessor => F_Pointer);
+   end Set_Pointer;
+
+   procedure Set_Unused_32 (Ctx : in out Context; Val : RFLX.ICMP.Unused_32) is
+      Field_Value : constant Field_Dependent_Value := (F_Unused_32, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Unused_32);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Unused_32) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Unused_32).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Unused_32)) := (State => S_Invalid, Predecessor => F_Unused_32);
+   end Set_Unused_32;
+
+   procedure Set_Sequence_Number (Ctx : in out Context; Val : RFLX.ICMP.Sequence_Number) is
+      Field_Value : constant Field_Dependent_Value := (F_Sequence_Number, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Sequence_Number);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Sequence_Number) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Sequence_Number).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Sequence_Number)) := (State => S_Invalid, Predecessor => F_Sequence_Number);
+   end Set_Sequence_Number;
+
+   procedure Set_Unused_24 (Ctx : in out Context; Val : RFLX.ICMP.Unused_24) is
+      Field_Value : constant Field_Dependent_Value := (F_Unused_24, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Unused_24);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Unused_24) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Unused_24).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Unused_24)) := (State => S_Invalid, Predecessor => F_Unused_24);
+   end Set_Unused_24;
+
+   procedure Set_Originate_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) is
+      Field_Value : constant Field_Dependent_Value := (F_Originate_Timestamp, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Originate_Timestamp);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Originate_Timestamp) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Originate_Timestamp).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Originate_Timestamp)) := (State => S_Invalid, Predecessor => F_Originate_Timestamp);
+   end Set_Originate_Timestamp;
+
+   procedure Set_Receive_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) is
+      Field_Value : constant Field_Dependent_Value := (F_Receive_Timestamp, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Receive_Timestamp);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Receive_Timestamp) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Receive_Timestamp).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Receive_Timestamp)) := (State => S_Invalid, Predecessor => F_Receive_Timestamp);
+   end Set_Receive_Timestamp;
+
+   procedure Set_Transmit_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) is
+      Field_Value : constant Field_Dependent_Value := (F_Transmit_Timestamp, To_Base (Val));
+      First, Last : Types.Bit_Index;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Transmit_Timestamp);
+      Set_Field_Value (Ctx, Field_Value, First, Last);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Transmit_Timestamp) := (State => S_Valid, First => First, Last => Last, Value => Field_Value, Predecessor => Ctx.Cursors (F_Transmit_Timestamp).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Transmit_Timestamp)) := (State => S_Invalid, Predecessor => F_Transmit_Timestamp);
+   end Set_Transmit_Timestamp;
+
+   procedure Set_Data_Empty (Ctx : in out Context) is
+      First : constant Types.Bit_Index := Field_First (Ctx, F_Data);
+      Last : constant Types.Bit_Index := Field_Last (Ctx, F_Data);
+   begin
+      Reset_Dependent_Fields (Ctx, F_Data);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      Ctx.Cursors (F_Data) := (State => S_Valid, First => First, Last => Last, Value => (Fld => F_Data), Predecessor => Ctx.Cursors (F_Data).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Data)) := (State => S_Invalid, Predecessor => F_Data);
+   end Set_Data_Empty;
+
+   procedure Set_Data (Ctx : in out Context) is
+      First : constant Types.Bit_Index := Field_First (Ctx, F_Data);
+      Last : constant Types.Bit_Index := Field_Last (Ctx, F_Data);
+      function Buffer_First return Types.Index is
+        (Types.Byte_Index (First));
+      function Buffer_Last return Types.Index is
+        (Types.Byte_Index (Last));
+   begin
+      Initialize_Data (Ctx);
+      Process_Data (Ctx.Buffer.all (Buffer_First .. Buffer_Last));
+   end Set_Data;
+
+   procedure Set_Bounded_Data (Ctx : in out Context; Length : Types.Bit_Length) is
+      First : constant Types.Bit_Index := Field_First (Ctx, F_Data);
+      Last : constant Types.Bit_Index := First + Length - 1;
+      function Buffer_First return Types.Index is
+        (Types.Byte_Index (First));
+      function Buffer_Last return Types.Index is
+        (Types.Byte_Index (Last));
+   begin
+      Initialize_Bounded_Data (Ctx, Length);
+      Process_Data (Ctx.Buffer.all (Buffer_First .. Buffer_Last));
+   end Set_Bounded_Data;
+
+   procedure Initialize_Data (Ctx : in out Context) is
+      First : constant Types.Bit_Index := Field_First (Ctx, F_Data);
+      Last : constant Types.Bit_Index := Field_Last (Ctx, F_Data);
+   begin
+      Reset_Dependent_Fields (Ctx, F_Data);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      pragma Assert ((if
+                         Structural_Valid (Ctx.Cursors (F_Tag))
+                      then
+                         Ctx.Cursors (F_Tag).Last - Ctx.Cursors (F_Tag).First + 1 = RFLX.ICMP.Tag_Base'Size
+                         and then Ctx.Cursors (F_Tag).Predecessor = F_Initial
+                         and then Ctx.Cursors (F_Tag).First = Ctx.First
+                         and then (if
+                                      Structural_Valid (Ctx.Cursors (F_Code_Destination_Unreachable))
+                                      and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                   then
+                                      Ctx.Cursors (F_Code_Destination_Unreachable).Last - Ctx.Cursors (F_Code_Destination_Unreachable).First + 1 = RFLX.ICMP.Code_Destination_Unreachable_Base'Size
+                                      and then Ctx.Cursors (F_Code_Destination_Unreachable).Predecessor = F_Tag
+                                      and then Ctx.Cursors (F_Code_Destination_Unreachable).First = Ctx.Cursors (F_Tag).Last + 1
+                                      and then (if
+                                                   Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                then
+                                                   Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                   and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Destination_Unreachable
+                                                   and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Destination_Unreachable).Last + 1
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                             then
+                                                                Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                             then
+                                                                Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                          then
+                                                                             Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                             and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                             and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                          and then (if
+                                                                                                       Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                    then
+                                                                                                       Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                       and then (if
+                                                                                                                    Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                 then
+                                                                                                                    Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                             then
+                                                                Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                          then
+                                                                             Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                             and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                             and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                             then
+                                                                Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                         and then (if
+                                      Structural_Valid (Ctx.Cursors (F_Code_Redirect))
+                                      and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                   then
+                                      Ctx.Cursors (F_Code_Redirect).Last - Ctx.Cursors (F_Code_Redirect).First + 1 = RFLX.ICMP.Code_Redirect_Base'Size
+                                      and then Ctx.Cursors (F_Code_Redirect).Predecessor = F_Tag
+                                      and then Ctx.Cursors (F_Code_Redirect).First = Ctx.Cursors (F_Tag).Last + 1
+                                      and then (if
+                                                   Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                then
+                                                   Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                   and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Redirect
+                                                   and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Redirect).Last + 1
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                             then
+                                                                Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                             then
+                                                                Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                          then
+                                                                             Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                             and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                             and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                          and then (if
+                                                                                                       Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                    then
+                                                                                                       Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                       and then (if
+                                                                                                                    Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                 then
+                                                                                                                    Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                             then
+                                                                Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                          then
+                                                                             Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                             and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                             and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                             then
+                                                                Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                         and then (if
+                                      Structural_Valid (Ctx.Cursors (F_Code_Time_Exceeded))
+                                      and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                   then
+                                      Ctx.Cursors (F_Code_Time_Exceeded).Last - Ctx.Cursors (F_Code_Time_Exceeded).First + 1 = RFLX.ICMP.Code_Time_Exceeded_Base'Size
+                                      and then Ctx.Cursors (F_Code_Time_Exceeded).Predecessor = F_Tag
+                                      and then Ctx.Cursors (F_Code_Time_Exceeded).First = Ctx.Cursors (F_Tag).Last + 1
+                                      and then (if
+                                                   Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                then
+                                                   Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                   and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Time_Exceeded
+                                                   and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Time_Exceeded).Last + 1
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                             then
+                                                                Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                             then
+                                                                Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                          then
+                                                                             Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                             and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                             and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                          and then (if
+                                                                                                       Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                    then
+                                                                                                       Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                       and then (if
+                                                                                                                    Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                 then
+                                                                                                                    Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                             then
+                                                                Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                          then
+                                                                             Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                             and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                             and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                             then
+                                                                Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                         and then (if
+                                      Structural_Valid (Ctx.Cursors (F_Code_Zero))
+                                      and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                   then
+                                      Ctx.Cursors (F_Code_Zero).Last - Ctx.Cursors (F_Code_Zero).First + 1 = RFLX.ICMP.Code_Zero_Base'Size
+                                      and then Ctx.Cursors (F_Code_Zero).Predecessor = F_Tag
+                                      and then Ctx.Cursors (F_Code_Zero).First = Ctx.Cursors (F_Tag).Last + 1
+                                      and then (if
+                                                   Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                then
+                                                   Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                   and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Zero
+                                                   and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Zero).Last + 1
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                             then
+                                                                Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                             then
+                                                                Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                          then
+                                                                             Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                             and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                             and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                          and then (if
+                                                                                                       Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                    then
+                                                                                                       Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                       and then (if
+                                                                                                                    Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                 then
+                                                                                                                    Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                             then
+                                                                Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                          then
+                                                                             Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                             and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                             and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                             then
+                                                                Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))));
+      Ctx.Cursors (F_Data) := (State => S_Structural_Valid, First => First, Last => Last, Value => (Fld => F_Data), Predecessor => Ctx.Cursors (F_Data).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Data)) := (State => S_Invalid, Predecessor => F_Data);
+   end Initialize_Data;
+
+   procedure Initialize_Bounded_Data (Ctx : in out Context; Length : Types.Bit_Length) is
+      First : constant Types.Bit_Index := Field_First (Ctx, F_Data);
+      Last : constant Types.Bit_Index := First + Length - 1;
+   begin
+      Reset_Dependent_Fields (Ctx, F_Data);
+      Ctx := (Ctx.Buffer_First, Ctx.Buffer_Last, Ctx.First, Last, Ctx.Buffer, Ctx.Cursors);
+      pragma Assert ((if
+                         Structural_Valid (Ctx.Cursors (F_Tag))
+                      then
+                         Ctx.Cursors (F_Tag).Last - Ctx.Cursors (F_Tag).First + 1 = RFLX.ICMP.Tag_Base'Size
+                         and then Ctx.Cursors (F_Tag).Predecessor = F_Initial
+                         and then Ctx.Cursors (F_Tag).First = Ctx.First
+                         and then (if
+                                      Structural_Valid (Ctx.Cursors (F_Code_Destination_Unreachable))
+                                      and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                   then
+                                      Ctx.Cursors (F_Code_Destination_Unreachable).Last - Ctx.Cursors (F_Code_Destination_Unreachable).First + 1 = RFLX.ICMP.Code_Destination_Unreachable_Base'Size
+                                      and then Ctx.Cursors (F_Code_Destination_Unreachable).Predecessor = F_Tag
+                                      and then Ctx.Cursors (F_Code_Destination_Unreachable).First = Ctx.Cursors (F_Tag).Last + 1
+                                      and then (if
+                                                   Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                then
+                                                   Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                   and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Destination_Unreachable
+                                                   and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Destination_Unreachable).Last + 1
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                             then
+                                                                Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                             then
+                                                                Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                          then
+                                                                             Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                             and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                             and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                          and then (if
+                                                                                                       Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                    then
+                                                                                                       Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                       and then (if
+                                                                                                                    Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                 then
+                                                                                                                    Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                             then
+                                                                Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                          then
+                                                                             Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                             and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                             and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                             then
+                                                                Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                         and then (if
+                                      Structural_Valid (Ctx.Cursors (F_Code_Redirect))
+                                      and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                   then
+                                      Ctx.Cursors (F_Code_Redirect).Last - Ctx.Cursors (F_Code_Redirect).First + 1 = RFLX.ICMP.Code_Redirect_Base'Size
+                                      and then Ctx.Cursors (F_Code_Redirect).Predecessor = F_Tag
+                                      and then Ctx.Cursors (F_Code_Redirect).First = Ctx.Cursors (F_Tag).Last + 1
+                                      and then (if
+                                                   Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                then
+                                                   Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                   and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Redirect
+                                                   and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Redirect).Last + 1
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                             then
+                                                                Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                             then
+                                                                Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                          then
+                                                                             Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                             and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                             and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                          and then (if
+                                                                                                       Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                    then
+                                                                                                       Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                       and then (if
+                                                                                                                    Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                 then
+                                                                                                                    Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                             then
+                                                                Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                          then
+                                                                             Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                             and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                             and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                             then
+                                                                Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                         and then (if
+                                      Structural_Valid (Ctx.Cursors (F_Code_Time_Exceeded))
+                                      and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                   then
+                                      Ctx.Cursors (F_Code_Time_Exceeded).Last - Ctx.Cursors (F_Code_Time_Exceeded).First + 1 = RFLX.ICMP.Code_Time_Exceeded_Base'Size
+                                      and then Ctx.Cursors (F_Code_Time_Exceeded).Predecessor = F_Tag
+                                      and then Ctx.Cursors (F_Code_Time_Exceeded).First = Ctx.Cursors (F_Tag).Last + 1
+                                      and then (if
+                                                   Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                then
+                                                   Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                   and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Time_Exceeded
+                                                   and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Time_Exceeded).Last + 1
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                             then
+                                                                Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                             then
+                                                                Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                          then
+                                                                             Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                             and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                             and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                          and then (if
+                                                                                                       Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                    then
+                                                                                                       Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                       and then (if
+                                                                                                                    Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                 then
+                                                                                                                    Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                             then
+                                                                Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                          then
+                                                                             Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                             and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                             and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                             then
+                                                                Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))
+                         and then (if
+                                      Structural_Valid (Ctx.Cursors (F_Code_Zero))
+                                      and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                   then
+                                      Ctx.Cursors (F_Code_Zero).Last - Ctx.Cursors (F_Code_Zero).First + 1 = RFLX.ICMP.Code_Zero_Base'Size
+                                      and then Ctx.Cursors (F_Code_Zero).Predecessor = F_Tag
+                                      and then Ctx.Cursors (F_Code_Zero).First = Ctx.Cursors (F_Tag).Last + 1
+                                      and then (if
+                                                   Structural_Valid (Ctx.Cursors (F_Checksum))
+                                                then
+                                                   Ctx.Cursors (F_Checksum).Last - Ctx.Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                                   and then Ctx.Cursors (F_Checksum).Predecessor = F_Code_Zero
+                                                   and then Ctx.Cursors (F_Checksum).First = Ctx.Cursors (F_Code_Zero).Last + 1
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Gateway_Internet_Address))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                             then
+                                                                Ctx.Cursors (F_Gateway_Internet_Address).Last - Ctx.Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Gateway_Internet_Address).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Gateway_Internet_Address).Last + 1))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Identifier))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                             then
+                                                                Ctx.Cursors (F_Identifier).Last - Ctx.Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                                and then Ctx.Cursors (F_Identifier).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Identifier).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Sequence_Number))
+                                                                          then
+                                                                             Ctx.Cursors (F_Sequence_Number).Last - Ctx.Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                             and then Ctx.Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                             and then Ctx.Cursors (F_Sequence_Number).First = Ctx.Cursors (F_Identifier).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = Ctx.Last - Ctx.Cursors (F_Sequence_Number).Last
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Sequence_Number).Last + 1)
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Originate_Timestamp))
+                                                                                          and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                                    or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Originate_Timestamp).Last - Ctx.Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                          and then Ctx.Cursors (F_Originate_Timestamp).First = Ctx.Cursors (F_Sequence_Number).Last + 1
+                                                                                          and then (if
+                                                                                                       Structural_Valid (Ctx.Cursors (F_Receive_Timestamp))
+                                                                                                    then
+                                                                                                       Ctx.Cursors (F_Receive_Timestamp).Last - Ctx.Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                       and then Ctx.Cursors (F_Receive_Timestamp).First = Ctx.Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                       and then (if
+                                                                                                                    Structural_Valid (Ctx.Cursors (F_Transmit_Timestamp))
+                                                                                                                 then
+                                                                                                                    Ctx.Cursors (F_Transmit_Timestamp).Last - Ctx.Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                                    and then Ctx.Cursors (F_Transmit_Timestamp).First = Ctx.Cursors (F_Receive_Timestamp).Last + 1)))))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Pointer))
+                                                                and then Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                             then
+                                                                Ctx.Cursors (F_Pointer).Last - Ctx.Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                                and then Ctx.Cursors (F_Pointer).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Pointer).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Unused_24))
+                                                                          then
+                                                                             Ctx.Cursors (F_Unused_24).Last - Ctx.Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                             and then Ctx.Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                             and then Ctx.Cursors (F_Unused_24).First = Ctx.Cursors (F_Pointer).Last + 1
+                                                                             and then (if
+                                                                                          Structural_Valid (Ctx.Cursors (F_Data))
+                                                                                       then
+                                                                                          Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                                          and then Ctx.Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                          and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_24).Last + 1)))
+                                                   and then (if
+                                                                Structural_Valid (Ctx.Cursors (F_Unused_32))
+                                                                and then (Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                          or Types.U64 (Ctx.Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                             then
+                                                                Ctx.Cursors (F_Unused_32).Last - Ctx.Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                                and then Ctx.Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                                and then Ctx.Cursors (F_Unused_32).First = Ctx.Cursors (F_Checksum).Last + 1
+                                                                and then (if
+                                                                             Structural_Valid (Ctx.Cursors (F_Data))
+                                                                          then
+                                                                             Ctx.Cursors (F_Data).Last - Ctx.Cursors (F_Data).First + 1 = 224
+                                                                             and then Ctx.Cursors (F_Data).Predecessor = F_Unused_32
+                                                                             and then Ctx.Cursors (F_Data).First = Ctx.Cursors (F_Unused_32).Last + 1))))));
+      Ctx.Cursors (F_Data) := (State => S_Structural_Valid, First => First, Last => Last, Value => (Fld => F_Data), Predecessor => Ctx.Cursors (F_Data).Predecessor);
+      Ctx.Cursors (Successor (Ctx, F_Data)) := (State => S_Invalid, Predecessor => F_Data);
+   end Initialize_Bounded_Data;
+
+end RFLX.ICMP.Generic_Message;

--- a/generated/rflx-icmp-generic_message.ads
+++ b/generated/rflx-icmp-generic_message.ads
@@ -1,0 +1,1779 @@
+pragma Style_Checks ("N3aAbcdefhiIklnOprStux");
+with RFLX.RFLX_Generic_Types;
+
+generic
+   with package Types is new RFLX.RFLX_Generic_Types (<>);
+package RFLX.ICMP.Generic_Message with
+  SPARK_Mode,
+  Annotate =>
+    (GNATprove, Terminating)
+is
+
+   pragma Warnings (Off, "use clause for type ""U64"" * has no effect");
+
+   use type Types.Bytes, Types.Bytes_Ptr, Types.Index, Types.Bit_Index, Types.U64;
+
+   pragma Warnings (On, "use clause for type ""U64"" * has no effect");
+
+   type Virtual_Field is (F_Initial, F_Tag, F_Code_Destination_Unreachable, F_Code_Redirect, F_Code_Time_Exceeded, F_Code_Zero, F_Checksum, F_Gateway_Internet_Address, F_Identifier, F_Pointer, F_Unused_32, F_Sequence_Number, F_Unused_24, F_Originate_Timestamp, F_Data, F_Receive_Timestamp, F_Transmit_Timestamp, F_Final);
+
+   subtype Field is Virtual_Field range F_Tag .. F_Transmit_Timestamp;
+
+   type Field_Cursor is private with
+     Default_Initial_Condition =>
+       False;
+
+   type Field_Cursors is private with
+     Default_Initial_Condition =>
+       False;
+
+   type Context (Buffer_First, Buffer_Last : Types.Index := Types.Index'First; First, Last : Types.Bit_Index := Types.Bit_Index'First) is private with
+     Default_Initial_Condition =>
+       Types.Byte_Index (First) >= Buffer_First
+       and Types.Byte_Index (Last) <= Buffer_Last
+       and First <= Last
+       and Last <= Types.Bit_Index'Last / 2;
+
+   type Field_Dependent_Value (Fld : Virtual_Field := F_Initial) is
+      record
+         case Fld is
+            when F_Initial | F_Data | F_Final =>
+               null;
+            when F_Tag =>
+               Tag_Value : RFLX.ICMP.Tag_Base;
+            when F_Code_Destination_Unreachable =>
+               Code_Destination_Unreachable_Value : RFLX.ICMP.Code_Destination_Unreachable_Base;
+            when F_Code_Redirect =>
+               Code_Redirect_Value : RFLX.ICMP.Code_Redirect_Base;
+            when F_Code_Time_Exceeded =>
+               Code_Time_Exceeded_Value : RFLX.ICMP.Code_Time_Exceeded_Base;
+            when F_Code_Zero =>
+               Code_Zero_Value : RFLX.ICMP.Code_Zero_Base;
+            when F_Checksum =>
+               Checksum_Value : RFLX.ICMP.Checksum;
+            when F_Gateway_Internet_Address =>
+               Gateway_Internet_Address_Value : RFLX.ICMP.Gateway_Internet_Address;
+            when F_Identifier =>
+               Identifier_Value : RFLX.ICMP.Identifier;
+            when F_Pointer =>
+               Pointer_Value : RFLX.ICMP.Pointer;
+            when F_Unused_32 =>
+               Unused_32_Value : RFLX.ICMP.Unused_32_Base;
+            when F_Sequence_Number =>
+               Sequence_Number_Value : RFLX.ICMP.Sequence_Number;
+            when F_Unused_24 =>
+               Unused_24_Value : RFLX.ICMP.Unused_24_Base;
+            when F_Originate_Timestamp =>
+               Originate_Timestamp_Value : RFLX.ICMP.Timestamp;
+            when F_Receive_Timestamp =>
+               Receive_Timestamp_Value : RFLX.ICMP.Timestamp;
+            when F_Transmit_Timestamp =>
+               Transmit_Timestamp_Value : RFLX.ICMP.Timestamp;
+         end case;
+      end record;
+
+   procedure Initialize (Ctx : out Context; Buffer : in out Types.Bytes_Ptr) with
+     Pre =>
+       not Ctx'Constrained
+       and then Buffer /= null
+       and then Buffer'Length > 0
+       and then Buffer'Last <= Types.Index'Last / 2,
+     Post =>
+       Has_Buffer (Ctx)
+       and Buffer = null
+       and Ctx.Buffer_First = Buffer'First'Old
+       and Ctx.Buffer_Last = Buffer'Last'Old
+       and Ctx.First = Types.First_Bit_Index (Ctx.Buffer_First)
+       and Initialized (Ctx),
+     Depends =>
+       (Ctx => Buffer, Buffer => null);
+
+   procedure Initialize (Ctx : out Context; Buffer : in out Types.Bytes_Ptr; First, Last : Types.Bit_Index) with
+     Pre =>
+       not Ctx'Constrained
+       and then Buffer /= null
+       and then Buffer'Length > 0
+       and then Types.Byte_Index (First) >= Buffer'First
+       and then Types.Byte_Index (Last) <= Buffer'Last
+       and then First <= Last
+       and then Last <= Types.Bit_Index'Last / 2,
+     Post =>
+       Buffer = null
+       and Has_Buffer (Ctx)
+       and Ctx.Buffer_First = Buffer'First'Old
+       and Ctx.Buffer_Last = Buffer'Last'Old
+       and Ctx.First = First
+       and Ctx.Last = Last
+       and Initialized (Ctx),
+     Depends =>
+       (Ctx => (Buffer, First, Last), Buffer => null);
+
+   function Initialized (Ctx : Context) return Boolean with
+     Ghost;
+
+   procedure Take_Buffer (Ctx : in out Context; Buffer : out Types.Bytes_Ptr) with
+     Pre =>
+       Has_Buffer (Ctx),
+     Post =>
+       not Has_Buffer (Ctx)
+       and Buffer /= null
+       and Ctx.Buffer_First = Buffer'First
+       and Ctx.Buffer_Last = Buffer'Last
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Ctx.Last = Ctx.Last'Old
+       and Context_Cursors (Ctx) = Context_Cursors (Ctx)'Old,
+     Depends =>
+       (Ctx => Ctx, Buffer => Ctx);
+
+   function Has_Buffer (Ctx : Context) return Boolean;
+
+   function Message_Last (Ctx : Context) return Types.Bit_Index with
+     Pre =>
+       Has_Buffer (Ctx)
+       and then Structural_Valid_Message (Ctx);
+
+   function Path_Condition (Ctx : Context; Fld : Field) return Boolean with
+     Pre =>
+       Valid_Predecessor (Ctx, Fld);
+
+   function Field_Condition (Ctx : Context; Val : Field_Dependent_Value) return Boolean with
+     Pre =>
+       Has_Buffer (Ctx)
+       and Val.Fld in Field'Range
+       and Valid_Predecessor (Ctx, Val.Fld);
+
+   function Field_Length (Ctx : Context; Fld : Field) return Types.Bit_Length with
+     Pre =>
+       Valid_Next (Ctx, Fld);
+
+   function Field_First (Ctx : Context; Fld : Field) return Types.Bit_Index with
+     Pre =>
+       Valid_Next (Ctx, Fld);
+
+   function Field_Last (Ctx : Context; Fld : Field) return Types.Bit_Index with
+     Pre =>
+       Valid_Next (Ctx, Fld);
+
+   function Predecessor (Ctx : Context; Fld : Virtual_Field) return Virtual_Field;
+
+   function Valid_Predecessor (Ctx : Context; Fld : Virtual_Field) return Boolean;
+
+   function Valid_Next (Ctx : Context; Fld : Field) return Boolean;
+
+   function Available_Space (Ctx : Context; Fld : Field) return Types.Bit_Length with
+     Pre =>
+       Valid_Next (Ctx, Fld);
+
+   function Equal (Ctx : Context; Fld : Field; Data : Types.Bytes) return Boolean with
+     Pre =>
+       Has_Buffer (Ctx)
+       and Valid_Next (Ctx, Fld);
+
+   procedure Verify (Ctx : in out Context; Fld : Field) with
+     Post =>
+       Has_Buffer (Ctx) = Has_Buffer (Ctx)'Old
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Ctx.Last = Ctx.Last'Old;
+
+   procedure Verify_Message (Ctx : in out Context) with
+     Post =>
+       Has_Buffer (Ctx) = Has_Buffer (Ctx)'Old
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Ctx.Last = Ctx.Last'Old;
+
+   function Present (Ctx : Context; Fld : Field) return Boolean;
+
+   function Structural_Valid (Ctx : Context; Fld : Field) return Boolean;
+
+   function Valid (Ctx : Context; Fld : Field) return Boolean with
+     Post =>
+       (if
+           Valid'Result
+        then
+           Structural_Valid (Ctx, Fld)
+           and Present (Ctx, Fld));
+
+   function Incomplete (Ctx : Context; Fld : Field) return Boolean;
+
+   function Invalid (Ctx : Context; Fld : Field) return Boolean;
+
+   function Structural_Valid_Message (Ctx : Context) return Boolean with
+     Pre =>
+       Has_Buffer (Ctx);
+
+   function Valid_Message (Ctx : Context) return Boolean with
+     Pre =>
+       Has_Buffer (Ctx);
+
+   function Incomplete_Message (Ctx : Context) return Boolean;
+
+   function Get_Tag (Ctx : Context) return RFLX.ICMP.Tag with
+     Pre =>
+       Valid (Ctx, F_Tag);
+
+   function Get_Code_Destination_Unreachable (Ctx : Context) return RFLX.ICMP.Code_Destination_Unreachable with
+     Pre =>
+       Valid (Ctx, F_Code_Destination_Unreachable);
+
+   function Get_Code_Redirect (Ctx : Context) return RFLX.ICMP.Code_Redirect with
+     Pre =>
+       Valid (Ctx, F_Code_Redirect);
+
+   function Get_Code_Time_Exceeded (Ctx : Context) return RFLX.ICMP.Code_Time_Exceeded with
+     Pre =>
+       Valid (Ctx, F_Code_Time_Exceeded);
+
+   function Get_Code_Zero (Ctx : Context) return RFLX.ICMP.Code_Zero with
+     Pre =>
+       Valid (Ctx, F_Code_Zero);
+
+   function Get_Checksum (Ctx : Context) return RFLX.ICMP.Checksum with
+     Pre =>
+       Valid (Ctx, F_Checksum);
+
+   function Get_Gateway_Internet_Address (Ctx : Context) return RFLX.ICMP.Gateway_Internet_Address with
+     Pre =>
+       Valid (Ctx, F_Gateway_Internet_Address);
+
+   function Get_Identifier (Ctx : Context) return RFLX.ICMP.Identifier with
+     Pre =>
+       Valid (Ctx, F_Identifier);
+
+   function Get_Pointer (Ctx : Context) return RFLX.ICMP.Pointer with
+     Pre =>
+       Valid (Ctx, F_Pointer);
+
+   function Get_Unused_32 (Ctx : Context) return RFLX.ICMP.Unused_32 with
+     Pre =>
+       Valid (Ctx, F_Unused_32);
+
+   function Get_Sequence_Number (Ctx : Context) return RFLX.ICMP.Sequence_Number with
+     Pre =>
+       Valid (Ctx, F_Sequence_Number);
+
+   function Get_Unused_24 (Ctx : Context) return RFLX.ICMP.Unused_24 with
+     Pre =>
+       Valid (Ctx, F_Unused_24);
+
+   function Get_Originate_Timestamp (Ctx : Context) return RFLX.ICMP.Timestamp with
+     Pre =>
+       Valid (Ctx, F_Originate_Timestamp);
+
+   function Get_Receive_Timestamp (Ctx : Context) return RFLX.ICMP.Timestamp with
+     Pre =>
+       Valid (Ctx, F_Receive_Timestamp);
+
+   function Get_Transmit_Timestamp (Ctx : Context) return RFLX.ICMP.Timestamp with
+     Pre =>
+       Valid (Ctx, F_Transmit_Timestamp);
+
+   generic
+      with procedure Process_Data (Data : Types.Bytes);
+   procedure Get_Data (Ctx : Context) with
+     Pre =>
+       Has_Buffer (Ctx)
+       and Present (Ctx, F_Data);
+
+   procedure Set_Tag (Ctx : in out Context; Val : RFLX.ICMP.Tag) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Tag)
+       and then Field_Last (Ctx, F_Tag) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Tag, To_Base (Val)))
+       and then True
+       and then Available_Space (Ctx, F_Tag) >= Field_Length (Ctx, F_Tag),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Tag)
+       and Get_Tag (Ctx) = Val
+       and Invalid (Ctx, F_Code_Destination_Unreachable)
+       and Invalid (Ctx, F_Code_Redirect)
+       and Invalid (Ctx, F_Code_Time_Exceeded)
+       and Invalid (Ctx, F_Code_Zero)
+       and Invalid (Ctx, F_Checksum)
+       and Invalid (Ctx, F_Gateway_Internet_Address)
+       and Invalid (Ctx, F_Identifier)
+       and Invalid (Ctx, F_Pointer)
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Destination_Unreachable))
+            then
+               Predecessor (Ctx, F_Code_Destination_Unreachable) = F_Tag
+               and Valid_Next (Ctx, F_Code_Destination_Unreachable))
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Redirect))
+            then
+               Predecessor (Ctx, F_Code_Redirect) = F_Tag
+               and Valid_Next (Ctx, F_Code_Redirect))
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Time_Exceeded))
+            then
+               Predecessor (Ctx, F_Code_Time_Exceeded) = F_Tag
+               and Valid_Next (Ctx, F_Code_Time_Exceeded))
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Information_Reply))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Information_Request))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Timestamp_Reply))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Timestamp_Msg))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Parameter_Problem))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Source_Quench))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Echo_Reply))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Echo_Request))
+            then
+               Predecessor (Ctx, F_Code_Zero) = F_Tag
+               and Valid_Next (Ctx, F_Code_Zero))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Tag) = Predecessor (Ctx, F_Tag)'Old
+       and Valid_Next (Ctx, F_Tag) = Valid_Next (Ctx, F_Tag)'Old;
+
+   procedure Set_Code_Destination_Unreachable (Ctx : in out Context; Val : RFLX.ICMP.Code_Destination_Unreachable) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Code_Destination_Unreachable)
+       and then Field_Last (Ctx, F_Code_Destination_Unreachable) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Code_Destination_Unreachable, To_Base (Val)))
+       and then True
+       and then Available_Space (Ctx, F_Code_Destination_Unreachable) >= Field_Length (Ctx, F_Code_Destination_Unreachable),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Code_Destination_Unreachable)
+       and Get_Code_Destination_Unreachable (Ctx) = Val
+       and Invalid (Ctx, F_Code_Redirect)
+       and Invalid (Ctx, F_Code_Time_Exceeded)
+       and Invalid (Ctx, F_Code_Zero)
+       and Invalid (Ctx, F_Checksum)
+       and Invalid (Ctx, F_Gateway_Internet_Address)
+       and Invalid (Ctx, F_Identifier)
+       and Invalid (Ctx, F_Pointer)
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Checksum) = F_Code_Destination_Unreachable
+            and Valid_Next (Ctx, F_Checksum))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Code_Destination_Unreachable) = Predecessor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Valid_Next (Ctx, F_Code_Destination_Unreachable) = Valid_Next (Ctx, F_Code_Destination_Unreachable)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old;
+
+   procedure Set_Code_Redirect (Ctx : in out Context; Val : RFLX.ICMP.Code_Redirect) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Code_Redirect)
+       and then Field_Last (Ctx, F_Code_Redirect) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Code_Redirect, To_Base (Val)))
+       and then True
+       and then Available_Space (Ctx, F_Code_Redirect) >= Field_Length (Ctx, F_Code_Redirect),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Code_Redirect)
+       and Get_Code_Redirect (Ctx) = Val
+       and Invalid (Ctx, F_Code_Time_Exceeded)
+       and Invalid (Ctx, F_Code_Zero)
+       and Invalid (Ctx, F_Checksum)
+       and Invalid (Ctx, F_Gateway_Internet_Address)
+       and Invalid (Ctx, F_Identifier)
+       and Invalid (Ctx, F_Pointer)
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Checksum) = F_Code_Redirect
+            and Valid_Next (Ctx, F_Checksum))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Code_Redirect) = Predecessor (Ctx, F_Code_Redirect)'Old
+       and Valid_Next (Ctx, F_Code_Redirect) = Valid_Next (Ctx, F_Code_Redirect)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old;
+
+   procedure Set_Code_Time_Exceeded (Ctx : in out Context; Val : RFLX.ICMP.Code_Time_Exceeded) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Code_Time_Exceeded)
+       and then Field_Last (Ctx, F_Code_Time_Exceeded) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Code_Time_Exceeded, To_Base (Val)))
+       and then True
+       and then Available_Space (Ctx, F_Code_Time_Exceeded) >= Field_Length (Ctx, F_Code_Time_Exceeded),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Code_Time_Exceeded)
+       and Get_Code_Time_Exceeded (Ctx) = Val
+       and Invalid (Ctx, F_Code_Zero)
+       and Invalid (Ctx, F_Checksum)
+       and Invalid (Ctx, F_Gateway_Internet_Address)
+       and Invalid (Ctx, F_Identifier)
+       and Invalid (Ctx, F_Pointer)
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Checksum) = F_Code_Time_Exceeded
+            and Valid_Next (Ctx, F_Checksum))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Code_Time_Exceeded) = Predecessor (Ctx, F_Code_Time_Exceeded)'Old
+       and Valid_Next (Ctx, F_Code_Time_Exceeded) = Valid_Next (Ctx, F_Code_Time_Exceeded)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old;
+
+   procedure Set_Code_Zero (Ctx : in out Context; Val : RFLX.ICMP.Code_Zero) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Code_Zero)
+       and then Field_Last (Ctx, F_Code_Zero) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Code_Zero, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Code_Zero) >= Field_Length (Ctx, F_Code_Zero),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Code_Zero)
+       and Get_Code_Zero (Ctx) = Val
+       and Invalid (Ctx, F_Checksum)
+       and Invalid (Ctx, F_Gateway_Internet_Address)
+       and Invalid (Ctx, F_Identifier)
+       and Invalid (Ctx, F_Pointer)
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Checksum) = F_Code_Zero
+            and Valid_Next (Ctx, F_Checksum))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Code_Zero) = Predecessor (Ctx, F_Code_Zero)'Old
+       and Valid_Next (Ctx, F_Code_Zero) = Valid_Next (Ctx, F_Code_Zero)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old;
+
+   procedure Set_Checksum (Ctx : in out Context; Val : RFLX.ICMP.Checksum) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Checksum)
+       and then Field_Last (Ctx, F_Checksum) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Checksum, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Checksum) >= Field_Length (Ctx, F_Checksum),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Checksum)
+       and Get_Checksum (Ctx) = Val
+       and Invalid (Ctx, F_Gateway_Internet_Address)
+       and Invalid (Ctx, F_Identifier)
+       and Invalid (Ctx, F_Pointer)
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Redirect))
+            then
+               Predecessor (Ctx, F_Gateway_Internet_Address) = F_Checksum
+               and Valid_Next (Ctx, F_Gateway_Internet_Address))
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Information_Reply))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Information_Request))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Timestamp_Reply))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Timestamp_Msg))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Echo_Request))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Echo_Reply))
+            then
+               Predecessor (Ctx, F_Identifier) = F_Checksum
+               and Valid_Next (Ctx, F_Identifier))
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Parameter_Problem))
+            then
+               Predecessor (Ctx, F_Pointer) = F_Checksum
+               and Valid_Next (Ctx, F_Pointer))
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Time_Exceeded))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Destination_Unreachable))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Source_Quench))
+            then
+               Predecessor (Ctx, F_Unused_32) = F_Checksum
+               and Valid_Next (Ctx, F_Unused_32))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Checksum) = Predecessor (Ctx, F_Checksum)'Old
+       and Valid_Next (Ctx, F_Checksum) = Valid_Next (Ctx, F_Checksum)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old;
+
+   procedure Set_Gateway_Internet_Address (Ctx : in out Context; Val : RFLX.ICMP.Gateway_Internet_Address) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Gateway_Internet_Address)
+       and then Field_Last (Ctx, F_Gateway_Internet_Address) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Gateway_Internet_Address, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Gateway_Internet_Address) >= Field_Length (Ctx, F_Gateway_Internet_Address),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Gateway_Internet_Address)
+       and Get_Gateway_Internet_Address (Ctx) = Val
+       and Invalid (Ctx, F_Identifier)
+       and Invalid (Ctx, F_Pointer)
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Data) = F_Gateway_Internet_Address
+            and Valid_Next (Ctx, F_Data))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Gateway_Internet_Address) = Predecessor (Ctx, F_Gateway_Internet_Address)'Old
+       and Valid_Next (Ctx, F_Gateway_Internet_Address) = Valid_Next (Ctx, F_Gateway_Internet_Address)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old;
+
+   procedure Set_Identifier (Ctx : in out Context; Val : RFLX.ICMP.Identifier) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Identifier)
+       and then Field_Last (Ctx, F_Identifier) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Identifier, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Identifier) >= Field_Length (Ctx, F_Identifier),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Identifier)
+       and Get_Identifier (Ctx) = Val
+       and Invalid (Ctx, F_Pointer)
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Sequence_Number) = F_Identifier
+            and Valid_Next (Ctx, F_Sequence_Number))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Identifier) = Predecessor (Ctx, F_Identifier)'Old
+       and Valid_Next (Ctx, F_Identifier) = Valid_Next (Ctx, F_Identifier)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
+       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old;
+
+   procedure Set_Pointer (Ctx : in out Context; Val : RFLX.ICMP.Pointer) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Pointer)
+       and then Field_Last (Ctx, F_Pointer) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Pointer, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Pointer) >= Field_Length (Ctx, F_Pointer),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Pointer)
+       and Get_Pointer (Ctx) = Val
+       and Invalid (Ctx, F_Unused_32)
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Unused_24) = F_Pointer
+            and Valid_Next (Ctx, F_Unused_24))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Pointer) = Predecessor (Ctx, F_Pointer)'Old
+       and Valid_Next (Ctx, F_Pointer) = Valid_Next (Ctx, F_Pointer)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
+       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
+       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old;
+
+   procedure Set_Unused_32 (Ctx : in out Context; Val : RFLX.ICMP.Unused_32) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Unused_32)
+       and then Field_Last (Ctx, F_Unused_32) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Unused_32, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Unused_32) >= Field_Length (Ctx, F_Unused_32),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Unused_32)
+       and Get_Unused_32 (Ctx) = Val
+       and Invalid (Ctx, F_Sequence_Number)
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Data) = F_Unused_32
+            and Valid_Next (Ctx, F_Data))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Unused_32) = Predecessor (Ctx, F_Unused_32)'Old
+       and Valid_Next (Ctx, F_Unused_32) = Valid_Next (Ctx, F_Unused_32)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
+       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
+       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
+       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old;
+
+   procedure Set_Sequence_Number (Ctx : in out Context; Val : RFLX.ICMP.Sequence_Number) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Sequence_Number)
+       and then Field_Last (Ctx, F_Sequence_Number) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Sequence_Number, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Sequence_Number) >= Field_Length (Ctx, F_Sequence_Number),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Sequence_Number)
+       and Get_Sequence_Number (Ctx) = Val
+       and Invalid (Ctx, F_Unused_24)
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Echo_Reply))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Echo_Request))
+            then
+               Predecessor (Ctx, F_Data) = F_Sequence_Number
+               and Valid_Next (Ctx, F_Data))
+       and (if
+               Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Timestamp_Msg))
+               or Types.U64 (To_Base (Get_Tag (Ctx))) = Types.U64 (To_Base (Timestamp_Reply))
+            then
+               Predecessor (Ctx, F_Originate_Timestamp) = F_Sequence_Number
+               and Valid_Next (Ctx, F_Originate_Timestamp))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Sequence_Number) = Predecessor (Ctx, F_Sequence_Number)'Old
+       and Valid_Next (Ctx, F_Sequence_Number) = Valid_Next (Ctx, F_Sequence_Number)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Get_Identifier (Ctx) = Get_Identifier (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
+       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
+       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
+       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
+       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old;
+
+   procedure Set_Unused_24 (Ctx : in out Context; Val : RFLX.ICMP.Unused_24) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Unused_24)
+       and then Field_Last (Ctx, F_Unused_24) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Unused_24, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Unused_24) >= Field_Length (Ctx, F_Unused_24),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Unused_24)
+       and Get_Unused_24 (Ctx) = Val
+       and Invalid (Ctx, F_Originate_Timestamp)
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Data) = F_Unused_24
+            and Valid_Next (Ctx, F_Data))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Unused_24) = Predecessor (Ctx, F_Unused_24)'Old
+       and Valid_Next (Ctx, F_Unused_24) = Valid_Next (Ctx, F_Unused_24)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Get_Pointer (Ctx) = Get_Pointer (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
+       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
+       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
+       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
+       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old
+       and Context_Cursor (Ctx, F_Sequence_Number) = Context_Cursor (Ctx, F_Sequence_Number)'Old;
+
+   procedure Set_Originate_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Originate_Timestamp)
+       and then Field_Last (Ctx, F_Originate_Timestamp) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Originate_Timestamp, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Originate_Timestamp) >= Field_Length (Ctx, F_Originate_Timestamp),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Originate_Timestamp)
+       and Get_Originate_Timestamp (Ctx) = Val
+       and Invalid (Ctx, F_Data)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Receive_Timestamp) = F_Originate_Timestamp
+            and Valid_Next (Ctx, F_Receive_Timestamp))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Originate_Timestamp) = Predecessor (Ctx, F_Originate_Timestamp)'Old
+       and Valid_Next (Ctx, F_Originate_Timestamp) = Valid_Next (Ctx, F_Originate_Timestamp)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Get_Identifier (Ctx) = Get_Identifier (Ctx)'Old
+       and Get_Sequence_Number (Ctx) = Get_Sequence_Number (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
+       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
+       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
+       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
+       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old
+       and Context_Cursor (Ctx, F_Sequence_Number) = Context_Cursor (Ctx, F_Sequence_Number)'Old
+       and Context_Cursor (Ctx, F_Unused_24) = Context_Cursor (Ctx, F_Unused_24)'Old;
+
+   procedure Set_Receive_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Receive_Timestamp)
+       and then Field_Last (Ctx, F_Receive_Timestamp) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Receive_Timestamp, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Receive_Timestamp) >= Field_Length (Ctx, F_Receive_Timestamp),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Receive_Timestamp)
+       and Get_Receive_Timestamp (Ctx) = Val
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and (Predecessor (Ctx, F_Transmit_Timestamp) = F_Receive_Timestamp
+            and Valid_Next (Ctx, F_Transmit_Timestamp))
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Receive_Timestamp) = Predecessor (Ctx, F_Receive_Timestamp)'Old
+       and Valid_Next (Ctx, F_Receive_Timestamp) = Valid_Next (Ctx, F_Receive_Timestamp)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Get_Identifier (Ctx) = Get_Identifier (Ctx)'Old
+       and Get_Sequence_Number (Ctx) = Get_Sequence_Number (Ctx)'Old
+       and Get_Originate_Timestamp (Ctx) = Get_Originate_Timestamp (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
+       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
+       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
+       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
+       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old
+       and Context_Cursor (Ctx, F_Sequence_Number) = Context_Cursor (Ctx, F_Sequence_Number)'Old
+       and Context_Cursor (Ctx, F_Unused_24) = Context_Cursor (Ctx, F_Unused_24)'Old
+       and Context_Cursor (Ctx, F_Originate_Timestamp) = Context_Cursor (Ctx, F_Originate_Timestamp)'Old
+       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old;
+
+   procedure Set_Transmit_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Transmit_Timestamp)
+       and then Field_Last (Ctx, F_Transmit_Timestamp) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (F_Transmit_Timestamp, To_Base (Val)))
+       and then Valid (To_Base (Val))
+       and then Available_Space (Ctx, F_Transmit_Timestamp) >= Field_Length (Ctx, F_Transmit_Timestamp),
+     Post =>
+       Has_Buffer (Ctx)
+       and Valid (Ctx, F_Transmit_Timestamp)
+       and Get_Transmit_Timestamp (Ctx) = Val
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Transmit_Timestamp) = Predecessor (Ctx, F_Transmit_Timestamp)'Old
+       and Valid_Next (Ctx, F_Transmit_Timestamp) = Valid_Next (Ctx, F_Transmit_Timestamp)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Get_Identifier (Ctx) = Get_Identifier (Ctx)'Old
+       and Get_Sequence_Number (Ctx) = Get_Sequence_Number (Ctx)'Old
+       and Get_Originate_Timestamp (Ctx) = Get_Originate_Timestamp (Ctx)'Old
+       and Get_Receive_Timestamp (Ctx) = Get_Receive_Timestamp (Ctx)'Old
+       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
+       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
+       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
+       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
+       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
+       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
+       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
+       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
+       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
+       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old
+       and Context_Cursor (Ctx, F_Sequence_Number) = Context_Cursor (Ctx, F_Sequence_Number)'Old
+       and Context_Cursor (Ctx, F_Unused_24) = Context_Cursor (Ctx, F_Unused_24)'Old
+       and Context_Cursor (Ctx, F_Originate_Timestamp) = Context_Cursor (Ctx, F_Originate_Timestamp)'Old
+       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
+       and Context_Cursor (Ctx, F_Receive_Timestamp) = Context_Cursor (Ctx, F_Receive_Timestamp)'Old;
+
+   procedure Set_Data_Empty (Ctx : in out Context) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Data)
+       and then Field_Last (Ctx, F_Data) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (Fld => F_Data))
+       and then Available_Space (Ctx, F_Data) >= Field_Length (Ctx, F_Data)
+       and then Field_First (Ctx, F_Data) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Data) mod Types.Byte'Size = 0
+       and then Field_Length (Ctx, F_Data) = 0,
+     Post =>
+       Has_Buffer (Ctx)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Data) = Predecessor (Ctx, F_Data)'Old
+       and Valid_Next (Ctx, F_Data) = Valid_Next (Ctx, F_Data)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Structural_Valid (Ctx, F_Data);
+
+   generic
+      with procedure Process_Data (Data : out Types.Bytes);
+      with function Valid_Length (Length : Types.Length) return Boolean;
+   procedure Set_Data (Ctx : in out Context) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Data)
+       and then Field_Last (Ctx, F_Data) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (Fld => F_Data))
+       and then Available_Space (Ctx, F_Data) >= Field_Length (Ctx, F_Data)
+       and then Field_First (Ctx, F_Data) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Data) mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Field_Length (Ctx, F_Data) / Types.Byte'Size)),
+     Post =>
+       Has_Buffer (Ctx)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Data) = Predecessor (Ctx, F_Data)'Old
+       and Valid_Next (Ctx, F_Data) = Valid_Next (Ctx, F_Data)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Structural_Valid (Ctx, F_Data);
+
+   generic
+      with procedure Process_Data (Data : out Types.Bytes);
+      with function Valid_Length (Length : Types.Length) return Boolean;
+   procedure Set_Bounded_Data (Ctx : in out Context; Length : Types.Bit_Length) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Data)
+       and then Field_Last (Ctx, F_Data) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (Fld => F_Data))
+       and then Available_Space (Ctx, F_Data) >= Length
+       and then Field_First (Ctx, F_Data) + Length <= Types.Bit_Index'Last / 2
+       and then ((Valid (Ctx, F_Tag)
+                  and (Get_Tag (Ctx) = Echo_Reply
+                       or Get_Tag (Ctx) = Echo_Request)))
+       and then Field_First (Ctx, F_Data) mod Types.Byte'Size = 1
+       and then Length mod Types.Byte'Size = 0
+       and then Valid_Length (Types.Length (Length / Types.Byte'Size)),
+     Post =>
+       Has_Buffer (Ctx)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Data) = Predecessor (Ctx, F_Data)'Old
+       and Valid_Next (Ctx, F_Data) = Valid_Next (Ctx, F_Data)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Structural_Valid (Ctx, F_Data);
+
+   procedure Initialize_Data (Ctx : in out Context) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Data)
+       and then Field_Last (Ctx, F_Data) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (Fld => F_Data))
+       and then Available_Space (Ctx, F_Data) >= Field_Length (Ctx, F_Data)
+       and then Field_First (Ctx, F_Data) mod Types.Byte'Size = 1
+       and then Field_Length (Ctx, F_Data) mod Types.Byte'Size = 0,
+     Post =>
+       Has_Buffer (Ctx)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Data) = Predecessor (Ctx, F_Data)'Old
+       and Valid_Next (Ctx, F_Data) = Valid_Next (Ctx, F_Data)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Structural_Valid (Ctx, F_Data);
+
+   procedure Initialize_Bounded_Data (Ctx : in out Context; Length : Types.Bit_Length) with
+     Pre =>
+       not Ctx'Constrained
+       and then Has_Buffer (Ctx)
+       and then Valid_Next (Ctx, F_Data)
+       and then Field_Last (Ctx, F_Data) <= Types.Bit_Index'Last / 2
+       and then Field_Condition (Ctx, (Fld => F_Data))
+       and then Available_Space (Ctx, F_Data) >= Length
+       and then Field_First (Ctx, F_Data) + Length <= Types.Bit_Index'Last / 2
+       and then ((Valid (Ctx, F_Tag)
+                  and (Get_Tag (Ctx) = Echo_Reply
+                       or Get_Tag (Ctx) = Echo_Request)))
+       and then Field_First (Ctx, F_Data) mod Types.Byte'Size = 1
+       and then Length mod Types.Byte'Size = 0,
+     Post =>
+       Has_Buffer (Ctx)
+       and Invalid (Ctx, F_Receive_Timestamp)
+       and Invalid (Ctx, F_Transmit_Timestamp)
+       and Ctx.Buffer_First = Ctx.Buffer_First'Old
+       and Ctx.Buffer_Last = Ctx.Buffer_Last'Old
+       and Ctx.First = Ctx.First'Old
+       and Predecessor (Ctx, F_Data) = Predecessor (Ctx, F_Data)'Old
+       and Valid_Next (Ctx, F_Data) = Valid_Next (Ctx, F_Data)'Old
+       and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
+       and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
+       and Structural_Valid (Ctx, F_Data);
+
+   function Context_Cursor (Ctx : Context; Fld : Field) return Field_Cursor with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+private
+
+   type Cursor_State is (S_Valid, S_Structural_Valid, S_Invalid, S_Incomplete);
+
+   function Valid_Value (Val : Field_Dependent_Value) return Boolean is
+     ((case Val.Fld is
+          when F_Tag =>
+             Valid (Val.Tag_Value),
+          when F_Code_Destination_Unreachable =>
+             Valid (Val.Code_Destination_Unreachable_Value),
+          when F_Code_Redirect =>
+             Valid (Val.Code_Redirect_Value),
+          when F_Code_Time_Exceeded =>
+             Valid (Val.Code_Time_Exceeded_Value),
+          when F_Code_Zero =>
+             Valid (Val.Code_Zero_Value),
+          when F_Checksum =>
+             Valid (Val.Checksum_Value),
+          when F_Gateway_Internet_Address =>
+             Valid (Val.Gateway_Internet_Address_Value),
+          when F_Identifier =>
+             Valid (Val.Identifier_Value),
+          when F_Pointer =>
+             Valid (Val.Pointer_Value),
+          when F_Unused_32 =>
+             Valid (Val.Unused_32_Value),
+          when F_Sequence_Number =>
+             Valid (Val.Sequence_Number_Value),
+          when F_Unused_24 =>
+             Valid (Val.Unused_24_Value),
+          when F_Originate_Timestamp =>
+             Valid (Val.Originate_Timestamp_Value),
+          when F_Data =>
+             True,
+          when F_Receive_Timestamp =>
+             Valid (Val.Receive_Timestamp_Value),
+          when F_Transmit_Timestamp =>
+             Valid (Val.Transmit_Timestamp_Value),
+          when F_Initial | F_Final =>
+             False));
+
+   type Field_Cursor (State : Cursor_State := S_Invalid) is
+      record
+         Predecessor : Virtual_Field := F_Final;
+         case State is
+            when S_Valid | S_Structural_Valid =>
+               First : Types.Bit_Index := Types.Bit_Index'First;
+               Last : Types.Bit_Length := Types.Bit_Length'First;
+               Value : Field_Dependent_Value := (Fld => F_Final);
+            when S_Invalid | S_Incomplete =>
+               null;
+         end case;
+      end record with
+     Dynamic_Predicate =>
+       (if
+           State = S_Valid
+           or State = S_Structural_Valid
+        then
+           Valid_Value (Field_Cursor.Value));
+
+   type Field_Cursors is array (Virtual_Field) of Field_Cursor;
+
+   function Structural_Valid (Cursor : Field_Cursor) return Boolean is
+     (Cursor.State = S_Valid
+      or Cursor.State = S_Structural_Valid);
+
+   function Valid (Cursor : Field_Cursor) return Boolean is
+     (Cursor.State = S_Valid);
+
+   function Invalid (Cursor : Field_Cursor) return Boolean is
+     (Cursor.State = S_Invalid
+      or Cursor.State = S_Incomplete);
+
+   function Valid_Context (Buffer_First, Buffer_Last : Types.Index; First, Last : Types.Bit_Index; Buffer : access constant Types.Bytes; Cursors : Field_Cursors) return Boolean is
+     ((if
+          Buffer /= null
+       then
+          Buffer'First = Buffer_First
+          and Buffer'Last = Buffer_Last)
+      and then (Types.Byte_Index (First) >= Buffer_First
+                and Types.Byte_Index (Last) <= Buffer_Last
+                and First <= Last
+                and Last <= Types.Bit_Index'Last / 2)
+      and then (for all F in Field'First .. Field'Last =>
+                   (if
+                       Structural_Valid (Cursors (F))
+                    then
+                       Cursors (F).First >= First
+                       and Cursors (F).Last <= Last
+                       and Cursors (F).First <= Cursors (F).Last + 1
+                       and Cursors (F).Value.Fld = F))
+      and then ((if
+                    Structural_Valid (Cursors (F_Code_Destination_Unreachable))
+                 then
+                    (Valid (Cursors (F_Tag))
+                     and then Cursors (F_Code_Destination_Unreachable).Predecessor = F_Tag
+                     and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))))
+                and then (if
+                             Structural_Valid (Cursors (F_Code_Redirect))
+                          then
+                             (Valid (Cursors (F_Tag))
+                              and then Cursors (F_Code_Redirect).Predecessor = F_Tag
+                              and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))))
+                and then (if
+                             Structural_Valid (Cursors (F_Code_Time_Exceeded))
+                          then
+                             (Valid (Cursors (F_Tag))
+                              and then Cursors (F_Code_Time_Exceeded).Predecessor = F_Tag
+                              and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))))
+                and then (if
+                             Structural_Valid (Cursors (F_Code_Zero))
+                          then
+                             (Valid (Cursors (F_Tag))
+                              and then Cursors (F_Code_Zero).Predecessor = F_Tag
+                              and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))))
+                and then (if
+                             Structural_Valid (Cursors (F_Checksum))
+                          then
+                             (Valid (Cursors (F_Code_Destination_Unreachable))
+                              and then Cursors (F_Checksum).Predecessor = F_Code_Destination_Unreachable)
+                             or (Valid (Cursors (F_Code_Redirect))
+                                 and then Cursors (F_Checksum).Predecessor = F_Code_Redirect)
+                             or (Valid (Cursors (F_Code_Time_Exceeded))
+                                 and then Cursors (F_Checksum).Predecessor = F_Code_Time_Exceeded)
+                             or (Valid (Cursors (F_Code_Zero))
+                                 and then Cursors (F_Checksum).Predecessor = F_Code_Zero))
+                and then (if
+                             Structural_Valid (Cursors (F_Gateway_Internet_Address))
+                          then
+                             (Valid (Cursors (F_Checksum))
+                              and then Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                              and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))))
+                and then (if
+                             Structural_Valid (Cursors (F_Identifier))
+                          then
+                             (Valid (Cursors (F_Checksum))
+                              and then Cursors (F_Identifier).Predecessor = F_Checksum
+                              and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))))
+                and then (if
+                             Structural_Valid (Cursors (F_Pointer))
+                          then
+                             (Valid (Cursors (F_Checksum))
+                              and then Cursors (F_Pointer).Predecessor = F_Checksum
+                              and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))))
+                and then (if
+                             Structural_Valid (Cursors (F_Unused_32))
+                          then
+                             (Valid (Cursors (F_Checksum))
+                              and then Cursors (F_Unused_32).Predecessor = F_Checksum
+                              and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))))
+                and then (if
+                             Structural_Valid (Cursors (F_Sequence_Number))
+                          then
+                             (Valid (Cursors (F_Identifier))
+                              and then Cursors (F_Sequence_Number).Predecessor = F_Identifier))
+                and then (if
+                             Structural_Valid (Cursors (F_Unused_24))
+                          then
+                             (Valid (Cursors (F_Pointer))
+                              and then Cursors (F_Unused_24).Predecessor = F_Pointer))
+                and then (if
+                             Structural_Valid (Cursors (F_Originate_Timestamp))
+                          then
+                             (Valid (Cursors (F_Sequence_Number))
+                              and then Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                              and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                        or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))))
+                and then (if
+                             Structural_Valid (Cursors (F_Data))
+                          then
+                             (Valid (Cursors (F_Gateway_Internet_Address))
+                              and then Cursors (F_Data).Predecessor = F_Gateway_Internet_Address)
+                             or (Valid (Cursors (F_Sequence_Number))
+                                 and then Cursors (F_Data).Predecessor = F_Sequence_Number
+                                 and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                           or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))))
+                             or (Valid (Cursors (F_Unused_24))
+                                 and then Cursors (F_Data).Predecessor = F_Unused_24)
+                             or (Valid (Cursors (F_Unused_32))
+                                 and then Cursors (F_Data).Predecessor = F_Unused_32))
+                and then (if
+                             Structural_Valid (Cursors (F_Receive_Timestamp))
+                          then
+                             (Valid (Cursors (F_Originate_Timestamp))
+                              and then Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp))
+                and then (if
+                             Structural_Valid (Cursors (F_Transmit_Timestamp))
+                          then
+                             (Valid (Cursors (F_Receive_Timestamp))
+                              and then Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp)))
+      and then ((if
+                    Invalid (Cursors (F_Tag))
+                 then
+                    Invalid (Cursors (F_Code_Destination_Unreachable)))
+                and then (if
+                             Invalid (Cursors (F_Tag))
+                          then
+                             Invalid (Cursors (F_Code_Redirect)))
+                and then (if
+                             Invalid (Cursors (F_Tag))
+                          then
+                             Invalid (Cursors (F_Code_Time_Exceeded)))
+                and then (if
+                             Invalid (Cursors (F_Tag))
+                          then
+                             Invalid (Cursors (F_Code_Zero)))
+                and then (if
+                             Invalid (Cursors (F_Code_Destination_Unreachable))
+                             and then Invalid (Cursors (F_Code_Redirect))
+                             and then Invalid (Cursors (F_Code_Time_Exceeded))
+                             and then Invalid (Cursors (F_Code_Zero))
+                          then
+                             Invalid (Cursors (F_Checksum)))
+                and then (if
+                             Invalid (Cursors (F_Checksum))
+                          then
+                             Invalid (Cursors (F_Gateway_Internet_Address)))
+                and then (if
+                             Invalid (Cursors (F_Checksum))
+                          then
+                             Invalid (Cursors (F_Identifier)))
+                and then (if
+                             Invalid (Cursors (F_Checksum))
+                          then
+                             Invalid (Cursors (F_Pointer)))
+                and then (if
+                             Invalid (Cursors (F_Checksum))
+                          then
+                             Invalid (Cursors (F_Unused_32)))
+                and then (if
+                             Invalid (Cursors (F_Identifier))
+                          then
+                             Invalid (Cursors (F_Sequence_Number)))
+                and then (if
+                             Invalid (Cursors (F_Pointer))
+                          then
+                             Invalid (Cursors (F_Unused_24)))
+                and then (if
+                             Invalid (Cursors (F_Sequence_Number))
+                          then
+                             Invalid (Cursors (F_Originate_Timestamp)))
+                and then (if
+                             Invalid (Cursors (F_Gateway_Internet_Address))
+                             and then Invalid (Cursors (F_Sequence_Number))
+                             and then Invalid (Cursors (F_Unused_24))
+                             and then Invalid (Cursors (F_Unused_32))
+                          then
+                             Invalid (Cursors (F_Data)))
+                and then (if
+                             Invalid (Cursors (F_Originate_Timestamp))
+                          then
+                             Invalid (Cursors (F_Receive_Timestamp)))
+                and then (if
+                             Invalid (Cursors (F_Receive_Timestamp))
+                          then
+                             Invalid (Cursors (F_Transmit_Timestamp))))
+      and then (if
+                   Structural_Valid (Cursors (F_Tag))
+                then
+                   Cursors (F_Tag).Last - Cursors (F_Tag).First + 1 = RFLX.ICMP.Tag_Base'Size
+                   and then Cursors (F_Tag).Predecessor = F_Initial
+                   and then Cursors (F_Tag).First = First
+                   and then (if
+                                Structural_Valid (Cursors (F_Code_Destination_Unreachable))
+                                and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                             then
+                                Cursors (F_Code_Destination_Unreachable).Last - Cursors (F_Code_Destination_Unreachable).First + 1 = RFLX.ICMP.Code_Destination_Unreachable_Base'Size
+                                and then Cursors (F_Code_Destination_Unreachable).Predecessor = F_Tag
+                                and then Cursors (F_Code_Destination_Unreachable).First = Cursors (F_Tag).Last + 1
+                                and then (if
+                                             Structural_Valid (Cursors (F_Checksum))
+                                          then
+                                             Cursors (F_Checksum).Last - Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                             and then Cursors (F_Checksum).Predecessor = F_Code_Destination_Unreachable
+                                             and then Cursors (F_Checksum).First = Cursors (F_Code_Destination_Unreachable).Last + 1
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Gateway_Internet_Address))
+                                                          and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                       then
+                                                          Cursors (F_Gateway_Internet_Address).Last - Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                          and then Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                          and then Cursors (F_Gateway_Internet_Address).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Data))
+                                                                    then
+                                                                       Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                       and then Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                       and then Cursors (F_Data).First = Cursors (F_Gateway_Internet_Address).Last + 1))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Identifier))
+                                                          and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                       then
+                                                          Cursors (F_Identifier).Last - Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                          and then Cursors (F_Identifier).Predecessor = F_Checksum
+                                                          and then Cursors (F_Identifier).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Sequence_Number))
+                                                                    then
+                                                                       Cursors (F_Sequence_Number).Last - Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                       and then Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                       and then Cursors (F_Sequence_Number).First = Cursors (F_Identifier).Last + 1
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Data))
+                                                                                    and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                              or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                 then
+                                                                                    Cursors (F_Data).Last - Cursors (F_Data).First + 1 = Last - Cursors (F_Sequence_Number).Last
+                                                                                    and then Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                    and then Cursors (F_Data).First = Cursors (F_Sequence_Number).Last + 1)
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Originate_Timestamp))
+                                                                                    and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                              or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                 then
+                                                                                    Cursors (F_Originate_Timestamp).Last - Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                    and then Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                    and then Cursors (F_Originate_Timestamp).First = Cursors (F_Sequence_Number).Last + 1
+                                                                                    and then (if
+                                                                                                 Structural_Valid (Cursors (F_Receive_Timestamp))
+                                                                                              then
+                                                                                                 Cursors (F_Receive_Timestamp).Last - Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                 and then Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                 and then Cursors (F_Receive_Timestamp).First = Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                 and then (if
+                                                                                                              Structural_Valid (Cursors (F_Transmit_Timestamp))
+                                                                                                           then
+                                                                                                              Cursors (F_Transmit_Timestamp).Last - Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                              and then Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                              and then Cursors (F_Transmit_Timestamp).First = Cursors (F_Receive_Timestamp).Last + 1)))))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Pointer))
+                                                          and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                       then
+                                                          Cursors (F_Pointer).Last - Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                          and then Cursors (F_Pointer).Predecessor = F_Checksum
+                                                          and then Cursors (F_Pointer).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Unused_24))
+                                                                    then
+                                                                       Cursors (F_Unused_24).Last - Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                       and then Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                       and then Cursors (F_Unused_24).First = Cursors (F_Pointer).Last + 1
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Data))
+                                                                                 then
+                                                                                    Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                                    and then Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                    and then Cursors (F_Data).First = Cursors (F_Unused_24).Last + 1)))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Unused_32))
+                                                          and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                       then
+                                                          Cursors (F_Unused_32).Last - Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                          and then Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                          and then Cursors (F_Unused_32).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Data))
+                                                                    then
+                                                                       Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                       and then Cursors (F_Data).Predecessor = F_Unused_32
+                                                                       and then Cursors (F_Data).First = Cursors (F_Unused_32).Last + 1))))
+                   and then (if
+                                Structural_Valid (Cursors (F_Code_Redirect))
+                                and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                             then
+                                Cursors (F_Code_Redirect).Last - Cursors (F_Code_Redirect).First + 1 = RFLX.ICMP.Code_Redirect_Base'Size
+                                and then Cursors (F_Code_Redirect).Predecessor = F_Tag
+                                and then Cursors (F_Code_Redirect).First = Cursors (F_Tag).Last + 1
+                                and then (if
+                                             Structural_Valid (Cursors (F_Checksum))
+                                          then
+                                             Cursors (F_Checksum).Last - Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                             and then Cursors (F_Checksum).Predecessor = F_Code_Redirect
+                                             and then Cursors (F_Checksum).First = Cursors (F_Code_Redirect).Last + 1
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Gateway_Internet_Address))
+                                                          and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                       then
+                                                          Cursors (F_Gateway_Internet_Address).Last - Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                          and then Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                          and then Cursors (F_Gateway_Internet_Address).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Data))
+                                                                    then
+                                                                       Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                       and then Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                       and then Cursors (F_Data).First = Cursors (F_Gateway_Internet_Address).Last + 1))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Identifier))
+                                                          and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                       then
+                                                          Cursors (F_Identifier).Last - Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                          and then Cursors (F_Identifier).Predecessor = F_Checksum
+                                                          and then Cursors (F_Identifier).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Sequence_Number))
+                                                                    then
+                                                                       Cursors (F_Sequence_Number).Last - Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                       and then Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                       and then Cursors (F_Sequence_Number).First = Cursors (F_Identifier).Last + 1
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Data))
+                                                                                    and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                              or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                 then
+                                                                                    Cursors (F_Data).Last - Cursors (F_Data).First + 1 = Last - Cursors (F_Sequence_Number).Last
+                                                                                    and then Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                    and then Cursors (F_Data).First = Cursors (F_Sequence_Number).Last + 1)
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Originate_Timestamp))
+                                                                                    and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                              or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                 then
+                                                                                    Cursors (F_Originate_Timestamp).Last - Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                    and then Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                    and then Cursors (F_Originate_Timestamp).First = Cursors (F_Sequence_Number).Last + 1
+                                                                                    and then (if
+                                                                                                 Structural_Valid (Cursors (F_Receive_Timestamp))
+                                                                                              then
+                                                                                                 Cursors (F_Receive_Timestamp).Last - Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                 and then Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                 and then Cursors (F_Receive_Timestamp).First = Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                 and then (if
+                                                                                                              Structural_Valid (Cursors (F_Transmit_Timestamp))
+                                                                                                           then
+                                                                                                              Cursors (F_Transmit_Timestamp).Last - Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                              and then Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                              and then Cursors (F_Transmit_Timestamp).First = Cursors (F_Receive_Timestamp).Last + 1)))))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Pointer))
+                                                          and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                       then
+                                                          Cursors (F_Pointer).Last - Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                          and then Cursors (F_Pointer).Predecessor = F_Checksum
+                                                          and then Cursors (F_Pointer).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Unused_24))
+                                                                    then
+                                                                       Cursors (F_Unused_24).Last - Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                       and then Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                       and then Cursors (F_Unused_24).First = Cursors (F_Pointer).Last + 1
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Data))
+                                                                                 then
+                                                                                    Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                                    and then Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                    and then Cursors (F_Data).First = Cursors (F_Unused_24).Last + 1)))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Unused_32))
+                                                          and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                       then
+                                                          Cursors (F_Unused_32).Last - Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                          and then Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                          and then Cursors (F_Unused_32).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Data))
+                                                                    then
+                                                                       Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                       and then Cursors (F_Data).Predecessor = F_Unused_32
+                                                                       and then Cursors (F_Data).First = Cursors (F_Unused_32).Last + 1))))
+                   and then (if
+                                Structural_Valid (Cursors (F_Code_Time_Exceeded))
+                                and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                             then
+                                Cursors (F_Code_Time_Exceeded).Last - Cursors (F_Code_Time_Exceeded).First + 1 = RFLX.ICMP.Code_Time_Exceeded_Base'Size
+                                and then Cursors (F_Code_Time_Exceeded).Predecessor = F_Tag
+                                and then Cursors (F_Code_Time_Exceeded).First = Cursors (F_Tag).Last + 1
+                                and then (if
+                                             Structural_Valid (Cursors (F_Checksum))
+                                          then
+                                             Cursors (F_Checksum).Last - Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                             and then Cursors (F_Checksum).Predecessor = F_Code_Time_Exceeded
+                                             and then Cursors (F_Checksum).First = Cursors (F_Code_Time_Exceeded).Last + 1
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Gateway_Internet_Address))
+                                                          and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                       then
+                                                          Cursors (F_Gateway_Internet_Address).Last - Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                          and then Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                          and then Cursors (F_Gateway_Internet_Address).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Data))
+                                                                    then
+                                                                       Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                       and then Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                       and then Cursors (F_Data).First = Cursors (F_Gateway_Internet_Address).Last + 1))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Identifier))
+                                                          and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                       then
+                                                          Cursors (F_Identifier).Last - Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                          and then Cursors (F_Identifier).Predecessor = F_Checksum
+                                                          and then Cursors (F_Identifier).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Sequence_Number))
+                                                                    then
+                                                                       Cursors (F_Sequence_Number).Last - Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                       and then Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                       and then Cursors (F_Sequence_Number).First = Cursors (F_Identifier).Last + 1
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Data))
+                                                                                    and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                              or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                 then
+                                                                                    Cursors (F_Data).Last - Cursors (F_Data).First + 1 = Last - Cursors (F_Sequence_Number).Last
+                                                                                    and then Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                    and then Cursors (F_Data).First = Cursors (F_Sequence_Number).Last + 1)
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Originate_Timestamp))
+                                                                                    and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                              or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                 then
+                                                                                    Cursors (F_Originate_Timestamp).Last - Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                    and then Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                    and then Cursors (F_Originate_Timestamp).First = Cursors (F_Sequence_Number).Last + 1
+                                                                                    and then (if
+                                                                                                 Structural_Valid (Cursors (F_Receive_Timestamp))
+                                                                                              then
+                                                                                                 Cursors (F_Receive_Timestamp).Last - Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                 and then Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                 and then Cursors (F_Receive_Timestamp).First = Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                 and then (if
+                                                                                                              Structural_Valid (Cursors (F_Transmit_Timestamp))
+                                                                                                           then
+                                                                                                              Cursors (F_Transmit_Timestamp).Last - Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                              and then Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                              and then Cursors (F_Transmit_Timestamp).First = Cursors (F_Receive_Timestamp).Last + 1)))))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Pointer))
+                                                          and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                       then
+                                                          Cursors (F_Pointer).Last - Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                          and then Cursors (F_Pointer).Predecessor = F_Checksum
+                                                          and then Cursors (F_Pointer).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Unused_24))
+                                                                    then
+                                                                       Cursors (F_Unused_24).Last - Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                       and then Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                       and then Cursors (F_Unused_24).First = Cursors (F_Pointer).Last + 1
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Data))
+                                                                                 then
+                                                                                    Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                                    and then Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                    and then Cursors (F_Data).First = Cursors (F_Unused_24).Last + 1)))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Unused_32))
+                                                          and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                       then
+                                                          Cursors (F_Unused_32).Last - Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                          and then Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                          and then Cursors (F_Unused_32).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Data))
+                                                                    then
+                                                                       Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                       and then Cursors (F_Data).Predecessor = F_Unused_32
+                                                                       and then Cursors (F_Data).First = Cursors (F_Unused_32).Last + 1))))
+                   and then (if
+                                Structural_Valid (Cursors (F_Code_Zero))
+                                and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                          or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                          or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                          or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                          or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                          or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench))
+                                          or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                          or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                             then
+                                Cursors (F_Code_Zero).Last - Cursors (F_Code_Zero).First + 1 = RFLX.ICMP.Code_Zero_Base'Size
+                                and then Cursors (F_Code_Zero).Predecessor = F_Tag
+                                and then Cursors (F_Code_Zero).First = Cursors (F_Tag).Last + 1
+                                and then (if
+                                             Structural_Valid (Cursors (F_Checksum))
+                                          then
+                                             Cursors (F_Checksum).Last - Cursors (F_Checksum).First + 1 = RFLX.ICMP.Checksum'Size
+                                             and then Cursors (F_Checksum).Predecessor = F_Code_Zero
+                                             and then Cursors (F_Checksum).First = Cursors (F_Code_Zero).Last + 1
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Gateway_Internet_Address))
+                                                          and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Redirect))
+                                                       then
+                                                          Cursors (F_Gateway_Internet_Address).Last - Cursors (F_Gateway_Internet_Address).First + 1 = RFLX.ICMP.Gateway_Internet_Address'Size
+                                                          and then Cursors (F_Gateway_Internet_Address).Predecessor = F_Checksum
+                                                          and then Cursors (F_Gateway_Internet_Address).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Data))
+                                                                    then
+                                                                       Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                       and then Cursors (F_Data).Predecessor = F_Gateway_Internet_Address
+                                                                       and then Cursors (F_Data).First = Cursors (F_Gateway_Internet_Address).Last + 1))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Identifier))
+                                                          and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Reply))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Information_Request))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply)))
+                                                       then
+                                                          Cursors (F_Identifier).Last - Cursors (F_Identifier).First + 1 = RFLX.ICMP.Identifier'Size
+                                                          and then Cursors (F_Identifier).Predecessor = F_Checksum
+                                                          and then Cursors (F_Identifier).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Sequence_Number))
+                                                                    then
+                                                                       Cursors (F_Sequence_Number).Last - Cursors (F_Sequence_Number).First + 1 = RFLX.ICMP.Sequence_Number'Size
+                                                                       and then Cursors (F_Sequence_Number).Predecessor = F_Identifier
+                                                                       and then Cursors (F_Sequence_Number).First = Cursors (F_Identifier).Last + 1
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Data))
+                                                                                    and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Reply))
+                                                                                              or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Echo_Request)))
+                                                                                 then
+                                                                                    Cursors (F_Data).Last - Cursors (F_Data).First + 1 = Last - Cursors (F_Sequence_Number).Last
+                                                                                    and then Cursors (F_Data).Predecessor = F_Sequence_Number
+                                                                                    and then Cursors (F_Data).First = Cursors (F_Sequence_Number).Last + 1)
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Originate_Timestamp))
+                                                                                    and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Msg))
+                                                                                              or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Timestamp_Reply)))
+                                                                                 then
+                                                                                    Cursors (F_Originate_Timestamp).Last - Cursors (F_Originate_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                    and then Cursors (F_Originate_Timestamp).Predecessor = F_Sequence_Number
+                                                                                    and then Cursors (F_Originate_Timestamp).First = Cursors (F_Sequence_Number).Last + 1
+                                                                                    and then (if
+                                                                                                 Structural_Valid (Cursors (F_Receive_Timestamp))
+                                                                                              then
+                                                                                                 Cursors (F_Receive_Timestamp).Last - Cursors (F_Receive_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                 and then Cursors (F_Receive_Timestamp).Predecessor = F_Originate_Timestamp
+                                                                                                 and then Cursors (F_Receive_Timestamp).First = Cursors (F_Originate_Timestamp).Last + 1
+                                                                                                 and then (if
+                                                                                                              Structural_Valid (Cursors (F_Transmit_Timestamp))
+                                                                                                           then
+                                                                                                              Cursors (F_Transmit_Timestamp).Last - Cursors (F_Transmit_Timestamp).First + 1 = RFLX.ICMP.Timestamp'Size
+                                                                                                              and then Cursors (F_Transmit_Timestamp).Predecessor = F_Receive_Timestamp
+                                                                                                              and then Cursors (F_Transmit_Timestamp).First = Cursors (F_Receive_Timestamp).Last + 1)))))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Pointer))
+                                                          and then Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Parameter_Problem))
+                                                       then
+                                                          Cursors (F_Pointer).Last - Cursors (F_Pointer).First + 1 = RFLX.ICMP.Pointer'Size
+                                                          and then Cursors (F_Pointer).Predecessor = F_Checksum
+                                                          and then Cursors (F_Pointer).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Unused_24))
+                                                                    then
+                                                                       Cursors (F_Unused_24).Last - Cursors (F_Unused_24).First + 1 = RFLX.ICMP.Unused_24_Base'Size
+                                                                       and then Cursors (F_Unused_24).Predecessor = F_Pointer
+                                                                       and then Cursors (F_Unused_24).First = Cursors (F_Pointer).Last + 1
+                                                                       and then (if
+                                                                                    Structural_Valid (Cursors (F_Data))
+                                                                                 then
+                                                                                    Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                                    and then Cursors (F_Data).Predecessor = F_Unused_24
+                                                                                    and then Cursors (F_Data).First = Cursors (F_Unused_24).Last + 1)))
+                                             and then (if
+                                                          Structural_Valid (Cursors (F_Unused_32))
+                                                          and then (Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Time_Exceeded))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Destination_Unreachable))
+                                                                    or Types.U64 (Cursors (F_Tag).Value.Tag_Value) = Types.U64 (To_Base (Source_Quench)))
+                                                       then
+                                                          Cursors (F_Unused_32).Last - Cursors (F_Unused_32).First + 1 = RFLX.ICMP.Unused_32_Base'Size
+                                                          and then Cursors (F_Unused_32).Predecessor = F_Checksum
+                                                          and then Cursors (F_Unused_32).First = Cursors (F_Checksum).Last + 1
+                                                          and then (if
+                                                                       Structural_Valid (Cursors (F_Data))
+                                                                    then
+                                                                       Cursors (F_Data).Last - Cursors (F_Data).First + 1 = 224
+                                                                       and then Cursors (F_Data).Predecessor = F_Unused_32
+                                                                       and then Cursors (F_Data).First = Cursors (F_Unused_32).Last + 1))))));
+
+   type Context (Buffer_First, Buffer_Last : Types.Index := Types.Index'First; First, Last : Types.Bit_Index := Types.Bit_Index'First) is
+      record
+         Buffer : Types.Bytes_Ptr := null;
+         Cursors : Field_Cursors := (others => (State => S_Invalid, Predecessor => F_Final));
+      end record with
+     Dynamic_Predicate =>
+       Valid_Context (Context.Buffer_First, Context.Buffer_Last, Context.First, Context.Last, Context.Buffer, Context.Cursors);
+
+   function Context_Cursor (Ctx : Context; Fld : Field) return Field_Cursor is
+     (Ctx.Cursors (Fld));
+
+   function Context_Cursors (Ctx : Context) return Field_Cursors is
+     (Ctx.Cursors);
+
+end RFLX.ICMP.Generic_Message;

--- a/generated/rflx-icmp-message.ads
+++ b/generated/rflx-icmp-message.ads
@@ -1,0 +1,6 @@
+pragma Style_Checks ("N3aAbcdefhiIklnOprStux");
+pragma SPARK_Mode;
+with RFLX.ICMP.Generic_Message;
+with RFLX.RFLX_Types;
+
+package RFLX.ICMP.Message is new RFLX.ICMP.Generic_Message (RFLX.RFLX_Types);

--- a/generated/rflx-icmp.ads
+++ b/generated/rflx-icmp.ads
@@ -1,0 +1,549 @@
+pragma Style_Checks ("N3aAbcdefhiIklnOprStux");
+
+package RFLX.ICMP with
+  SPARK_Mode
+is
+
+   type Tag_Base is mod 2**8;
+
+   type Tag is (Echo_Reply, Destination_Unreachable, Source_Quench, Redirect, Echo_Request, Time_Exceeded, Parameter_Problem, Timestamp_Msg, Timestamp_Reply, Information_Request, Information_Reply) with
+     Size =>
+       8;
+   for Tag use (Echo_Reply => 0, Destination_Unreachable => 3, Source_Quench => 4, Redirect => 5, Echo_Request => 8, Time_Exceeded => 11, Parameter_Problem => 12, Timestamp_Msg => 13, Timestamp_Reply => 14, Information_Request => 15, Information_Reply => 16);
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Tag return RFLX.ICMP.Tag is
+     (RFLX.ICMP.Tag'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   function Valid (Val : RFLX.ICMP.Tag_Base) return Boolean is
+     ((case Val is
+          when 0 | 8 | 3 | 11 | 12 | 4 | 5 | 13 | 14 | 15 | 16 =>
+             True,
+          when others =>
+             False));
+
+   function To_Base (Enum : RFLX.ICMP.Tag) return RFLX.ICMP.Tag_Base is
+     ((case Enum is
+          when Echo_Reply =>
+             0,
+          when Echo_Request =>
+             8,
+          when Destination_Unreachable =>
+             3,
+          when Time_Exceeded =>
+             11,
+          when Parameter_Problem =>
+             12,
+          when Source_Quench =>
+             4,
+          when Redirect =>
+             5,
+          when Timestamp_Msg =>
+             13,
+          when Timestamp_Reply =>
+             14,
+          when Information_Request =>
+             15,
+          when Information_Reply =>
+             16));
+
+   pragma Warnings (Off, "unreachable branch");
+
+   function To_Actual (Val : RFLX.ICMP.Tag_Base) return RFLX.ICMP.Tag is
+     ((case Val is
+          when 0 =>
+             Echo_Reply,
+          when 8 =>
+             Echo_Request,
+          when 3 =>
+             Destination_Unreachable,
+          when 11 =>
+             Time_Exceeded,
+          when 12 =>
+             Parameter_Problem,
+          when 4 =>
+             Source_Quench,
+          when 5 =>
+             Redirect,
+          when 13 =>
+             Timestamp_Msg,
+          when 14 =>
+             Timestamp_Reply,
+          when 15 =>
+             Information_Request,
+          when 16 =>
+             Information_Reply,
+          when others =>
+             Unreachable_ICMP_Tag))
+    with
+     Pre =>
+       Valid (Val);
+
+   pragma Warnings (On, "unreachable branch");
+
+   type Code_Destination_Unreachable_Base is mod 2**8;
+
+   type Code_Destination_Unreachable is (Net_Unreachable, Host_Unreachable, Protocol_Unreachable, Port_Unreachable, Fragmentation_Needed_DF_Set, Source_Route_Failed) with
+     Size =>
+       8;
+   for Code_Destination_Unreachable use (Net_Unreachable => 0, Host_Unreachable => 1, Protocol_Unreachable => 2, Port_Unreachable => 3, Fragmentation_Needed_DF_Set => 4, Source_Route_Failed => 5);
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Code_Destination_Unreachable return RFLX.ICMP.Code_Destination_Unreachable is
+     (RFLX.ICMP.Code_Destination_Unreachable'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   function Valid (Val : RFLX.ICMP.Code_Destination_Unreachable_Base) return Boolean is
+     ((case Val is
+          when 0 | 1 | 2 | 3 | 4 | 5 =>
+             True,
+          when others =>
+             False));
+
+   function To_Base (Enum : RFLX.ICMP.Code_Destination_Unreachable) return RFLX.ICMP.Code_Destination_Unreachable_Base is
+     ((case Enum is
+          when Net_Unreachable =>
+             0,
+          when Host_Unreachable =>
+             1,
+          when Protocol_Unreachable =>
+             2,
+          when Port_Unreachable =>
+             3,
+          when Fragmentation_Needed_DF_Set =>
+             4,
+          when Source_Route_Failed =>
+             5));
+
+   pragma Warnings (Off, "unreachable branch");
+
+   function To_Actual (Val : RFLX.ICMP.Code_Destination_Unreachable_Base) return RFLX.ICMP.Code_Destination_Unreachable is
+     ((case Val is
+          when 0 =>
+             Net_Unreachable,
+          when 1 =>
+             Host_Unreachable,
+          when 2 =>
+             Protocol_Unreachable,
+          when 3 =>
+             Port_Unreachable,
+          when 4 =>
+             Fragmentation_Needed_DF_Set,
+          when 5 =>
+             Source_Route_Failed,
+          when others =>
+             Unreachable_ICMP_Code_Destination_Unreachable))
+    with
+     Pre =>
+       Valid (Val);
+
+   pragma Warnings (On, "unreachable branch");
+
+   type Code_Time_Exceeded_Base is mod 2**8;
+
+   type Code_Time_Exceeded is (TTL_Exceeded, Fragment_Reassembly_Time_Exceeded) with
+     Size =>
+       8;
+   for Code_Time_Exceeded use (TTL_Exceeded => 0, Fragment_Reassembly_Time_Exceeded => 1);
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Code_Time_Exceeded return RFLX.ICMP.Code_Time_Exceeded is
+     (RFLX.ICMP.Code_Time_Exceeded'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   function Valid (Val : RFLX.ICMP.Code_Time_Exceeded_Base) return Boolean is
+     ((case Val is
+          when 0 | 1 =>
+             True,
+          when others =>
+             False));
+
+   function To_Base (Enum : RFLX.ICMP.Code_Time_Exceeded) return RFLX.ICMP.Code_Time_Exceeded_Base is
+     ((case Enum is
+          when TTL_Exceeded =>
+             0,
+          when Fragment_Reassembly_Time_Exceeded =>
+             1));
+
+   pragma Warnings (Off, "unreachable branch");
+
+   function To_Actual (Val : RFLX.ICMP.Code_Time_Exceeded_Base) return RFLX.ICMP.Code_Time_Exceeded is
+     ((case Val is
+          when 0 =>
+             TTL_Exceeded,
+          when 1 =>
+             Fragment_Reassembly_Time_Exceeded,
+          when others =>
+             Unreachable_ICMP_Code_Time_Exceeded))
+    with
+     Pre =>
+       Valid (Val);
+
+   pragma Warnings (On, "unreachable branch");
+
+   type Code_Redirect_Base is mod 2**8;
+
+   type Code_Redirect is (Redirect_for_Network, Redirect_for_Host, Redirect_for_Service_Network, Redirect_for_Service_Host) with
+     Size =>
+       8;
+   for Code_Redirect use (Redirect_for_Network => 0, Redirect_for_Host => 1, Redirect_for_Service_Network => 2, Redirect_for_Service_Host => 3);
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Code_Redirect return RFLX.ICMP.Code_Redirect is
+     (RFLX.ICMP.Code_Redirect'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   function Valid (Val : RFLX.ICMP.Code_Redirect_Base) return Boolean is
+     ((case Val is
+          when 0 | 1 | 2 | 3 =>
+             True,
+          when others =>
+             False));
+
+   function To_Base (Enum : RFLX.ICMP.Code_Redirect) return RFLX.ICMP.Code_Redirect_Base is
+     ((case Enum is
+          when Redirect_for_Network =>
+             0,
+          when Redirect_for_Host =>
+             1,
+          when Redirect_for_Service_Network =>
+             2,
+          when Redirect_for_Service_Host =>
+             3));
+
+   pragma Warnings (Off, "unreachable branch");
+
+   function To_Actual (Val : RFLX.ICMP.Code_Redirect_Base) return RFLX.ICMP.Code_Redirect is
+     ((case Val is
+          when 0 =>
+             Redirect_for_Network,
+          when 1 =>
+             Redirect_for_Host,
+          when 2 =>
+             Redirect_for_Service_Network,
+          when 3 =>
+             Redirect_for_Service_Host,
+          when others =>
+             Unreachable_ICMP_Code_Redirect))
+    with
+     Pre =>
+       Valid (Val);
+
+   pragma Warnings (On, "unreachable branch");
+
+   type Code_Zero_Base is mod 2**8 with
+     Annotate =>
+       (GNATprove, No_Wrap_Around);
+
+   type Code_Zero is range 0 .. 0 with
+     Size =>
+       8;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Code_Zero return RFLX.ICMP.Code_Zero is
+     (RFLX.ICMP.Code_Zero'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   function Valid (Val : RFLX.ICMP.Code_Zero_Base) return Boolean is
+     (Val = 0);
+
+   function To_Base (Val : RFLX.ICMP.Code_Zero) return RFLX.ICMP.Code_Zero_Base is
+     (RFLX.ICMP.Code_Zero_Base (Val));
+
+   function To_Actual (Val : RFLX.ICMP.Code_Zero_Base) return RFLX.ICMP.Code_Zero is
+     (RFLX.ICMP.Code_Zero (Val))
+    with
+     Pre =>
+       Valid (Val);
+
+   type Checksum is mod 2**16 with
+     Size =>
+       16;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Checksum return RFLX.ICMP.Checksum is
+     (RFLX.ICMP.Checksum'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   pragma Warnings (Off, "unused variable ""Val""");
+
+   pragma Warnings (Off, "formal parameter ""Val"" is not referenced");
+
+   function Valid (Val : RFLX.ICMP.Checksum) return Boolean is
+     (True);
+
+   pragma Warnings (On, "formal parameter ""Val"" is not referenced");
+
+   pragma Warnings (On, "unused variable ""Val""");
+
+   function To_Base (Val : RFLX.ICMP.Checksum) return RFLX.ICMP.Checksum is
+     (Val);
+
+   function To_Actual (Val : RFLX.ICMP.Checksum) return RFLX.ICMP.Checksum is
+     (Val)
+    with
+     Pre =>
+       Valid (Val);
+
+   type Identifier is mod 2**16 with
+     Size =>
+       16;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Identifier return RFLX.ICMP.Identifier is
+     (RFLX.ICMP.Identifier'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   pragma Warnings (Off, "unused variable ""Val""");
+
+   pragma Warnings (Off, "formal parameter ""Val"" is not referenced");
+
+   function Valid (Val : RFLX.ICMP.Identifier) return Boolean is
+     (True);
+
+   pragma Warnings (On, "formal parameter ""Val"" is not referenced");
+
+   pragma Warnings (On, "unused variable ""Val""");
+
+   function To_Base (Val : RFLX.ICMP.Identifier) return RFLX.ICMP.Identifier is
+     (Val);
+
+   function To_Actual (Val : RFLX.ICMP.Identifier) return RFLX.ICMP.Identifier is
+     (Val)
+    with
+     Pre =>
+       Valid (Val);
+
+   type Sequence_Number is mod 2**16 with
+     Size =>
+       16;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Sequence_Number return RFLX.ICMP.Sequence_Number is
+     (RFLX.ICMP.Sequence_Number'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   pragma Warnings (Off, "unused variable ""Val""");
+
+   pragma Warnings (Off, "formal parameter ""Val"" is not referenced");
+
+   function Valid (Val : RFLX.ICMP.Sequence_Number) return Boolean is
+     (True);
+
+   pragma Warnings (On, "formal parameter ""Val"" is not referenced");
+
+   pragma Warnings (On, "unused variable ""Val""");
+
+   function To_Base (Val : RFLX.ICMP.Sequence_Number) return RFLX.ICMP.Sequence_Number is
+     (Val);
+
+   function To_Actual (Val : RFLX.ICMP.Sequence_Number) return RFLX.ICMP.Sequence_Number is
+     (Val)
+    with
+     Pre =>
+       Valid (Val);
+
+   type Pointer is mod 2**8 with
+     Size =>
+       8;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Pointer return RFLX.ICMP.Pointer is
+     (RFLX.ICMP.Pointer'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   pragma Warnings (Off, "unused variable ""Val""");
+
+   pragma Warnings (Off, "formal parameter ""Val"" is not referenced");
+
+   function Valid (Val : RFLX.ICMP.Pointer) return Boolean is
+     (True);
+
+   pragma Warnings (On, "formal parameter ""Val"" is not referenced");
+
+   pragma Warnings (On, "unused variable ""Val""");
+
+   function To_Base (Val : RFLX.ICMP.Pointer) return RFLX.ICMP.Pointer is
+     (Val);
+
+   function To_Actual (Val : RFLX.ICMP.Pointer) return RFLX.ICMP.Pointer is
+     (Val)
+    with
+     Pre =>
+       Valid (Val);
+
+   type Timestamp is mod 2**32 with
+     Size =>
+       32;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Timestamp return RFLX.ICMP.Timestamp is
+     (RFLX.ICMP.Timestamp'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   pragma Warnings (Off, "unused variable ""Val""");
+
+   pragma Warnings (Off, "formal parameter ""Val"" is not referenced");
+
+   function Valid (Val : RFLX.ICMP.Timestamp) return Boolean is
+     (True);
+
+   pragma Warnings (On, "formal parameter ""Val"" is not referenced");
+
+   pragma Warnings (On, "unused variable ""Val""");
+
+   function To_Base (Val : RFLX.ICMP.Timestamp) return RFLX.ICMP.Timestamp is
+     (Val);
+
+   function To_Actual (Val : RFLX.ICMP.Timestamp) return RFLX.ICMP.Timestamp is
+     (Val)
+    with
+     Pre =>
+       Valid (Val);
+
+   type Gateway_Internet_Address is mod 2**32 with
+     Size =>
+       32;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Gateway_Internet_Address return RFLX.ICMP.Gateway_Internet_Address is
+     (RFLX.ICMP.Gateway_Internet_Address'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   pragma Warnings (Off, "unused variable ""Val""");
+
+   pragma Warnings (Off, "formal parameter ""Val"" is not referenced");
+
+   function Valid (Val : RFLX.ICMP.Gateway_Internet_Address) return Boolean is
+     (True);
+
+   pragma Warnings (On, "formal parameter ""Val"" is not referenced");
+
+   pragma Warnings (On, "unused variable ""Val""");
+
+   function To_Base (Val : RFLX.ICMP.Gateway_Internet_Address) return RFLX.ICMP.Gateway_Internet_Address is
+     (Val);
+
+   function To_Actual (Val : RFLX.ICMP.Gateway_Internet_Address) return RFLX.ICMP.Gateway_Internet_Address is
+     (Val)
+    with
+     Pre =>
+       Valid (Val);
+
+   type Unused_32_Base is mod 2**32 with
+     Annotate =>
+       (GNATprove, No_Wrap_Around);
+
+   type Unused_32 is range 0 .. 0 with
+     Size =>
+       32;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Unused_32 return RFLX.ICMP.Unused_32 is
+     (RFLX.ICMP.Unused_32'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   function Valid (Val : RFLX.ICMP.Unused_32_Base) return Boolean is
+     (Val = 0);
+
+   function To_Base (Val : RFLX.ICMP.Unused_32) return RFLX.ICMP.Unused_32_Base is
+     (RFLX.ICMP.Unused_32_Base (Val));
+
+   function To_Actual (Val : RFLX.ICMP.Unused_32_Base) return RFLX.ICMP.Unused_32 is
+     (RFLX.ICMP.Unused_32 (Val))
+    with
+     Pre =>
+       Valid (Val);
+
+   type Unused_24_Base is mod 2**24 with
+     Annotate =>
+       (GNATprove, No_Wrap_Around);
+
+   type Unused_24 is range 0 .. 0 with
+     Size =>
+       24;
+
+   pragma Warnings (Off, "precondition is * false");
+
+   function Unreachable_ICMP_Unused_24 return RFLX.ICMP.Unused_24 is
+     (RFLX.ICMP.Unused_24'First)
+    with
+     Pre =>
+       False;
+
+   pragma Warnings (On, "precondition is * false");
+
+   function Valid (Val : RFLX.ICMP.Unused_24_Base) return Boolean is
+     (Val = 0);
+
+   function To_Base (Val : RFLX.ICMP.Unused_24) return RFLX.ICMP.Unused_24_Base is
+     (RFLX.ICMP.Unused_24_Base (Val));
+
+   function To_Actual (Val : RFLX.ICMP.Unused_24_Base) return RFLX.ICMP.Unused_24 is
+     (RFLX.ICMP.Unused_24 (Val))
+    with
+     Pre =>
+       Valid (Val);
+
+end RFLX.ICMP;

--- a/generated/rflx-in_ipv4-contains.ads
+++ b/generated/rflx-in_ipv4-contains.ads
@@ -4,5 +4,6 @@ with RFLX.RFLX_Types;
 with RFLX.In_IPv4.Generic_Contains;
 with RFLX.IPv4.Packet;
 with RFLX.UDP.Datagram;
+with RFLX.ICMP.Message;
 
-package RFLX.In_IPv4.Contains is new RFLX.In_IPv4.Generic_Contains (RFLX.RFLX_Types, RFLX.IPv4.Packet, RFLX.UDP.Datagram);
+package RFLX.In_IPv4.Contains is new RFLX.In_IPv4.Generic_Contains (RFLX.RFLX_Types, RFLX.IPv4.Packet, RFLX.UDP.Datagram, RFLX.ICMP.Message);

--- a/generated/rflx-in_ipv4-generic_contains.adb
+++ b/generated/rflx-in_ipv4-generic_contains.adb
@@ -15,4 +15,15 @@ is
       pragma Warnings (On, "unused assignment to ""Buffer""");
    end Switch_To_Payload;
 
+   procedure Switch_To_Payload (IPv4_Packet_Context : in out IPv4_Packet.Context; ICMP_Message_Context : out ICMP_Message.Context) is
+      First : constant Types.Bit_Index := IPv4_Packet.Field_First (IPv4_Packet_Context, IPv4_Packet.F_Payload);
+      Last : constant Types.Bit_Index := IPv4_Packet.Field_Last (IPv4_Packet_Context, IPv4_Packet.F_Payload);
+      Buffer : Types.Bytes_Ptr;
+   begin
+      IPv4_Packet.Take_Buffer (IPv4_Packet_Context, Buffer);
+      pragma Warnings (Off, "unused assignment to ""Buffer""");
+      ICMP_Message.Initialize (ICMP_Message_Context, Buffer, First, Last);
+      pragma Warnings (On, "unused assignment to ""Buffer""");
+   end Switch_To_Payload;
+
 end RFLX.In_IPv4.Generic_Contains;

--- a/generated/rflx-in_ipv4-generic_contains.ads
+++ b/generated/rflx-in_ipv4-generic_contains.ads
@@ -4,11 +4,13 @@ with RFLX.IPv4;
 use RFLX.IPv4;
 with RFLX.IPv4.Generic_Packet;
 with RFLX.UDP.Generic_Datagram;
+with RFLX.ICMP.Generic_Message;
 
 generic
    with package Types is new RFLX.RFLX_Generic_Types (<>);
    with package IPv4_Packet is new RFLX.IPv4.Generic_Packet (Types, others => <>);
    with package UDP_Datagram is new RFLX.UDP.Generic_Datagram (Types, others => <>);
+   with package ICMP_Message is new RFLX.ICMP.Generic_Message (Types, others => <>);
 package RFLX.In_IPv4.Generic_Contains with
   SPARK_Mode,
   Annotate =>
@@ -42,6 +44,34 @@ is
        and UDP_Datagram_Context.First = IPv4_Packet.Field_First (IPv4_Packet_Context, IPv4_Packet.F_Payload)
        and UDP_Datagram_Context.Last = IPv4_Packet.Field_Last (IPv4_Packet_Context, IPv4_Packet.F_Payload)
        and UDP_Datagram.Initialized (UDP_Datagram_Context)
+       and IPv4_Packet_Context.Buffer_First = IPv4_Packet_Context.Buffer_First'Old
+       and IPv4_Packet_Context.Buffer_Last = IPv4_Packet_Context.Buffer_Last'Old
+       and IPv4_Packet_Context.First = IPv4_Packet_Context.First'Old
+       and IPv4_Packet.Context_Cursors (IPv4_Packet_Context) = IPv4_Packet.Context_Cursors (IPv4_Packet_Context)'Old;
+
+   function ICMP_Message_In_IPv4_Packet_Payload (Ctx : IPv4_Packet.Context) return Boolean is
+     (IPv4_Packet.Has_Buffer (Ctx)
+      and then IPv4_Packet.Present (Ctx, IPv4_Packet.F_Payload)
+      and then IPv4_Packet.Valid (Ctx, IPv4_Packet.F_Protocol)
+      and then IPv4_Packet.Get_Protocol (Ctx).Known
+      and then IPv4_Packet.Get_Protocol (Ctx).Enum = PROTOCOL_ICMP);
+
+   procedure Switch_To_Payload (IPv4_Packet_Context : in out IPv4_Packet.Context; ICMP_Message_Context : out ICMP_Message.Context) with
+     Pre =>
+       not IPv4_Packet_Context'Constrained
+       and not ICMP_Message_Context'Constrained
+       and IPv4_Packet.Has_Buffer (IPv4_Packet_Context)
+       and IPv4_Packet.Present (IPv4_Packet_Context, IPv4_Packet.F_Payload)
+       and IPv4_Packet.Valid (IPv4_Packet_Context, IPv4_Packet.F_Protocol)
+       and ICMP_Message_In_IPv4_Packet_Payload (IPv4_Packet_Context),
+     Post =>
+       not IPv4_Packet.Has_Buffer (IPv4_Packet_Context)
+       and ICMP_Message.Has_Buffer (ICMP_Message_Context)
+       and IPv4_Packet_Context.Buffer_First = ICMP_Message_Context.Buffer_First
+       and IPv4_Packet_Context.Buffer_Last = ICMP_Message_Context.Buffer_Last
+       and ICMP_Message_Context.First = IPv4_Packet.Field_First (IPv4_Packet_Context, IPv4_Packet.F_Payload)
+       and ICMP_Message_Context.Last = IPv4_Packet.Field_Last (IPv4_Packet_Context, IPv4_Packet.F_Payload)
+       and ICMP_Message.Initialized (ICMP_Message_Context)
        and IPv4_Packet_Context.Buffer_First = IPv4_Packet_Context.Buffer_First'Old
        and IPv4_Packet_Context.Buffer_Last = IPv4_Packet_Context.Buffer_Last'Old
        and IPv4_Packet_Context.First = IPv4_Packet_Context.First'Old

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -93,11 +93,10 @@ class MessageState(Base):
     checksums: Mapping[ID, Sequence[expr.Expr]] = {}
 
 
-# pylint: disable=too-many-public-methods
 @invariant(lambda self: valid_message_field_types(self))
 @invariant(lambda self: not self.types if not self.structure else True)
 class AbstractMessage(type_.Type):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-public-methods
     def __init__(
         self,
         identifier: StrID,

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -272,7 +272,9 @@ class AbstractMessage(type_.Type):
                     **{
                         v: v.__class__(f"{self.package}.{v.name}")
                         for v in expression.variables()
-                        if v.identifier in literals and v.identifier not in type_.BUILTIN_LITERALS
+                        if v.identifier in literals
+                        and v.identifier not in type_.BUILTIN_LITERALS
+                        and v.identifier != ID("Message")
                     },
                 }
             ).simplified()

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -144,7 +144,8 @@ class AbstractMessage(type_.Type):
             return f"type {self.name} is null message"
 
         fields = ""
-        for f in [INITIAL, *self.fields]:
+        field_list = [INITIAL, *self.fields]
+        for i, f in enumerate(field_list):
             if f != INITIAL:
                 fields += "\n" if fields else ""
                 fields += f"{f.name} : {self.types[f].name}"
@@ -154,6 +155,7 @@ class AbstractMessage(type_.Type):
                 and outgoing[0].condition == expr.TRUE
                 and outgoing[0].length == expr.UNDEFINED
                 and outgoing[0].first == expr.UNDEFINED
+                and (i >= len(field_list) - 1 or field_list[i + 1] == outgoing[0].target)
             ):
                 if f == INITIAL:
                     fields += "null"

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -93,6 +93,7 @@ class MessageState(Base):
     checksums: Mapping[ID, Sequence[expr.Expr]] = {}
 
 
+# pylint: disable=too-many-public-methods
 @invariant(lambda self: valid_message_field_types(self))
 @invariant(lambda self: not self.types if not self.structure else True)
 class AbstractMessage(type_.Type):
@@ -248,6 +249,9 @@ class AbstractMessage(type_.Type):
             return field_type.size
 
         raise NotImplementedError
+
+    def paths(self, field: Field) -> Set[Tuple[Link, ...]]:
+        return self._state.paths[field]
 
     def prefixed(self, prefix: str) -> "AbstractMessage":
         fields = {f.identifier for f in self.fields}

--- a/specs/in_ipv4.rflx
+++ b/specs/in_ipv4.rflx
@@ -1,9 +1,13 @@
 with IPv4;
 with UDP;
+with ICMP;
 
 package In_IPv4 is
 
    for IPv4.Packet use (Payload => UDP.Datagram)
       if Protocol = PROTOCOL_UDP;
+
+   for IPv4.Packet use (Payload => ICMP.Message)
+      if Protocol = PROTOCOL_ICMP;
 
 end In_IPv4;

--- a/test.gpr
+++ b/test.gpr
@@ -71,6 +71,8 @@ project Test is
       for Proof_Switches ("rflx-ethernet.ads") use ("--prover=Z3", "--steps=1");
       for Proof_Switches ("rflx-expression-message.ads") use ("--prover=Z3", "--steps=1");
       for Proof_Switches ("rflx-expression-tests.adb") use ("--prover=Z3", "--steps=1");
+      for Proof_Switches ("rflx-icmp-message.ads") use ("--prover=Z3,altergo,CVC4", "--steps=37511");
+      for Proof_Switches ("rflx-icmp.ads") use ("--prover=CVC4", "--steps=1");
       for Proof_Switches ("rflx-in_ethernet-contains.ads") use ("--prover=CVC4,Z3", "--steps=514");
       for Proof_Switches ("rflx-in_ethernet-tests.adb") use ("--prover=Z3,altergo,CVC4", "--steps=132596");
       for Proof_Switches ("rflx-in_ipv4-contains.ads") use ("--prover=CVC4,Z3", "--steps=4900");

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1146,6 +1146,66 @@ def test_prefixed_message() -> None:
     )
 
 
+def test_prefixed_message_attribute() -> None:
+    result = Message(
+        "P.M",
+        [
+            Link(INITIAL, Field("F1")),
+            Link(
+                Field("F1"),
+                Field("F2"),
+                LessEqual(Variable("F1"), Number(100)),
+                first=First("F1"),
+            ),
+            Link(
+                Field("F1"),
+                Field("F3"),
+                GreaterEqual(Variable("F1"), Number(200)),
+                first=First("F1"),
+            ),
+            Link(Field("F2"), FINAL, Equal(Variable("F2"), Number(42))),
+            Link(Field("F3"), Field("F4"), length=Sub(Last("Message"), Last("F3"))),
+            Link(Field("F4"), FINAL),
+        ],
+        {
+            Field("F1"): deepcopy(MODULAR_INTEGER),
+            Field("F2"): deepcopy(MODULAR_INTEGER),
+            Field("F3"): deepcopy(RANGE_INTEGER),
+            Field("F4"): Opaque(),
+        },
+    ).prefixed("X_")
+
+    expected = Message(
+        "P.M",
+        [
+            Link(INITIAL, Field("X_F1")),
+            Link(
+                Field("X_F1"),
+                Field("X_F2"),
+                LessEqual(Variable("X_F1"), Number(100)),
+                first=First("X_F1"),
+            ),
+            Link(
+                Field("X_F1"),
+                Field("X_F3"),
+                GreaterEqual(Variable("X_F1"), Number(200)),
+                first=First("X_F1"),
+            ),
+            Link(Field("X_F2"), FINAL, Equal(Variable("X_F2"), Number(42))),
+            Link(Field("X_F3"), Field("X_F4"), length=Add(Last("Message"), -Last("X_F3"))),
+            Link(Field("X_F4"), FINAL),
+        ],
+        {
+            Field("X_F1"): deepcopy(MODULAR_INTEGER),
+            Field("X_F2"): deepcopy(MODULAR_INTEGER),
+            Field("X_F3"): deepcopy(RANGE_INTEGER),
+            Field("X_F4"): Opaque(),
+        },
+    )
+
+    assert result == expected
+
+
 def test_merge_message_simple() -> None:
     assert_equal(
         deepcopy(M_SMPL_REF).merged(),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -54,7 +54,7 @@ from rflx.model import (
     UnprovenMessage,
 )
 from tests.models import ENUMERATION, ETHERNET_FRAME, MODULAR_INTEGER, RANGE_INTEGER
-from tests.utils import assert_equal, assert_message_model_error
+from tests.utils import assert_equal, assert_message_model_error, multilinestr
 
 M_NO_REF = UnprovenMessage(
     "P.No_Ref",
@@ -1839,3 +1839,33 @@ def test_paths() -> None:
             Link(Field("L"), Field("O"), condition=LessEqual(Variable("L"), Number(100))),
         ),
     }
+
+
+def test_message_str() -> None:
+    message = Message(
+        "P.M",
+        [
+            Link(INITIAL, Field("L")),
+            Link(Field("L"), Field("O"), condition=Greater(Variable("L"), Number(100))),
+            Link(Field("L"), Field("P"), condition=LessEqual(Variable("L"), Number(100))),
+            Link(Field("P"), FINAL),
+            Link(Field("O"), FINAL),
+        ],
+        {Field("L"): MODULAR_INTEGER, Field("O"): MODULAR_INTEGER, Field("P"): MODULAR_INTEGER},
+    )
+    assert_equal(
+        str(message),
+        multilinestr(
+            """type M is
+                  message
+                     L : Modular
+                        then O
+                           if L > 100
+                        then P
+                           if L <= 100;
+                     O : Modular
+                        then null;
+                     P : Modular;
+                  end message"""
+        ),
+    )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1816,3 +1816,26 @@ def test_opaque_length_valid_multiple_of_8_dynamic_cond() -> None:
         ],
         {Field("L"): MODULAR_INTEGER, Field("O"): Opaque()},
     )
+
+
+def test_paths() -> None:
+    message = Message(
+        "P.M",
+        [
+            Link(INITIAL, Field("L")),
+            Link(Field("L"), Field("O"), condition=Greater(Variable("L"), Number(100))),
+            Link(Field("L"), Field("O"), condition=LessEqual(Variable("L"), Number(100))),
+            Link(Field("O"), FINAL),
+        ],
+        {Field("L"): MODULAR_INTEGER, Field("O"): MODULAR_INTEGER},
+    )
+    assert message.paths(Field("O")) == {
+        (
+            Link(INITIAL, Field("L")),
+            Link(Field("L"), Field("O"), condition=Greater(Variable("L"), Number(100))),
+        ),
+        (
+            Link(INITIAL, Field("L")),
+            Link(Field("L"), Field("O"), condition=LessEqual(Variable("L"), Number(100))),
+        ),
+    }


### PR DESCRIPTION
- Add method to get paths from `AbstractMessage`
- Add ICMP to IPv4 refinements
- Correctly handle special `Message` variable
- Fix string representation of messages 