### PR TITLE
Issue 441: Use `::` as package separator in identifiers

### DIFF
--- a/examples/ping/specs/ipv4.rflx
+++ b/examples/ping/specs/ipv4.rflx
@@ -14,7 +14,7 @@ package IPv4 is
    type Protocol is (PROTOCOL_ICMP => 1, PROTOCOL_UDP => 17) with Size => 8, Always_Valid;
    type Header_Checksum is mod 2**16;
    type Address is mod 2**32;
-   type Options is array of IPv4_Option.Option;
+   type Options is array of IPv4_Option::Option;
 
    type Packet is
       message
@@ -45,7 +45,7 @@ package IPv4 is
          Payload : Opaque;
       end message;
 
-   for Packet use (Payload => ICMP.Message)
+   for Packet use (Payload => ICMP::Message)
       if Protocol = PROTOCOL_ICMP;
 
 end IPv4;

--- a/rflx/ada.py
+++ b/rflx/ada.py
@@ -7,9 +7,38 @@ from enum import Enum
 from sys import intern
 from typing import List, Mapping, Optional, Sequence, Tuple, Union
 
+import rflx.identifier
 from rflx.common import Base, file_name, indent, indent_next, unique
 from rflx.contract import invariant
-from rflx.identifier import ID, StrID
+
+
+class ID(rflx.identifier.ID):
+    @property
+    def _separator(self) -> str:
+        return "."
+
+    def __add__(self, other: object) -> "ID":
+        result = super().__add__(other)
+        assert isinstance(result, ID)
+        return result
+
+    def __radd__(self, other: object) -> "ID":
+        result = super().__radd__(other)
+        assert isinstance(result, ID)
+        return result
+
+    def __mul__(self, other: object) -> "ID":
+        result = super().__mul__(other)
+        assert isinstance(result, ID)
+        return result
+
+    def __rmul__(self, other: object) -> "ID":
+        result = super().__rmul__(other)
+        assert isinstance(result, ID)
+        return result
+
+
+StrID = Union[str, ID]
 
 
 class Precedence(Enum):

--- a/rflx/common.py
+++ b/rflx/common.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC
 from typing import Iterable, Iterator, Sequence, Set, TypeVar
 
@@ -44,11 +45,11 @@ def indent_next(string: str, indentation: int) -> str:
 
 
 def flat_name(full_name: str) -> str:
-    return full_name.replace(".", "_")
+    return re.sub(r"(?:\.|::)", "_", full_name)
 
 
 def file_name(identifier: str) -> str:
-    return identifier.lower().replace(".", "-")
+    return re.sub(r"(?:\.|::)", "-", identifier.lower())
 
 
 T = TypeVar("T")  # pylint: disable=invalid-name

--- a/rflx/expression.py
+++ b/rflx/expression.py
@@ -1013,7 +1013,7 @@ class Variable(Name):
         declarations[self.identifier].reference()
 
     def ada_expr(self) -> ada.Expr:
-        return ada.Variable(self.identifier, self.negative)
+        return ada.Variable(ada.ID(self.identifier), self.negative)
 
     def z3expr(self) -> z3.ArithRef:
         if self.negative:
@@ -1064,7 +1064,7 @@ class Attribute(Name):
         return self.prefix.variables()
 
     def ada_expr(self) -> ada.Expr:
-        return getattr(ada, self.__class__.__name__)(self.prefix, self.negative)
+        return getattr(ada, self.__class__.__name__)(self.prefix.ada_expr(), self.negative)
 
     def z3expr(self) -> z3.ExprRef:
         if not isinstance(self.prefix, Variable):
@@ -1233,7 +1233,7 @@ class Selected(Name):
         )
 
     def ada_expr(self) -> ada.Expr:
-        return ada.Selected(self.prefix.ada_expr(), self.selector_name, self.negative)
+        return ada.Selected(self.prefix.ada_expr(), ada.ID(self.selector_name), self.negative)
 
     def z3expr(self) -> z3.ExprRef:
         raise NotImplementedError
@@ -1268,7 +1268,7 @@ class Call(Name):
         return call
 
     def ada_expr(self) -> ada.Expr:
-        return ada.Call(self.name, [a.ada_expr() for a in self.args], self.negative)
+        return ada.Call(ada.ID(self.name), [a.ada_expr() for a in self.args], self.negative)
 
     def z3expr(self) -> z3.ExprRef:
         raise NotImplementedError
@@ -1885,13 +1885,13 @@ class Conversion(Expr):
         return Conversion(self.name, self.argument.simplified(), self.type_, self.location)
 
     def ada_expr(self) -> ada.Expr:
-        return ada.Conversion(self.name, self.argument.ada_expr())
+        return ada.Conversion(ada.ID(self.name), self.argument.ada_expr())
 
     def z3expr(self) -> z3.ExprRef:
         raise NotImplementedError
 
     def validate(self, declarations: Mapping[ID, Declaration]) -> None:
-        self.argument.validate(declarations)
+        raise NotImplementedError
 
     def variables(self) -> List["Variable"]:
         return self.argument.variables()

--- a/rflx/generator/const.py
+++ b/rflx/generator/const.py
@@ -1,15 +1,15 @@
+import rflx.ada as ada
 from rflx.common import file_name
-from rflx.identifier import ID
 
-REFINEMENT_PACKAGE = ID("Contains")
+REFINEMENT_PACKAGE = ada.ID("Contains")
 
-ARITHMETIC_PACKAGE = ID("RFLX_Arithmetic")
-BUILTIN_TYPES_CONVERSIONS_PACKAGE = ID("RFLX_Builtin_Types.Conversions")
-BUILTIN_TYPES_PACKAGE = ID("RFLX_Builtin_Types")
-GENERIC_TYPES_PACKAGE = ID("RFLX_Generic_Types")
-MESSAGE_SEQUENCE_PACKAGE = ID("RFLX_Message_Sequence")
-SCALAR_SEQUENCE_PACKAGE = ID("RFLX_Scalar_Sequence")
-TYPES_PACKAGE = ID("RFLX_Types")
+ARITHMETIC_PACKAGE = ada.ID("RFLX_Arithmetic")
+BUILTIN_TYPES_CONVERSIONS_PACKAGE = ada.ID("RFLX_Builtin_Types.Conversions")
+BUILTIN_TYPES_PACKAGE = ada.ID("RFLX_Builtin_Types")
+GENERIC_TYPES_PACKAGE = ada.ID("RFLX_Generic_Types")
+MESSAGE_SEQUENCE_PACKAGE = ada.ID("RFLX_Message_Sequence")
+SCALAR_SEQUENCE_PACKAGE = ada.ID("RFLX_Scalar_Sequence")
+TYPES_PACKAGE = ada.ID("RFLX_Types")
 
 LIBRARY_FILES = [
     file_name(str(p)) + ".ads"
@@ -34,7 +34,7 @@ LIBRARY_FILES = [
 
 TEMPLATE_DIR = ("rflx", "templates/")
 
-TYPES = ID("Types")
+TYPES = ada.ID("Types")
 TYPES_BYTE = TYPES * "Byte"
 TYPES_BYTES = TYPES * "Bytes"
 TYPES_BYTES_PTR = TYPES * "Bytes_Ptr"

--- a/rflx/generator/generator.py
+++ b/rflx/generator/generator.py
@@ -2,6 +2,7 @@ from typing import Mapping, Sequence
 
 import rflx.expression as expr
 from rflx.ada import (
+    ID,
     TRUE,
     Add,
     Aggregate,
@@ -51,7 +52,6 @@ from rflx.ada import (
     Variable,
 )
 from rflx.common import unique
-from rflx.identifier import ID
 from rflx.model import BUILTINS_PACKAGE, FINAL, Enumeration, Field, Message, Opaque, Scalar, Type
 
 from . import common, const
@@ -245,7 +245,7 @@ class GeneratorGenerator:
                     common.full_enum_name(field_type), self.prefix
                 )
             else:
-                type_name = common.prefixed_type_name(field_type.identifier, self.prefix)
+                type_name = common.prefixed_type_name(ID(field_type.identifier), self.prefix)
 
             return ProcedureSpecification(
                 f"Set_{field.name}",

--- a/rflx/generator/parser.py
+++ b/rflx/generator/parser.py
@@ -3,6 +3,7 @@ from typing import List, Mapping, Sequence, Tuple
 import rflx.expression as expr
 from rflx.ada import (
     FALSE,
+    ID,
     TRUE,
     Add,
     And,
@@ -43,7 +44,6 @@ from rflx.ada import (
     Variable,
 )
 from rflx.common import unique
-from rflx.identifier import ID
 from rflx.model import BUILTINS_PACKAGE, FINAL, INITIAL, Composite, Field, Message, Scalar, Type
 
 from . import common, const
@@ -633,7 +633,7 @@ class ParserGenerator:
             if field_type.package == BUILTINS_PACKAGE:
                 type_name = ID(field_type.name)
             else:
-                type_name = self.prefix * field_type.identifier
+                type_name = self.prefix * ID(field_type.identifier)
 
             return FunctionSpecification(
                 f"Get_{field.name}", type_name, [Parameter(["Ctx"], "Context")]

--- a/rflx/graph.py
+++ b/rflx/graph.py
@@ -51,7 +51,7 @@ class Graph:
     def __graph_with_defaults(cls, name: str) -> Dot:
         """Return default pydot graph."""
 
-        result = Dot(graph_name=name)
+        result = Dot(graph_name=f'"{name}"')
         result.set_graph_defaults(
             splines="true", ranksep="0.1 equally", pad="0.1", truecolor="true", bgcolor="#00000000"
         )

--- a/rflx/identifier.py
+++ b/rflx/identifier.py
@@ -1,6 +1,5 @@
 from typing import Optional, Sequence, Union
 
-# from rflx.contract import invariant
 from rflx.error import Location
 
 
@@ -21,6 +20,7 @@ class ID:
         else:
             assert False, f'unexpected identifier type "{type(identifier).__name__}"'
 
+        assert self._parts, "empty identifier"
         assert "" not in self._parts, "empty part in identifier"
         for c in [" ", ".", ":"]:
             assert all(c not in part for part in self._parts), f'"{c}" in identifier parts'
@@ -85,11 +85,11 @@ class ID:
 
     @property
     def name(self) -> "ID":
-        return ID(self.parts[-1])
+        return self.__class__(self._parts[-1])
 
     @property
     def parent(self) -> "ID":
-        return ID(self.parts[:-1])
+        return self.__class__(self._parts[:-1])
 
     @property
     def _separator(self) -> str:

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -269,12 +269,12 @@ class AbstractMessage(mty.Type):
             return expression.substituted(
                 mapping={
                     **{
-                        v: v.__class__(f"{prefix}{v.name}")
+                        v: v.__class__(ID(prefix) + v.name)
                         for v in expression.variables()
                         if v.identifier in fields
                     },
                     **{
-                        v: v.__class__(f"{self.package}.{v.name}")
+                        v: v.__class__(self.package * v.name)
                         for v in expression.variables()
                         if v.identifier in literals
                         and v.identifier not in mty.BUILTIN_LITERALS

--- a/rflx/parser/ast.py
+++ b/rflx/parser/ast.py
@@ -110,7 +110,7 @@ class RefinementSpec(Type):
         self.sdu = ID(sdu)
         self.condition = condition
         super().__init__(
-            f"__PACKAGE__.__REFINEMENT__{flat_name(str(self.sdu))}"
+            ID("__PACKAGE__") * f"__REFINEMENT__{flat_name(str(self.sdu))}"
             f"__{flat_name(str(self.pdu))}__{field}__",
             location,
         )

--- a/rflx/parser/parser.py
+++ b/rflx/parser/parser.py
@@ -157,7 +157,7 @@ class Parser:
 
     def __evaluate_types(self, spec: Specification, error: RecordFluxError) -> None:
         for t in spec.package.types:
-            t.identifier = ID(f"{spec.package.identifier}.{t.name}", t.identifier.location)
+            t.identifier = ID(spec.package.identifier, t.identifier.location) * t.name
 
             if t.identifier in self.__types:
                 error.append(
@@ -203,9 +203,7 @@ class Parser:
 
     def __evaluate_sessions(self, spec: Specification, error: RecordFluxError) -> None:
         for s in spec.package.sessions:
-            s.identifier = ID(
-                f"{spec.package.identifier}.{s.identifier.name}", s.identifier.location
-            )
+            s.identifier = ID(spec.package.identifier, s.identifier.location) * s.identifier.name
 
             if s.identifier in self.__types or s.identifier in self.__sessions:
                 error.append(

--- a/rflx/pyrflx/bitstring.py
+++ b/rflx/pyrflx/bitstring.py
@@ -19,6 +19,9 @@ class Bitstring:
             raise IndexError
         return Bitstring(self._bits[key])
 
+    def __repr__(self) -> str:
+        return f'Bitstring("{self._bits}")'
+
     def __str__(self) -> str:
         return self._bits
 

--- a/specs/in_ethernet.rflx
+++ b/specs/in_ethernet.rflx
@@ -3,7 +3,7 @@ with IPv4;
 
 package In_Ethernet is
 
-   for Ethernet.Frame use (Payload => IPv4.Packet)
+   for Ethernet::Frame use (Payload => IPv4::Packet)
       if Type_Length = 16#0800#;
 
 end In_Ethernet;

--- a/specs/in_ipv4.rflx
+++ b/specs/in_ipv4.rflx
@@ -4,10 +4,10 @@ with ICMP;
 
 package In_IPv4 is
 
-   for IPv4.Packet use (Payload => UDP.Datagram)
+   for IPv4::Packet use (Payload => UDP::Datagram)
       if Protocol = PROTOCOL_UDP;
 
-   for IPv4.Packet use (Payload => ICMP.Message)
+   for IPv4::Packet use (Payload => ICMP::Message)
       if Protocol = PROTOCOL_ICMP;
 
 end In_IPv4;

--- a/tests/feature_integration.rflx
+++ b/tests/feature_integration.rflx
@@ -9,27 +9,27 @@ package Feature_Integration is
 
    type Message is
       message
-         Enumeration : Enumeration_Type.Priority
+         Enumeration : Enumeration_Type::Priority
             then Integer
-               if Enumeration = Enumeration_Type.HIGH;
-         Integer : Integer_Type.Byte
+               if Enumeration = Enumeration_Type::HIGH;
+         Integer : Integer_Type::Byte
             then Scalar_Array
                with Length => 8 * Integer;
-         Scalar_Array : Array_Type.Bytes
+         Scalar_Array : Array_Type::Bytes
             then Message_Array
                with Length => 8 * Integer;
-         Message_Array : Array_Type.Bar;
-         Message_Type : Message_Type.PDU;
-         Message_In_Message : Message_In_Message.Message;
-         Derived_Message_In_Message : Message_In_Message.Derived_Message
+         Message_Array : Array_Type::Bar;
+         Message_Type : Message_Type::PDU;
+         Message_In_Message : Message_In_Message::Message;
+         Derived_Message_In_Message : Message_In_Message::Derived_Message
             then Opaque
                with Length => 8 * Integer;
          Opaque : Opaque;
       end message;
 
-   type Derived_Message is new Message_In_Message.Message;
+   type Derived_Message is new Message_In_Message::Message;
 
-   for TLV_With_Checksum.Message use (Value => Message_Type.PDU)
-      if Tag = TLV_With_Checksum.Msg_Data;
+   for TLV_With_Checksum::Message use (Value => Message_Type::PDU)
+      if Tag = TLV_With_Checksum::Msg_Data;
 
 end Feature_Integration;

--- a/tests/models.py
+++ b/tests/models.py
@@ -31,15 +31,15 @@ from rflx.model import (
     Refinement,
 )
 
-NULL_MESSAGE = Message("Null.Message", [], {})
+NULL_MESSAGE = Message("Null::Message", [], {})
 NULL_MODEL = Model([NULL_MESSAGE])
 
 TLV_TAG = Enumeration(
-    "TLV.Tag", [("Msg_Data", Number(1)), ("Msg_Error", Number(3))], Number(2), False
+    "TLV::Tag", [("Msg_Data", Number(1)), ("Msg_Error", Number(3))], Number(2), False
 )
-TLV_LENGTH = ModularInteger("TLV.Length", Pow(Number(2), Number(14)))
+TLV_LENGTH = ModularInteger("TLV::Length", Pow(Number(2), Number(14)))
 TLV_MESSAGE = Message(
-    "TLV.Message",
+    "TLV::Message",
     [
         Link(INITIAL, Field("Tag")),
         Link(Field("Tag"), Field("Length"), Equal(Variable("Tag"), Variable("Msg_Data"))),
@@ -56,14 +56,14 @@ NULL_MESSAGE_IN_TLV_MESSAGE_MODEL = Model(
     [TLV_TAG, TLV_LENGTH, TLV_MESSAGE, NULL_MESSAGE, NULL_MESSAGE_IN_TLV_MESSAGE]
 )
 
-ETHERNET_ADDRESS = ModularInteger("Ethernet.Address", Pow(Number(2), Number(48)))
+ETHERNET_ADDRESS = ModularInteger("Ethernet::Address", Pow(Number(2), Number(48)))
 ETHERNET_TYPE_LENGTH = RangeInteger(
-    "Ethernet.Type_Length", Number(46), Sub(Pow(Number(2), Number(16)), Number(1)), Number(16)
+    "Ethernet::Type_Length", Number(46), Sub(Pow(Number(2), Number(16)), Number(1)), Number(16)
 )
-ETHERNET_TPID = RangeInteger("Ethernet.TPID", Number(0x8100, 16), Number(0x8100, 16), Number(16))
-ETHERNET_TCI = ModularInteger("Ethernet.TCI", Pow(Number(2), Number(16)))
+ETHERNET_TPID = RangeInteger("Ethernet::TPID", Number(0x8100, 16), Number(0x8100, 16), Number(16))
+ETHERNET_TCI = ModularInteger("Ethernet::TCI", Pow(Number(2), Number(16)))
 ETHERNET_FRAME = Message(
-    "Ethernet.Frame",
+    "Ethernet::Frame",
     [
         Link(INITIAL, Field("Destination")),
         Link(Field("Destination"), Field("Source")),
@@ -118,39 +118,39 @@ ETHERNET_MODEL = Model(
 )
 
 ENUMERATION_PRIORITY = Enumeration(
-    "Enumeration.Priority",
+    "Enumeration::Priority",
     [("LOW", Number(1)), ("MEDIUM", Number(4)), ("HIGH", Number(7))],
     Number(3),
     True,
 )
 ENUMERATION_MESSAGE = Message(
-    "Enumeration.Message",
+    "Enumeration::Message",
     [Link(INITIAL, Field("Priority")), Link(Field("Priority"), FINAL)],
     {Field("Priority"): ENUMERATION_PRIORITY},
 )
 ENUMERATION_MODEL = Model([ENUMERATION_PRIORITY, ENUMERATION_MESSAGE])
 
-ARRAYS_LENGTH = ModularInteger("Arrays.Length", Pow(Number(2), Number(8)))
-ARRAYS_MODULAR_INTEGER = ModularInteger("Arrays.Modular_Integer", Pow(Number(2), Number(16)))
-ARRAYS_MODULAR_VECTOR = Array("Arrays.Modular_Vector", ARRAYS_MODULAR_INTEGER)
-ARRAYS_RANGE_INTEGER = RangeInteger("Arrays.Range_Integer", Number(1), Number(100), Number(8))
-ARRAYS_RANGE_VECTOR = Array("Arrays.Range_Vector", ARRAYS_RANGE_INTEGER)
+ARRAYS_LENGTH = ModularInteger("Arrays::Length", Pow(Number(2), Number(8)))
+ARRAYS_MODULAR_INTEGER = ModularInteger("Arrays::Modular_Integer", Pow(Number(2), Number(16)))
+ARRAYS_MODULAR_VECTOR = Array("Arrays::Modular_Vector", ARRAYS_MODULAR_INTEGER)
+ARRAYS_RANGE_INTEGER = RangeInteger("Arrays::Range_Integer", Number(1), Number(100), Number(8))
+ARRAYS_RANGE_VECTOR = Array("Arrays::Range_Vector", ARRAYS_RANGE_INTEGER)
 ARRAYS_ENUMERATION = Enumeration(
-    "Arrays.Enumeration",
+    "Arrays::Enumeration",
     [("ZERO", Number(0)), ("ONE", Number(1)), ("TWO", Number(2))],
     Number(8),
     False,
 )
-ARRAYS_ENUMERATION_VECTOR = Array("Arrays.Enumeration_Vector", ARRAYS_ENUMERATION)
+ARRAYS_ENUMERATION_VECTOR = Array("Arrays::Enumeration_Vector", ARRAYS_ENUMERATION)
 ARRAYS_AV_ENUMERATION = Enumeration(
-    "Arrays.AV_Enumeration",
+    "Arrays::AV_Enumeration",
     [("AV_ZERO", Number(0)), ("AV_ONE", Number(1)), ("AV_TWO", Number(2))],
     Number(8),
     True,
 )
-ARRAYS_AV_ENUMERATION_VECTOR = Array("Arrays.AV_Enumeration_Vector", ARRAYS_AV_ENUMERATION)
+ARRAYS_AV_ENUMERATION_VECTOR = Array("Arrays::AV_Enumeration_Vector", ARRAYS_AV_ENUMERATION)
 ARRAYS_MESSAGE = Message(
-    "Arrays.Message",
+    "Arrays::Message",
     [
         Link(INITIAL, Field("Length")),
         Link(Field("Length"), Field("Modular_Vector"), length=Mul(Variable("Length"), Number(8))),
@@ -168,7 +168,7 @@ ARRAYS_MESSAGE = Message(
     },
 )
 ARRAYS_INNER_MESSAGE = Message(
-    "Arrays.Inner_Message",
+    "Arrays::Inner_Message",
     [
         Link(INITIAL, Field("Length")),
         Link(Field("Length"), Field("Payload"), length=Mul(Variable("Length"), Number(8))),
@@ -176,9 +176,9 @@ ARRAYS_INNER_MESSAGE = Message(
     ],
     {Field("Length"): ARRAYS_LENGTH, Field("Payload"): Opaque()},
 )
-ARRAYS_INNER_MESSAGES = Array("Arrays.Inner_Messages", ARRAYS_INNER_MESSAGE)
+ARRAYS_INNER_MESSAGES = Array("Arrays::Inner_Messages", ARRAYS_INNER_MESSAGE)
 ARRAYS_MESSAGES_MESSAGE = Message(
-    "Arrays.Messages_Message",
+    "Arrays::Messages_Message",
     [
         Link(INITIAL, Field("Length")),
         Link(Field("Length"), Field("Messages"), length=Mul(Variable("Length"), Number(8))),
@@ -205,7 +205,7 @@ ARRAYS_MODEL = Model(
 )
 
 EXPRESSION_MESSAGE = Message(
-    "Expression.Message",
+    "Expression::Message",
     [
         Link(INITIAL, Field("Payload"), length=Number(16)),
         Link(Field("Payload"), FINAL, Equal(Variable("Payload"), Aggregate(Number(1), Number(2)))),
@@ -214,13 +214,13 @@ EXPRESSION_MESSAGE = Message(
 )
 EXPRESSION_MODEL = Model([EXPRESSION_MESSAGE])
 
-DERIVATION_MESSAGE = DerivedMessage("Derivation.Message", ARRAYS_MESSAGE)
+DERIVATION_MESSAGE = DerivedMessage("Derivation::Message", ARRAYS_MESSAGE)
 DERIVATION_MODEL = Model([*ARRAYS_MODEL.types, DERIVATION_MESSAGE])
 
-MODULAR_INTEGER = ModularInteger("P.Modular", Number(256))
-RANGE_INTEGER = RangeInteger("P.Range", Number(1), Number(100), Number(8))
+MODULAR_INTEGER = ModularInteger("P::Modular", Number(256))
+RANGE_INTEGER = RangeInteger("P::Range", Number(1), Number(100), Number(8))
 ENUMERATION = Enumeration(
-    "P.Enumeration",
+    "P::Enumeration",
     [("ZERO", Number(0)), ("ONE", Number(1)), ("TWO", Number(2))],
     Number(8),
     False,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,8 +4,8 @@ from typing import Callable, Tuple
 import pytest
 
 import rflx.expression as expr
+from rflx.ada import ID
 from rflx.generator import Generator, common, const
-from rflx.identifier import ID
 from rflx.model import BUILTIN_TYPES, Model, Type
 from tests.models import (
     ARRAYS_MODEL,
@@ -91,7 +91,7 @@ def test_unexpected_type() -> None:
         pass
 
     with pytest.raises(AssertionError, match='unexpected type "TestType"'):
-        Generator().generate(Model([TestType("P.T")]))
+        Generator().generate(Model([TestType("P::T")]))
 
 
 def test_null_spec() -> None:
@@ -191,8 +191,8 @@ def test_substitution_relation_aggregate(
             expr.Variable("Ctx"),
             expr.Variable("F_Value"),
             expr.Aggregate(
-                expr.Val(expr.Variable("Types.Byte"), expr.Number(1)),
-                expr.Val(expr.Variable("Types.Byte"), expr.Number(2)),
+                expr.Val(expr.Variable(expr.ID("Types") * "Byte"), expr.Number(1)),
+                expr.Val(expr.Variable(expr.ID("Types") * "Byte"), expr.Number(2)),
             ),
         ],
     )
@@ -235,7 +235,7 @@ def test_substitution_relation_scalar(
 def test_prefixed_type_name() -> None:
     assert common.prefixed_type_name(ID("Modular"), "P") == ID("P.Modular")
     for t in BUILTIN_TYPES:
-        assert common.prefixed_type_name(t, "P") == t
+        assert common.prefixed_type_name(ID(t), "P") == t
 
 
 def test_base_type_name() -> None:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -37,9 +37,9 @@ def assert_graph(graph: Graph, expected: str) -> None:
 
 
 def test_graph_object() -> None:
-    f_type = ModularInteger("P.T", Pow(Number(2), Number(32)))
+    f_type = ModularInteger("P::T", Pow(Number(2), Number(32)))
     m = Message(
-        "P.M",
+        "P::M",
         structure=[Link(INITIAL, Field("X")), Link(Field("X"), FINAL)],
         types={Field("X"): f_type},
     )
@@ -63,9 +63,9 @@ def test_graph_object() -> None:
 
 
 def test_empty_message_graph() -> None:
-    m = Message("P.M", [], {})
+    m = Message("P::M", [], {})
     expected = """
-        digraph "P.M" {
+        digraph "P::M" {
             graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true,
                    truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", penwidth="2.5"];
@@ -84,14 +84,14 @@ def test_empty_message_graph() -> None:
 
 
 def test_dot_graph() -> None:
-    f_type = ModularInteger("P.T", Pow(Number(2), Number(32)))
+    f_type = ModularInteger("P::T", Pow(Number(2), Number(32)))
     m = Message(
-        "P.M",
+        "P::M",
         structure=[Link(INITIAL, Field("X")), Link(Field("X"), FINAL)],
         types={Field("X"): f_type},
     )
     expected = """
-        digraph "P.M" {
+        digraph "P::M" {
             graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true,
                    truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", penwidth="2.5"];
@@ -115,9 +115,9 @@ def test_dot_graph() -> None:
 
 
 def test_dot_graph_with_condition() -> None:
-    f_type = ModularInteger("P.T", Pow(Number(2), Number(32)))
+    f_type = ModularInteger("P::T", Pow(Number(2), Number(32)))
     m = Message(
-        "P.M",
+        "P::M",
         structure=[
             Link(INITIAL, Field("X")),
             Link(Field("X"), FINAL, Greater(Variable("X"), Number(100))),
@@ -125,7 +125,7 @@ def test_dot_graph_with_condition() -> None:
         types={Field("X"): f_type},
     )
     expected = """
-        digraph "P.M" {
+        digraph "P::M" {
             graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true, truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", penwidth="2.5"];
             node [color="#6f6f6f", fillcolor="#009641", fontcolor="#ffffff", fontname=Arimo,
@@ -148,9 +148,9 @@ def test_dot_graph_with_condition() -> None:
 
 
 def test_dot_graph_with_double_edge() -> None:
-    f_type = ModularInteger("P.T", Pow(Number(2), Number(32)))
+    f_type = ModularInteger("P::T", Pow(Number(2), Number(32)))
     m = Message(
-        "P.M",
+        "P::M",
         structure=[
             Link(INITIAL, Field("X")),
             Link(Field("X"), FINAL, Greater(Variable("X"), Number(100))),
@@ -159,7 +159,7 @@ def test_dot_graph_with_double_edge() -> None:
         types={Field("X"): f_type},
     )
     expected = """
-        digraph "P.M" {
+        digraph "P::M" {
             graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true,
                    truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", penwidth="2.5"];
@@ -210,7 +210,7 @@ def test_session_graph() -> None:
         declarations=[VariableDeclaration("Global", "Some_Type")],
     )
     expected = """
-        digraph Session {
+        digraph "Session" {
             graph [bgcolor="#00000000", pad="0.1", ranksep="0.1 equally", splines=true,
                    truecolor=true];
             edge [color="#6f6f6f", fontcolor="#6f6f6f", fontname="Fira Code", penwidth="2.5"];

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -208,7 +208,7 @@ def test_array_with_imported_element_type_scalar(tmp_path: Path) -> None:
         """
            with Test;
            package Array_Test is
-              type T is array of Test.T;
+              type T is array of Test::T;
            end Array_Test;
         """
     )
@@ -228,7 +228,7 @@ def test_array_with_imported_element_type_message(tmp_path: Path) -> None:
         """
            with Test;
            package Array_Test is
-              type T is array of Test.M;
+              type T is array of Test::M;
            end Array_Test;
         """
     )

--- a/tests/tls_handshake_session.rflx
+++ b/tests/tls_handshake_session.rflx
@@ -11,101 +11,196 @@ package TLS_Handshake_Session is
 
       type Hash_Context is private;
 
-      with function Calculate_Binders (PSKs : GreenTLS.PSKs; Transcript_Hash : GreenTLS.Content) return TLS_Handshake.PSK_Binder_Entries;
-      with function Calculate_Binders_Length (PSKs : GreenTLS.PSKs) return Types.Bit_Length;
-      with function Calculate_ECDHE_Key (Client_Share : TLS_Handshake.Key_Share_Entry; Server_Share : TLS_Handshake.Key_Share_Entry) return GreenTLS.Content;
-      with function Create_Client_Hello_Extensions (Configuration : GreenTLS.Configuration) return FIXME;
-      with function Derive_Secret (Secret : GreenTLS.Content; Label : String; Transcript_Hash : GreenTLS.Content) return GreenTLS.Content;
+      with function Calculate_Binders (PSKs : GreenTLS_PSKs; Transcript_Hash : GreenTLS_Content) return TLS_Handshake_PSK_Binder_Entries;
+      with function Calculate_Binders_Length (PSKs : GreenTLS_PSKs) return Types_Bit_Length;
+      with function Calculate_ECDHE_Key (Client_Share : TLS_Handshake_Key_Share_Entry; Server_Share : TLS_Handshake_Key_Share_Entry) return GreenTLS_Content;
+      with function Create_Client_Hello_Extensions (Configuration : GreenTLS_Configuration) return FIXME;
+      with function Derive_Secret (Secret : GreenTLS_Content; Label : String; Transcript_Hash : GreenTLS_Content) return GreenTLS_Content;
       with function Empty_Hash return Hash_Context;
-      with function Get_Hash (Context : Hash_Context) return GreenTLS.Content;
-      with function Get_Hash_Length (Cipher_Suite : TLS_Handshake.Cipher_Suite) return GreenTLS.KM_Length;
-      with function Get_Zero_Content (Length : GreenTLS.KM_Length) return GreenTLS.Content;
-      with function HKDF_Expand_Label (Secret : GreenTLS.Content; Label : String; Context : GreenTLS.Content; Length : GreenTLS.KM_Length) return GreenTLS.Content;
-      with function HKDF_Extract (Salt : GreenTLS.Content; IKM : GreenTLS.Content) return GreenTLS.Content;
-      with function HMAC (Cipher_Suite : TLS_Handshake.Cipher_Suite; Key : GreenTLS.Content; Hash : GreenTLS.Content) return GreenTLS.Content;
-      with function Select_Supported_Groups (Server_Preferred_Groups : TLS_Handshake.Named_Groups; Supported_Groups : TLS_Handshake.Named_Groups) return TLS_Handshake.Named_Groups;
-      with function Truncate_Client_Hello (Client_Hello : TLS_Handshake.Handshake) return GreenTLS.Content;
+      with function Get_Hash (Context : Hash_Context) return GreenTLS_Content;
+      with function Get_Hash_Length (Cipher_Suite : TLS_Handshake_Cipher_Suite) return GreenTLS_KM_Length;
+      with function Get_Zero_Content (Length : GreenTLS_KM_Length) return GreenTLS_Content;
+      with function HKDF_Expand_Label (Secret : GreenTLS_Content; Label : String; Context : GreenTLS_Content; Length : GreenTLS_KM_Length) return GreenTLS_Content;
+      with function HKDF_Extract (Salt : GreenTLS_Content; IKM : GreenTLS_Content) return GreenTLS_Content;
+      with function HMAC (Cipher_Suite : TLS_Handshake_Cipher_Suite; Key : GreenTLS_Content; Hash : GreenTLS_Content) return GreenTLS_Content;
+      with function Select_Supported_Groups (Server_Preferred_Groups : TLS_Handshake_Named_Groups; Supported_Groups : TLS_Handshake_Named_Groups) return TLS_Handshake_Named_Groups;
+      with function Truncate_Client_Hello (Client_Hello : TLS_Handshake_Handshake) return GreenTLS_Content;
       with function Update_Hash (Context : Hash_Context; Data : Payload) return Hash_Context;
-      with function Validate_Certificate_Verify_Signature (Certificate_Message : TLS_Handshake.Certificate; Certificate_Verify_Message : TLS_Handshake.Certificate_Verify; Transcript_Hash : GreenTLS.Content) return GreenTLS.Signature_Validation_Result;
-      with function Validate_Server_Certificate (Certificate_Message : TLS_Handshake.Certificate; Configuration : GreenTLS.Configuration; Connection : GreenTLS.Connection) return GreenTLS.Certificate_Validation_Result;
+      with function Validate_Certificate_Verify_Signature (Certificate_Message : TLS_Handshake_Certificate; Certificate_Verify_Message : TLS_Handshake_Certificate_Verify; Transcript_Hash : GreenTLS_Content) return GreenTLS_Signature_Validation_Result;
+      with function Validate_Server_Certificate (Certificate_Message : TLS_Handshake_Certificate; Configuration : GreenTLS_Configuration; Connection : GreenTLS_Connection) return GreenTLS_Certificate_Validation_Result;
    session Client with
       Initial => START,
       Final => TERMINATED
    is
+      FIXME_NULL : Dummy;
+      FIXME : Dummy;
+      GreenTLS_APPLICATION_ALERT : Dummy;
+      GreenTLS_APPLICATION_NO_EARLY_DATA : Dummy;
+      GreenTLS_APPLICATION_PROTOCOL : Dummy;
+      GreenTLS_BAD_CERTIFICATE : Dummy;
+      GreenTLS_CERTIFICATE_EXPIRED : Dummy;
+      GreenTLS_CERTIFICATE_REVOKED : Dummy;
+      GreenTLS_CERTIFICATE_UNKNOWN : Dummy;
+      GreenTLS_DECRYPT_ERROR : Dummy;
+      GreenTLS_HEARTBEAT_MODE : Dummy;
+      GreenTLS_ILLEGAL_PARAMETER : Dummy;
+      GreenTLS_KEYSTORE_REQUEST : Dummy;
+      GreenTLS_KEYSTORE_REQUEST_PSK : Dummy;
+      GreenTLS_KEYSTORE_REQUEST_SERVER_PREFERRED_GROUPS : Dummy;
+      GreenTLS_KEY_UPDATE_CLIENT : Dummy;
+      GreenTLS_KEY_UPDATE_SERVER : Dummy;
+      GreenTLS_RNG_REQUEST : Dummy;
+      GreenTLS_RNG_RESPONSE : Dummy;
+      GreenTLS_TLS_1_2 : Dummy;
+      GreenTLS_UNSUPPORTED_CERTIFICATE : Dummy;
+      GreenTLS_VALID_CERTIFICATE : Dummy;
+      GreenTLS_VALID_SIGNATURE : Dummy;
+      TLS_Alert_ALERT : Dummy;
+      TLS_Alert_BAD_CERTIFICATE : Dummy;
+      TLS_Alert_CERTIFICATE_EXPIRED : Dummy;
+      TLS_Alert_CERTIFICATE_REVOKED : Dummy;
+      TLS_Alert_CERTIFICATE_UNKNOWN : Dummy;
+      TLS_Alert_DECODE_ERROR : Dummy;
+      TLS_Alert_DECRYPT_ERROR : Dummy;
+      TLS_Alert_ILLEGAL_PARAMETER : Dummy;
+      TLS_Alert_INTERNAL_ERROR : Dummy;
+      TLS_Alert_MISSING_EXTENSION : Dummy;
+      TLS_Alert_PROTOCOL_VERSION : Dummy;
+      TLS_Alert_UNEXPECTED_MESSAGE : Dummy;
+      TLS_Alert_UNSUPPORTED_CERTIFICATE : Dummy;
+      TLS_Handshake_EXTENSION_APPLICATION_LAYER_PROTOCOL_NEGOTIATION : Dummy;
+      TLS_Handshake_EXTENSION_CERTIFICATE_AUTHORITIES : Dummy;
+      TLS_Handshake_EXTENSION_COOKIE : Dummy;
+      TLS_Handshake_EXTENSION_EARLY_DATA : Dummy;
+      TLS_Handshake_EXTENSION_HEARTBEAT : Dummy;
+      TLS_Handshake_EXTENSION_KEY_SHARE : Dummy;
+      TLS_Handshake_EXTENSION_MAX_FRAGMENT_LENGTH : Dummy;
+      TLS_Handshake_EXTENSION_OID_FILTERS : Dummy;
+      TLS_Handshake_EXTENSION_POST_HANDSHAKE_AUTH : Dummy;
+      TLS_Handshake_EXTENSION_PRE_SHARED_KEY : Dummy;
+      TLS_Handshake_EXTENSION_PSK_KEY_EXCHANGE_MODES : Dummy;
+      TLS_Handshake_EXTENSION_SERVER_NAME : Dummy;
+      TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS_CERT : Dummy;
+      TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS : Dummy;
+      TLS_Handshake_EXTENSION_SUPPORTED_GROUPS : Dummy;
+      TLS_Handshake_EXTENSION_SUPPORTED_VERSIONS : Dummy;
+      TLS_Handshake_HANDSHAKE_CERTIFICATE : Dummy;
+      TLS_Handshake_HANDSHAKE_CERTIFICATE_REQUEST : Dummy;
+      TLS_Handshake_HANDSHAKE_CERTIFICATE_VERIFY : Dummy;
+      TLS_Handshake_HANDSHAKE_CLIENT_HELLO : Dummy;
+      TLS_Handshake_HANDSHAKE_ENCRYPTED_EXTENSIONS : Dummy;
+      TLS_Handshake_HANDSHAKE_END_OF_EARLY_DATA : Dummy;
+      TLS_Handshake_HANDSHAKE_FINISHED : Dummy;
+      TLS_Handshake_HANDSHAKE_KEY_UPDATE : Dummy;
+      TLS_Handshake_HANDSHAKE_MESSAGE_HASH : Dummy;
+      TLS_Handshake_HANDSHAKE_NEW_SESSION_TICKET : Dummy;
+      TLS_Handshake_HANDSHAKE_SERVER_HELLO : Dummy;
+      TLS_Handshake_PSK_DHE_KE : Dummy;
+      TLS_Handshake_PSK_KE : Dummy;
+      TLS_Handshake_TLS_1_3 : Dummy;
+      TLS_Handshake_UPDATE_REQUESTED : Dummy;
+      GreenTLS_Certificate : Dummy;
+      GreenTLS_KEYSTORE_REQUEST_CERTIFICATES : Dummy;
+      GreenTLS_KEYSTORE_REQUEST_NEW_SESSION_TICKET : Dummy;
+      GreenTLS_KEYSTORE_REQUEST_PSK_IDENTITIES : Dummy;
+      GreenTLS_KEYSTORE_REQUEST_PSKS : Dummy;
+      GreenTLS_KEYSTORE_REQUEST_SIGNATURE : Dummy;
+      GreenTLS_KEYSTORE_RESPONSE : Dummy;
+      GreenTLS_PSK : Dummy;
+      GreenTLS_PSK_Message : Dummy;
+      GreenTLS_TLS_1_3 : Dummy;
+      TLS_Handshake_Certificate_Authorities : Dummy;
+      TLS_Handshake_Certificate_Verify : Dummy;
+      TLS_Handshake_Client_Hello : Dummy;
+      TLS_Handshake_EXTENSION_PADDING : Dummy;
+      TLS_Handshake_Heartbeat : Dummy;
+      TLS_Handshake_Key_Share_CH : Dummy;
+      TLS_Handshake_Key_Share_Entry : Dummy;
+      TLS_Handshake_Key_Share_HRR : Dummy;
+      TLS_Handshake_Key_Share_SH : Dummy;
+      TLS_Handshake_Max_Fragment_Length : Dummy;
+      TLS_Handshake_OID_Filters : Dummy;
+      TLS_Handshake_Pre_Shared_Key_CH : Dummy;
+      TLS_Handshake_Pre_Shared_Key_SH : Dummy;
+      TLS_Handshake_Protocol_Name_List : Dummy;
+      TLS_Handshake_Signature_Algorithms_Cert : Dummy;
+      TLS_Handshake_Signature_Algorithms : Dummy;
+      TLS_Handshake_Supported_Groups : Dummy;
+      TLS_Handshake_TLS_1_2 : Dummy;
+      TLS_Handshake_UPDATE_NOT_REQUESTED : Dummy;
+      TLS_Handshake_EXTENSION_SIGNED_CERTIFICATE_TIMESTAMP : Dummy;
+      TLS_Handshake_Supported_Versions : Dummy;
+      TLS_Handshake_EXTENSION_STATUS_REQUEST : Dummy;
+
       Application_Layer_Protocol_Negotiation_Received : Boolean := False;
-      Binders : TLS_Handshake.PSK_Binder_Entries;
-      Binders_Length : TLS_Handshake.Binders_Length;
-      CCR_Handshake_Message : TLS_Handshake.Handshake;
+      Binders : TLS_Handshake_PSK_Binder_Entries;
+      Binders_Length : TLS_Handshake_Binders_Length;
+      CCR_Handshake_Message : TLS_Handshake_Handshake;
       CH_Cookie_Prepared : Boolean := False;
       CH_Key_Share_Prepared : Boolean := False;
       CH_PSK_Prepared : Boolean := False;
-      Certificate_Authorities : TLS_Handshake.Certificate_Authorities;
+      Certificate_Authorities : TLS_Handshake_Certificate_Authorities;
       Certificate_Authorities_Received : Boolean := False;
-      Certificate_Request : TLS_Handshake.Certificate_Request;
+      Certificate_Request : TLS_Handshake_Certificate_Request;
       Certificate_Request_Received : Boolean := False;
-      Certificate_Verify_Handshake_Message : TLS_Handshake.Handshake;
-      Client_Application_Traffic_Secret : GreenTLS.Content;
-      Client_Handshake_Traffic_Secret : GreenTLS.Content;
+      Certificate_Verify_Handshake_Message : TLS_Handshake_Handshake;
+      Client_Application_Traffic_Secret : GreenTLS_Content;
+      Client_Handshake_Traffic_Secret : GreenTLS_Content;
       Client_Hello_1_Hash : Hash_Context;
-      Client_Hello_Handshake_Message : TLS_Handshake.Handshake;
-      Client_Shares : TLS_Handshake.Key_Share_Entries;
-      Configuration : GreenTLS.Configuration;
-      Connection : GreenTLS.Connection;
+      Client_Hello_Handshake_Message : TLS_Handshake_Handshake;
+      Client_Shares : TLS_Handshake_Key_Share_Entries;
+      Configuration : GreenTLS_Configuration;
+      Connection : GreenTLS_Connection;
       DHE_Accepted : Boolean := False;
-      Derived_Handshake_Secret : GreenTLS.Content;
+      Derived_Handshake_Secret : GreenTLS_Content;
       Early_Data_Received : Boolean := False;
-      Early_Secret : GreenTLS.Content;
-      Encrypted_Extensions_Handshake_Message : TLS_Handshake.Handshake;
-      Error : TLS_Alert.Alert_Description;
-      Extensions_List : TLS_Handshake.Extensions;
-      Finished_Key : GreenTLS.Content;
-      Finished_Handshake_Message : TLS_Handshake.Handshake;
-      Hash_Length : GreenTLS.KM_Length;
+      Early_Secret : GreenTLS_Content;
+      Encrypted_Extensions_Handshake_Message : TLS_Handshake_Handshake;
+      Error : TLS_Alert_Alert_Description;
+      Extensions_List : TLS_Handshake_Extensions;
+      Finished_Key : GreenTLS_Content;
+      Finished_Handshake_Message : TLS_Handshake_Handshake;
+      Hash_Length : GreenTLS_KM_Length;
       Heartbeat_Received : Boolean := False;
-      Identity_Index : TLS_Handshake.Identity_Index;
-      Keystore_Message : GreenTLS.Keystore_Message;
-      Max_Fragment_Length : TLS_Handshake.Max_Fragment_Length_Value;
+      Identity_Index : TLS_Handshake_Identity_Index;
+      Keystore_Message : GreenTLS_Keystore_Message;
+      Max_Fragment_Length : TLS_Handshake_Max_Fragment_Length_Value;
       Max_Fragment_Length_Received : Boolean := False;
-      OID_Filters : TLS_Handshake.OID_Filters;
+      OID_Filters : TLS_Handshake_OID_Filters;
       OID_Filters_Received : Boolean := False;
-      PSK_Identities : TLS_Handshake.PSK_Identities;
-      PSKs : GreenTLS.PSKs;
-      Post_Handshake_Handshake_Message : TLS_Handshake.Handshake;
-      Random_Message : GreenTLS.RNG_Message;
-      Pre_Shared_Key_CH : TLS_Handshake.Pre_Shared_Key_CH;
-      Resumption_Master_Secret : GreenTLS.Content;
+      PSK_Identities : TLS_Handshake_PSK_Identities;
+      PSKs : GreenTLS_PSKs;
+      Post_Handshake_Handshake_Message : TLS_Handshake_Handshake;
+      Random_Message : GreenTLS_RNG_Message;
+      Pre_Shared_Key_CH : TLS_Handshake_Pre_Shared_Key_CH;
+      Resumption_Master_Secret : GreenTLS_Content;
       Retry_Request_Received : Boolean := False;
-      Selected_Group : TLS_Handshake.Named_Group;
-      Server_Application_Traffic_Secret : GreenTLS.Content;
-      Server_Handshake_Traffic_Secret : GreenTLS.Content;
-      Server_Hello_Handshake_Message : TLS_Handshake.Handshake;
-      Server_Name_Extension : TLS_Handshake.Extension;
+      Selected_Group : TLS_Handshake_Named_Group;
+      Server_Application_Traffic_Secret : GreenTLS_Content;
+      Server_Handshake_Traffic_Secret : GreenTLS_Content;
+      Server_Hello_Handshake_Message : TLS_Handshake_Handshake;
+      Server_Name_Extension : TLS_Handshake_Extension;
       Server_Name_Received : Boolean := False;
-      Server_Preferred_Groups : TLS_Handshake.Supported_Groups;
-      Signature_Algorithms : TLS_Handshake.Signature_Algorithms;
-      Signature_Algorithms_Cert : TLS_Handshake.Signature_Algorithms;
+      Server_Preferred_Groups : TLS_Handshake_Supported_Groups;
+      Signature_Algorithms : TLS_Handshake_Signature_Algorithms;
+      Signature_Algorithms_Cert : TLS_Handshake_Signature_Algorithms;
       Signature_Algorithms_Cert_Received : Boolean := False;
       Signature_Algorithms_Received : Boolean := False;
       Success : Boolean;
-      Supported_Groups : TLS_Handshake.Named_Groups;
+      Supported_Groups : TLS_Handshake_Named_Groups;
       Supported_Groups_Received : Boolean := False;
       Transcript_Hash : Hash_Context;
-      GreenTLS : Dummy;
-      TLS_Handshake : Dummy;
-      TLS_Alert : Dummy;
-      FIXME_NULL : Dummy;
-      FIXME : Dummy;
 
-      Certificate_Message : TLS_Handshake.Certificate renames CCR_Handshake_Message.Payload;
-      Certificate_Request_Message : TLS_Handshake.Certificate_Request renames CCR_Handshake_Message.Payload;
-      Certificate_Verify_Message : TLS_Handshake.Certificate_Verify renames Certificate_Verify_Handshake_Message.Payload;
-      Client_Hello_Message : TLS_Handshake.Client_Hello renames Client_Hello_Handshake_Message.Payload;
-      Encrypted_Extensions_Message : TLS_Handshake.Encrypted_Extensions renames Encrypted_Extensions_Handshake_Message.Payload;
-      Finished_Message : TLS_Handshake.Finished renames Finished_Handshake_Message.Payload;
-      Key_Update_Message : TLS_Handshake.Key_Update renames Post_Handshake_Handshake_Message.Payload;
-      New_Session_Ticket_Message : TLS_Handshake.New_Session_Ticket renames Post_Handshake_Handshake_Message.Payload;
-      PHA_Certificate_Request_Message : TLS_Handshake.Certificate_Request renames Post_Handshake_Handshake_Message.Payload;
-      Server_Hello_Message : TLS_Handshake.Server_Hello renames Server_Hello_Handshake_Message.Payload;
+      Certificate_Message : TLS_Handshake_Certificate renames CCR_Handshake_Message.Payload;
+      Certificate_Request_Message : TLS_Handshake_Certificate_Request renames CCR_Handshake_Message.Payload;
+      Certificate_Verify_Message : TLS_Handshake_Certificate_Verify renames Certificate_Verify_Handshake_Message.Payload;
+      Client_Hello_Message : TLS_Handshake_Client_Hello renames Client_Hello_Handshake_Message.Payload;
+      Encrypted_Extensions_Message : TLS_Handshake_Encrypted_Extensions renames Encrypted_Extensions_Handshake_Message.Payload;
+      Finished_Message : TLS_Handshake_Finished renames Finished_Handshake_Message.Payload;
+      Key_Update_Message : TLS_Handshake_Key_Update renames Post_Handshake_Handshake_Message.Payload;
+      New_Session_Ticket_Message : TLS_Handshake_New_Session_Ticket renames Post_Handshake_Handshake_Message.Payload;
+      PHA_Certificate_Request_Message : TLS_Handshake_Certificate_Request renames Post_Handshake_Handshake_Message.Payload;
+      Server_Hello_Message : TLS_Handshake_Server_Hello renames Server_Hello_Handshake_Message.Payload;
    begin
       state START is
       begin
@@ -121,18 +216,18 @@ package TLS_Handshake_Session is
 
       state SERVER_PREFERRED_GROUPS is
       begin
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_SERVER_PREFERRED_GROUPS));
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_SERVER_PREFERRED_GROUPS));
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
-               or Keystore_Message.Tag /= GreenTLS.KEYSTORE_RESPONSE
-               or Keystore_Message.Request /= GreenTLS.KEYSTORE_REQUEST_SERVER_PREFERRED_GROUPS
+               or Keystore_Message.Tag /= GreenTLS_KEYSTORE_RESPONSE
+               or Keystore_Message.Request /= GreenTLS_KEYSTORE_REQUEST_SERVER_PREFERRED_GROUPS
          then SERVER_PREFERRED_GROUPS_CONFIGURE
       end SERVER_PREFERRED_GROUPS;
 
       state SERVER_PREFERRED_GROUPS_CONFIGURE is
       begin
-         Server_Preferred_Groups := TLS_Handshake.Supported_Groups (Keystore_Message.Payload);
+         Server_Preferred_Groups := TLS_Handshake_Supported_Groups (Keystore_Message.Payload);
       transition
          then ERROR_INTERNAL_ERROR
             if Server_Preferred_Groups'Valid = False
@@ -147,11 +242,11 @@ package TLS_Handshake_Session is
       end SERVER_PREFERRED_GROUPS_SELECT;
 
       state CREATE_CLIENT_HELLO_EXTENSIONS is
-         Supported_Version : TLS_Handshake.Supported_Version;
-         Supported_Versions_Extension : TLS_Handshake.CH_Extension;
+         Supported_Version : TLS_Handshake_Supported_Version;
+         Supported_Versions_Extension : TLS_Handshake_CH_Extension;
       begin
-         Supported_Version := TLS_Handshake.Supported_Version'(Version => TLS_Handshake.TLS_1_3);
-         Supported_Versions_Extension := TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_SUPPORTED_VERSIONS, Data_Length => Supported_Version'Length, Data => Supported_Version);
+         Supported_Version := TLS_Handshake_Supported_Version'(Version => TLS_Handshake_TLS_1_3);
+         Supported_Versions_Extension := TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_SUPPORTED_VERSIONS, Data_Length => Supported_Version'Length, Data => Supported_Version);
          Extensions_List := Append (Extensions_List, Supported_Versions_Extension);
          Extensions_List := Extend (Extensions_List, Create_Client_Hello_Extensions (Configuration));
       transition
@@ -160,40 +255,40 @@ package TLS_Handshake_Session is
          then START_POST_HANDSHAKE_AUTH_EXTENSION
             if Configuration.Post_Handshake_Auth_Enabled = True
          then START_DHE
-            if TLS_Handshake.PSK_DHE_KE in Configuration.PSK_Key_Exchange_Modes
+            if TLS_Handshake_PSK_DHE_KE in Configuration.PSK_Key_Exchange_Modes
          then START_PSK
-            if TLS_Handshake.PSK_KE in Configuration.PSK_Key_Exchange_Modes
+            if TLS_Handshake_PSK_KE in Configuration.PSK_Key_Exchange_Modes
          then ERROR_INTERNAL_ERROR
       end CREATE_CLIENT_HELLO_EXTENSIONS;
 
       state START_POST_HANDSHAKE_AUTH_EXTENSION is
-         Post_Handshake_Auth_Extension : TLS_Handshake.CH_Extension;
+         Post_Handshake_Auth_Extension : TLS_Handshake_CH_Extension;
       begin
-         Post_Handshake_Auth_Extension := TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_POST_HANDSHAKE_AUTH, Data_Length => 0);
+         Post_Handshake_Auth_Extension := TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_POST_HANDSHAKE_AUTH, Data_Length => 0);
          Extensions_List := Append (Extensions_List, Post_Handshake_Auth_Extension);
       transition
          then ERROR_INTERNAL_ERROR
             if Extensions_List'Valid = False
          then START_DHE
-            if TLS_Handshake.PSK_DHE_KE in Configuration.PSK_Key_Exchange_Modes
+            if TLS_Handshake_PSK_DHE_KE in Configuration.PSK_Key_Exchange_Modes
          then START_PSK
-            if TLS_Handshake.PSK_KE in Configuration.PSK_Key_Exchange_Modes
+            if TLS_Handshake_PSK_KE in Configuration.PSK_Key_Exchange_Modes
          then ERROR_INTERNAL_ERROR
       end START_POST_HANDSHAKE_AUTH_EXTENSION;
 
       state START_DHE is
-         Supported_Groups_Extension : TLS_Handshake.CH_Extension;
-         Key_Share_Extension : TLS_Handshake.CH_Extension;
-         Signature_Algorithms_Extension : TLS_Handshake.CH_Extension;
+         Supported_Groups_Extension : TLS_Handshake_CH_Extension;
+         Key_Share_Extension : TLS_Handshake_CH_Extension;
+         Signature_Algorithms_Extension : TLS_Handshake_CH_Extension;
       begin
-         Supported_Groups_Extension := TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_SUPPORTED_GROUPS, Data_Length => Modes'Length, Data => Modes)
-            where Modes = TLS_Handshake.Supported_Groups'(Length => Configuration.Supported_Groups_Length, Groups => Configuration.Supported_Groups);
+         Supported_Groups_Extension := TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_SUPPORTED_GROUPS, Data_Length => Modes'Length, Data => Modes)
+            where Modes = TLS_Handshake_Supported_Groups'(Length => Configuration.Supported_Groups_Length, Groups => Configuration.Supported_Groups);
          Extensions_List := Append (Extensions_List, Supported_Groups_Extension);
-         Key_Share_Extension := TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_KEY_SHARE, Data_Length => Modes'Length, Data => Modes)
-            where Modes = TLS_Handshake.Key_Share'(Length => Configuration.Key_Shares_Length, Shares => Configuration.Key_Shares);
+         Key_Share_Extension := TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_KEY_SHARE, Data_Length => Modes'Length, Data => Modes)
+            where Modes = TLS_Handshake_Key_Share'(Length => Configuration.Key_Shares_Length, Shares => Configuration.Key_Shares);
          Extensions_List := Append (Extensions_List, Key_Share_Extension);
-         Signature_Algorithms_Extension := TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS, Data_Length => Modes'Length, Data => Modes)
-            where Modes = TLS_Handshake.Signature_Algorithms'(Length => Configuration.Signature_Algorithms_Length, Algorithms => Configuration.Signature_Algorithms);
+         Signature_Algorithms_Extension := TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS, Data_Length => Modes'Length, Data => Modes)
+            where Modes = TLS_Handshake_Signature_Algorithms'(Length => Configuration.Signature_Algorithms_Length, Algorithms => Configuration.Signature_Algorithms);
          Extensions_List := Append (Extensions_List, Signature_Algorithms_Extension);
       transition
          then ERROR_INTERNAL_ERROR
@@ -201,34 +296,34 @@ package TLS_Handshake_Session is
          then START_DHE_SIGNATURE_ALGORITHMS
             if Configuration.Server_Authentication_Enabled = True
          then START_PSK
-            if TLS_Handshake.PSK_KE in Configuration.PSK_Key_Exchange_Modes
+            if TLS_Handshake_PSK_KE in Configuration.PSK_Key_Exchange_Modes
          then START_SEND
       end START_DHE;
 
       state START_DHE_SIGNATURE_ALGORITHMS is
-         Signature_Algorithms_Cert_Extension : TLS_Handshake.CH_Extension;
+         Signature_Algorithms_Cert_Extension : TLS_Handshake_CH_Extension;
       begin
-         Signature_Algorithms_Cert_Extension := TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS_CERT, Data_Length => Modes'Length, Data => Modes)
-            where Modes = TLS_Handshake.Signature_Algorithms_Cert'(Length => Configuration.Signature_Algorithms_Cert_Length, Algorithms => Configuration.Signature_Algorithms_Cert);
+         Signature_Algorithms_Cert_Extension := TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS_CERT, Data_Length => Modes'Length, Data => Modes)
+            where Modes = TLS_Handshake_Signature_Algorithms_Cert'(Length => Configuration.Signature_Algorithms_Cert_Length, Algorithms => Configuration.Signature_Algorithms_Cert);
          Extensions_List := Append (Extensions_List, Signature_Algorithms_Cert_Extension);
       transition
          then ERROR_INTERNAL_ERROR
             if Extensions_List'Valid = False
          then START_PSK
-            if TLS_Handshake.PSK_KE in Configuration.PSK_Key_Exchange_Modes
+            if TLS_Handshake_PSK_KE in Configuration.PSK_Key_Exchange_Modes
          then START_SEND
       end START_DHE_SIGNATURE_ALGORITHMS;
 
       state START_PSK is
       begin
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_PSKS, Length => Connection'Length, Payload => Connection));
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_PSKS, Length => Connection'Length, Payload => Connection));
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
-               or Keystore_Message.Tag /= GreenTLS.KEYSTORE_RESPONSE
-               or Keystore_Message.Request /= GreenTLS.KEYSTORE_REQUEST_PSK_IDENTITIES
+               or Keystore_Message.Tag /= GreenTLS_KEYSTORE_RESPONSE
+               or Keystore_Message.Request /= GreenTLS_KEYSTORE_REQUEST_PSK_IDENTITIES
                or (Keystore_Message.Length = 0
-                   and TLS_Handshake.PSK_DHE_KE not in Configuration.PSK_Key_Exchange_Modes)
+                   and TLS_Handshake_PSK_DHE_KE not in Configuration.PSK_Key_Exchange_Modes)
          then START_SEND
             if Keystore_Message.Length = 0
          then START_PSK_EXTENSION_CHECK
@@ -236,10 +331,10 @@ package TLS_Handshake_Session is
 
       state START_PSK_EXTENSION_CHECK is
       begin
-         PSKs := GreenTLS.PSK_Message (Keystore_Message.Payload).PSKs;
+         PSKs := GreenTLS_PSK_Message (Keystore_Message.Payload).PSKs;
          Binders_Length := Calculate_Binders_Length (PSKs);
          PSK_Identities := [for K in PSKs => K.Identity when True];
-         Pre_Shared_Key_CH := TLS_Handshake.Pre_Shared_Key_CH'(Identities_Length => PSK_Identities'Length, Identities => PSK_Identities, Binders_Length => Binders_Length, Binders => FIXME_NULL);
+         Pre_Shared_Key_CH := TLS_Handshake_Pre_Shared_Key_CH'(Identities_Length => PSK_Identities'Length, Identities => PSK_Identities, Binders_Length => Binders_Length, Binders => FIXME_NULL);
       transition
          then ERROR_INTERNAL_ERROR
             if Pre_Shared_Key_CH'Valid = False
@@ -248,31 +343,31 @@ package TLS_Handshake_Session is
 
       state START_GET_RANDOM is
       begin
-         Random_Message := Call (RNG_Channel, GreenTLS.RNG_Message'(Tag => GreenTLS.RNG_REQUEST, Length => 32));
+         Random_Message := Call (RNG_Channel, GreenTLS_RNG_Message'(Tag => GreenTLS_RNG_REQUEST, Length => 32));
       transition
          then ERROR_INTERNAL_ERROR
             if Random_Message'Valid = False
-               or Random_Message.Tag /= GreenTLS.RNG_RESPONSE
+               or Random_Message.Tag /= GreenTLS_RNG_RESPONSE
                or Random_Message.Length /= 32
          then START_PSK_EXTENSIONS
       end START_GET_RANDOM;
 
       state START_PSK_EXTENSIONS is
-         PSK_Key_Exchange_Modes_Extension : TLS_Handshake.CH_Extension;
+         PSK_Key_Exchange_Modes_Extension : TLS_Handshake_CH_Extension;
          Client_Hello_Hash : Hash_Context;
       begin
-         PSK_Key_Exchange_Modes_Extension := TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_PSK_KEY_EXCHANGE_MODES, Data_Length => Modes'Length, Data => Modes)
-            where Modes = TLS_Handshake.PSK_Key_Exchange_Modes'(Length => Configuration.PSK_Key_Exchange_Modes_Length, Modes => Configuration.PSK_Key_Exchange_Modes);
+         PSK_Key_Exchange_Modes_Extension := TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_PSK_KEY_EXCHANGE_MODES, Data_Length => Modes'Length, Data => Modes)
+            where Modes = TLS_Handshake_PSK_Key_Exchange_Modes'(Length => Configuration.PSK_Key_Exchange_Modes_Length, Modes => Configuration.PSK_Key_Exchange_Modes);
          Extensions_List := Append (Extensions_List, PSK_Key_Exchange_Modes_Extension);
-         Extensions_List := Append (Extensions_List, TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_PRE_SHARED_KEY, Length => Pre_Shared_Key_CH'Length, Data => Pre_Shared_Key_CH));
-         Client_Hello_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CLIENT_HELLO, Length => CH'Length, Payload => CH)
-            where CH = TLS_Handshake.Client_Hello'(Legacy_Version => TLS_Handshake.TLS_1_2, Random => Random_Message.Data, Legacy_Session_ID_Length => 0, Cipher_Suites_Length => Configuration.Cipher_Suites'Length, Cipher_Suites => Configuration.Cipher_Suites, Legacy_Compression_Methods_Length => 0, Extensions_Length => Extensions_List'Length, Extensions => Extensions_List);
+         Extensions_List := Append (Extensions_List, TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_PRE_SHARED_KEY, Length => Pre_Shared_Key_CH'Length, Data => Pre_Shared_Key_CH));
+         Client_Hello_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CLIENT_HELLO, Length => CH'Length, Payload => CH)
+            where CH = TLS_Handshake_Client_Hello'(Legacy_Version => TLS_Handshake_TLS_1_2, Random => Random_Message.Data, Legacy_Session_ID_Length => 0, Cipher_Suites_Length => Configuration.Cipher_Suites'Length, Cipher_Suites => Configuration.Cipher_Suites, Legacy_Compression_Methods_Length => 0, Extensions_Length => Extensions_List'Length, Extensions => Extensions_List);
          Client_Hello_Hash := Empty_Hash;
          Client_Hello_Hash := Update_Hash (Client_Hello_Hash, Truncate_Client_Hello (Client_Hello_Handshake_Message)'Opaque);
          Binders := Calculate_Binders (PSKs, Get_Hash (Client_Hello_Hash));
-         Extensions_List := [for E in Extensions_List => E when E.Tag /= TLS_Handshake.EXTENSION_PRE_SHARED_KEY];
-         Extensions_List := Append (Extensions_List, TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_PRE_SHARED_KEY, Length => PSK_CH'Length, Data => PSK_CH)
-            where PSK_CH = TLS_Handshake.Pre_Shared_Key_CH'(Identities_Length => PSK_Identities'Length, Identities => PSK_Identities, Binders_Length => Binders_Length, Binders => Binders));
+         Extensions_List := [for E in Extensions_List => E when E.Tag /= TLS_Handshake_EXTENSION_PRE_SHARED_KEY];
+         Extensions_List := Append (Extensions_List, TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_PRE_SHARED_KEY, Length => PSK_CH'Length, Data => PSK_CH)
+            where PSK_CH = TLS_Handshake_Pre_Shared_Key_CH'(Identities_Length => PSK_Identities'Length, Identities => PSK_Identities, Binders_Length => Binders_Length, Binders => Binders));
       transition
          then ERROR_INTERNAL_ERROR
             if Extensions_List'Valid = False
@@ -286,7 +381,7 @@ package TLS_Handshake_Session is
          Client_Hello_1_Hash := Update_Hash (Client_Hello_1_Hash, Truncate_Client_Hello (Client_Hello_Handshake_Message)'Opaque);
          Transcript_Hash := Empty_Hash;
          Transcript_Hash := Update_Hash (Transcript_Hash, Client_Hello_Handshake_Message'Opaque);
-         Client_Hello_Message := Handshake.Client_Hello (Client_Hello_Handshake_Message.Payload);
+         Client_Hello_Message := TLS_Handshake_Client_Hello (Client_Hello_Handshake_Message.Payload);
       transition
          then ERROR_INTERNAL_ERROR
             if Success = False
@@ -296,17 +391,17 @@ package TLS_Handshake_Session is
       end START_SEND;
 
       state START_SEND_CLIENT_EARLY_TRAFFIC_SECRET is
-         Client_Early_Traffic_Secret : GreenTLS.Content;
-         Client_Key : GreenTLS.Content;
-         Client_IV : GreenTLS.Content;
+         Client_Early_Traffic_Secret : GreenTLS_Content;
+         Client_Key : GreenTLS_Content;
+         Client_IV : GreenTLS_Content;
       begin
-         Early_Secret := HKDF_Extract (Get_Zero_Content (Get_Hash_Length (PSKs'Head.Cipher_Suite)), GreenTLS.Content'(Data => PSKs'Head.Key));
+         Early_Secret := HKDF_Extract (Get_Zero_Content (Get_Hash_Length (PSKs'Head.Cipher_Suite)), GreenTLS_Content'(Data => PSKs'Head.Key));
          Client_Early_Traffic_Secret := Derive_Secret (Early_Secret.Data, "c e traffic", Get_Hash (Transcript_Hash));
-         Client_Key := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Early_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
-         Client_IV := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Early_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
+         Client_Key := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Early_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
+         Client_IV := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Early_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
          Keystore_Message := null;
-         Success := Write (Record_Data_Channel, GreenTLS.Control_Message'(Tag => GreenTLS.KEY_UPDATE_CLIENT, Length => KU'Length, Payload => KU)
-            where KU = GreenTLS.Key_Update_Message'(Key_Length => Client_Key'Length, Key => Client_Key.Data, IV_Length => Client_IV'Length, IV => Client_IV.Data));
+         Success := Write (Record_Data_Channel, GreenTLS_Control_Message'(Tag => GreenTLS_KEY_UPDATE_CLIENT, Length => KU'Length, Payload => KU)
+            where KU = GreenTLS_Key_Update_Message'(Key_Length => Client_Key'Length, Key => Client_Key.Data, IV_Length => Client_IV'Length, IV => Client_IV.Data));
          Client_Early_Traffic_Secret := null;
          Client_Key := null;
          Client_IV := null;
@@ -324,11 +419,11 @@ package TLS_Handshake_Session is
          then ERROR_DECODE_ERROR
             if Server_Hello_Handshake_Message'Valid = False
          then ERROR_UNEXPECTED_MESSAGE
-            if Server_Hello_Handshake_Message.Tag /= TLS_Handshake.HANDSHAKE_SERVER_HELLO
+            if Server_Hello_Handshake_Message.Tag /= TLS_Handshake_HANDSHAKE_SERVER_HELLO
          then ERROR_DECODE_ERROR
             if Server_Hello_Message'Valid = False
          then ERROR_PROTOCOL_VERSION
-            if Server_Hello_Message.Legacy_Version /= GreenTLS.TLS_1_2
+            if Server_Hello_Message.Legacy_Version /= GreenTLS_TLS_1_2
          then ERROR_ILLEGAL_PARAMETER
             if Server_Hello_Message.Legacy_Session_Id_Echo /= 0
                or Server_Hello_Message.Legacy_Compression_Method /= 0
@@ -336,18 +431,18 @@ package TLS_Handshake_Session is
             if Server_Hello_Message.Cipher_Suite not in Client_Hello_Message.Cipher_Suites
          then ERROR_MISSING_EXTENSION
             if (for all E in Server_Hello_Message.Extensions =>
-                   E.Tag /= TLS_Handshake.EXTENSION_SUPPORTED_VERSIONS)
+                   E.Tag /= TLS_Handshake_EXTENSION_SUPPORTED_VERSIONS)
          then ERROR_ILLEGAL_PARAMETER
             if (for some E in Server_Hello_Message.Extensions =>
-                   E.Tag = TLS_Handshake.EXTENSION_SUPPORTED_VERSIONS
-                   and GreenTLS.TLS_1_3 not in TLS_Handshake.Supported_Versions (E.Data).Versions)
+                   E.Tag = TLS_Handshake_EXTENSION_SUPPORTED_VERSIONS
+                   and GreenTLS_TLS_1_3 not in TLS_Handshake_Supported_Versions (E.Data).Versions)
          then ERROR_ILLEGAL_PARAMETER
             if (for some E in Server_Hello_Message.Extensions =>
                    E not in Client_Hello_Message.Extensions)
          then ERROR_ILLEGAL_PARAMETER
-            if TLS_Handshake.PSK_DHE_KE not in Configuration.PSK_Key_Exchange_Modes
+            if TLS_Handshake_PSK_DHE_KE not in Configuration.PSK_Key_Exchange_Modes
                and (for some E in Server_Hello_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE)
+                       E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE)
          then WAIT_SH_PARSE_HRR
             if Server_Hello_Message.HRR_Extensions'Present
                and Retry_Request_Received = False
@@ -356,94 +451,94 @@ package TLS_Handshake_Session is
                and Retry_Request_Received = True
          then WAIT_SH_EXTENSIONS_PSK
             if (for some E in Server_Hello_Message.Extensions =>
-                   E.Tag = TLS_Handshake.EXTENSION_PRE_SHARED_KEY)
+                   E.Tag = TLS_Handshake_EXTENSION_PRE_SHARED_KEY)
          then WAIT_SH_EXTENSIONS_DHE
             if (for some E in Server_Hello_Message.Extensions =>
-                   E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE)
+                   E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE)
          then ERROR_INVALID_CONFIGURATION
       end WAIT_SH;
 
       state WAIT_SH_EXTENSIONS_PSK is
       begin
-         Identity_Index := TLS_Handshake.Pre_Shared_Key_SH ([for E in Server_Hello_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_PRE_SHARED_KEY]'Head.Data).Selected_Identity;
+         Identity_Index := TLS_Handshake_Pre_Shared_Key_SH ([for E in Server_Hello_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_PRE_SHARED_KEY]'Head.Data).Selected_Identity;
       transition
          then ERROR_ILLEGAL_PARAMETER
             if Identity_Index /= 0
                and (for some E in Server_Hello_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_EARLY_DATA)
+                       E.Tag = TLS_Handshake_EXTENSION_EARLY_DATA)
          then ERROR_ILLEGAL_PARAMETER
             if (for some E in Client_Hello_Message.Extensions =>
-                   E.Tag = TLS_Handshake.EXTENSION_PRE_SHARED_KEY
-                   and TLS_Handshake.Pre_Shared_Key_CH (E.Data).Identities'Length < Identity_Index)
+                   E.Tag = TLS_Handshake_EXTENSION_PRE_SHARED_KEY
+                   and TLS_Handshake_Pre_Shared_Key_CH (E.Data).Identities'Length < Identity_Index)
          then WAIT_SH_EXTENSIONS_PSK_REQUEST
       end WAIT_SH_EXTENSIONS_PSK;
 
       state WAIT_SH_EXTENSIONS_PSK_REQUEST is
       begin
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_PSKS, Length => Selected_Identity'Length, Payload => Selected_Identity)
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_PSKS, Length => Selected_Identity'Length, Payload => Selected_Identity)
             where Selected_Identity = FIXME);
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
-               or Keystore_Message.Tag /= GreenTLS.KEYSTORE_RESPONSE
-               or Keystore_Message.Request /= GreenTLS.KEYSTORE_REQUEST_PSK
-               or GreenTLS.PSK (Keystore_Message.Payload)'Valid = False
+               or Keystore_Message.Tag /= GreenTLS_KEYSTORE_RESPONSE
+               or Keystore_Message.Request /= GreenTLS_KEYSTORE_REQUEST_PSK
+               or GreenTLS_PSK (Keystore_Message.Payload)'Valid = False
          then WAIT_SH_EXTENSIONS_PSK_VALIDATION
       end WAIT_SH_EXTENSIONS_PSK_REQUEST;
 
       state WAIT_SH_EXTENSIONS_PSK_VALIDATION is
-         Identity_Cipher_Suite : TLS_Handshake.Cipher_Suite;
+         Identity_Cipher_Suite : TLS_Handshake_Cipher_Suite;
       begin
-         Identity_Cipher_Suite := GreenTLS.PSK (Keystore_Message.Payload).Cipher_Suite;
+         Identity_Cipher_Suite := GreenTLS_PSK (Keystore_Message.Payload).Cipher_Suite;
       transition
          then ERROR_ILLEGAL_PARAMETER
             if Identity_Cipher_Suite /= Server_Hello_Message.Cipher_Suite
          then WAIT_SH_EXTENSIONS_DHE
             if (for some E in Server_Hello_Message.Extensions =>
-                   E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE)
+                   E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE)
          then SET_RECORD_KEYS
       end WAIT_SH_EXTENSIONS_PSK_VALIDATION;
 
       state WAIT_SH_EXTENSIONS_DHE is
       begin
-         Selected_Group := TLS_Handshake.Key_Share_SH ([for E in Server_Hello_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE]'Head.Data).Group;
+         Selected_Group := TLS_Handshake_Key_Share_SH ([for E in Server_Hello_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE]'Head.Data).Group;
          DHE_Accepted := True;
       transition
          then ERROR_ILLEGAL_PARAMETER
-            if (for some S in TLS_Handshake.Key_Share_CH ([for E in Client_Hello_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE]'Head.Data).Shares =>
+            if (for some S in TLS_Handshake_Key_Share_CH ([for E in Client_Hello_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE]'Head.Data).Shares =>
                    S.Group = Selected_Group) = False
          then SET_RECORD_KEYS
       end WAIT_SH_EXTENSIONS_DHE;
 
       state WAIT_SH_PARSE_HRR is
-         Client_Supported_Groups : TLS_Handshake.Named_Groups;
+         Client_Supported_Groups : TLS_Handshake_Named_Groups;
       begin
          Retry_Request_Received := True;
-         Client_Supported_Groups := TLS_Handshake.Supported_Groups ([for E in Client_Hello_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_SUPPORTED_GROUPS]'Head.Data).Groups;
-         Client_Shares := TLS_Handshake.Key_Share_CH ([for E in Client_Hello_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE]'Head.Data).Shares;
+         Client_Supported_Groups := TLS_Handshake_Supported_Groups ([for E in Client_Hello_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_SUPPORTED_GROUPS]'Head.Data).Groups;
+         Client_Shares := TLS_Handshake_Key_Share_CH ([for E in Client_Hello_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE]'Head.Data).Shares;
       transition
          then ERROR_ILLEGAL_PARAMETER
             if (for some E in Server_Hello_Message.Extensions =>
                    E not in Client_Hello_Message.Extensions
-                   and E.Tag /= TLS_Handshake.EXTENSION_COOKIE)
+                   and E.Tag /= TLS_Handshake_EXTENSION_COOKIE)
          then ERROR_ILLEGAL_PARAMETER
             if (for some E in Server_Hello_Message.Extensions =>
-                   E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE
-                   and TLS_Handshake.Key_Share_HRR (E.Data).Selected_Group not in Client_Supported_Groups)
+                   E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE
+                   and TLS_Handshake_Key_Share_HRR (E.Data).Selected_Group not in Client_Supported_Groups)
          then ERROR_ILLEGAL_PARAMETER
             if (for some E in Server_Hello_Message.Extensions =>
-                   E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE
+                   E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE
                    and (for some S in Client_Shares =>
-                           S.Group = TLS_Handshake.Key_Share_HRR (E.Data).Selected_Group))
+                           S.Group = TLS_Handshake_Key_Share_HRR (E.Data).Selected_Group))
          then WAIT_SH_PREPARE_CH
       end WAIT_SH_PARSE_HRR;
 
       state WAIT_SH_PREPARE_CH is
       begin
          Extensions_List'Reset;
-         Extensions_List := Extend (Extensions_List, [for E in Client_Hello_Message.Extensions => E when E.Tag /= TLS_Handshake.EXTENSION_KEY_SHARE
-         and E.Tag /= TLS_Handshake.EXTENSION_EARLY_DATA
-         and E.Tag /= TLS_Handshake.EXTENSION_PRE_SHARED_KEY]);
+         Extensions_List := Extend (Extensions_List, [for E in Client_Hello_Message.Extensions => E when E.Tag /= TLS_Handshake_EXTENSION_KEY_SHARE
+         and E.Tag /= TLS_Handshake_EXTENSION_EARLY_DATA
+         and E.Tag /= TLS_Handshake_EXTENSION_PRE_SHARED_KEY]);
       transition
          then WAIT_SH_PREPARE_CH_DISPATCH
       end WAIT_SH_PREPARE_CH;
@@ -454,22 +549,22 @@ package TLS_Handshake_Session is
          then WAIT_SH_PREPARE_CH_KEY_SHARE
             if CH_Key_Share_Prepared = False
                and (for some E in Server_Hello_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE)
+                       E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE)
          then WAIT_SH_PREPARE_CH_COOKIE
             if CH_Cookie_Prepared = False
                and (for some E in Server_Hello_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_COOKIE)
+                       E.Tag = TLS_Handshake_EXTENSION_COOKIE)
          then WAIT_SH_PREPARE_CH_PSK
             if CH_PSK_Prepared = False
                and (for some E in Server_Hello_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_PRE_SHARED_KEY)
+                       E.Tag = TLS_Handshake_EXTENSION_PRE_SHARED_KEY)
          then WAIT_SH_SEND_CH
       end WAIT_SH_PREPARE_CH_DISPATCH;
 
       state WAIT_SH_PREPARE_CH_KEY_SHARE is
       begin
-         Extensions_List := Append (Extensions_List, TLS_Handshake.Extension'(Tag => TLS_Handshake.EXTENSION_KEY_SHARE, Data_Length => Key_Share'Length, Data => Key_Share)
-            where Key_Share = TLS_Handshake.Key_Share_CH'(Length => Entries'Length, Shares => Entries)
+         Extensions_List := Append (Extensions_List, TLS_Handshake_Extension'(Tag => TLS_Handshake_EXTENSION_KEY_SHARE, Data_Length => Key_Share'Length, Data => Key_Share)
+            where Key_Share = TLS_Handshake_Key_Share_CH'(Length => Entries'Length, Shares => Entries)
                      where Entries = [for E in Client_Shares => E when E.Group = Selected_Group]);
          CH_Key_Share_Prepared := True;
       transition
@@ -478,7 +573,7 @@ package TLS_Handshake_Session is
 
       state WAIT_SH_PREPARE_CH_COOKIE is
       begin
-         Extensions_List := Append (Extensions_List, [for E in Server_Hello_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_COOKIE]'Head);
+         Extensions_List := Append (Extensions_List, [for E in Server_Hello_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_COOKIE]'Head);
          CH_Cookie_Prepared := True;
       transition
          then WAIT_SH_PREPARE_CH_DISPATCH
@@ -486,15 +581,15 @@ package TLS_Handshake_Session is
 
       state WAIT_SH_PREPARE_CH_PSK is
       begin
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_PSKS, Length => Connection'Length, Payload => Connection));
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_PSKS, Length => Connection'Length, Payload => Connection));
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
-               or Keystore_Message.Tag /= GreenTLS.KEYSTORE_RESPONSE
-               or Keystore_Message.Request /= GreenTLS.KEYSTORE_REQUEST_PSKS
+               or Keystore_Message.Tag /= GreenTLS_KEYSTORE_RESPONSE
+               or Keystore_Message.Request /= GreenTLS_KEYSTORE_REQUEST_PSKS
                or (Keystore_Message.Length = 0
-                   and TLS_Handshake.PSK_DHE_KE not in Configuration.PSK_Key_Exchange_Modes)
-               or GreenTLS.PSK_Message (Keystore_Message.Payload)'Valid = False
+                   and TLS_Handshake_PSK_DHE_KE not in Configuration.PSK_Key_Exchange_Modes)
+               or GreenTLS_PSK_Message (Keystore_Message.Payload)'Valid = False
          then WAIT_SH_NO_PSK_EXTENSION
             if Keystore_Message.Length = 0
          then WAIT_SH_PSK_EXTENSION_CHECK
@@ -502,10 +597,10 @@ package TLS_Handshake_Session is
 
       state WAIT_SH_PSK_EXTENSION_CHECK is
       begin
-         PSKs := [for K in GreenTLS.PSK_Message (Keystore_Message.Payload).PSKs => K when K.Cipher_Suite = Server_Hello_Message.Cipher_Suite];
+         PSKs := [for K in GreenTLS_PSK_Message (Keystore_Message.Payload).PSKs => K when K.Cipher_Suite = Server_Hello_Message.Cipher_Suite];
          Binders_Length := Calculate_Binders_Length (PSKs);
          PSK_Identities := [for K in PSKs => K.Identity when True];
-         Pre_Shared_Key_CH := TLS_Handshake.Pre_Shared_Key_CH'(Identities_Length => PSK_Identities'Length, Identities => PSK_Identities, Binders_Length => Binders_Length, Binders => FIXME_NULL);
+         Pre_Shared_Key_CH := TLS_Handshake_Pre_Shared_Key_CH'(Identities_Length => PSK_Identities'Length, Identities => PSK_Identities, Binders_Length => Binders_Length, Binders => FIXME_NULL);
       transition
          then ERROR_INTERNAL_ERROR
             if Pre_Shared_Key_CH'Valid = False
@@ -513,21 +608,21 @@ package TLS_Handshake_Session is
       end WAIT_SH_PSK_EXTENSION_CHECK;
 
       state WAIT_SH_PSK_EXTENSIONS is
-         PSK_Key_Exchange_Modes_Extension : TLS_Handshake.CH_Extension;
+         PSK_Key_Exchange_Modes_Extension : TLS_Handshake_CH_Extension;
          Client_Hello_Hash : Hash_Context;
       begin
-         PSK_Key_Exchange_Modes_Extension := TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_PSK_KEY_EXCHANGE_MODES, Data_Length => Modes'Length, Data => Modes)
-            where Modes = TLS_Handshake.PSK_Key_Exchange_Modes'(Length => Configuration.PSK_Key_Exchange_Modes_Length, Modes => Configuration.PSK_Key_Exchange_Modes);
+         PSK_Key_Exchange_Modes_Extension := TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_PSK_KEY_EXCHANGE_MODES, Data_Length => Modes'Length, Data => Modes)
+            where Modes = TLS_Handshake_PSK_Key_Exchange_Modes'(Length => Configuration.PSK_Key_Exchange_Modes_Length, Modes => Configuration.PSK_Key_Exchange_Modes);
          Extensions_List := Append (Extensions_List, PSK_Key_Exchange_Modes_Extension);
-         Extensions_List := Append (Extensions_List, TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_PRE_SHARED_KEY, Length => Pre_Shared_Key_CH'Length, Data => Pre_Shared_Key_CH));
-         Client_Hello_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CLIENT_HELLO, Length => CH'Length, Payload => CH)
-            where CH = TLS_Handshake.Client_Hello'(Legacy_Version => TLS_Handshake.TLS_1_2, Random => Random_Message.Data, Legacy_Session_ID_Length => 0, Cipher_Suites_Length => Configuration.Cipher_Suites'Length, Cipher_Suites => Configuration.Cipher_Suites, Legacy_Compression_Methods_Length => 0, Extensions_Length => Extensions_List'Length, Extensions => Extensions_List);
+         Extensions_List := Append (Extensions_List, TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_PRE_SHARED_KEY, Length => Pre_Shared_Key_CH'Length, Data => Pre_Shared_Key_CH));
+         Client_Hello_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CLIENT_HELLO, Length => CH'Length, Payload => CH)
+            where CH = TLS_Handshake_Client_Hello'(Legacy_Version => TLS_Handshake_TLS_1_2, Random => Random_Message.Data, Legacy_Session_ID_Length => 0, Cipher_Suites_Length => Configuration.Cipher_Suites'Length, Cipher_Suites => Configuration.Cipher_Suites, Legacy_Compression_Methods_Length => 0, Extensions_Length => Extensions_List'Length, Extensions => Extensions_List);
          Client_Hello_Hash := Empty_Hash;
          Client_Hello_Hash := Update_Hash (Client_Hello_Hash, Truncate_Client_Hello (Client_Hello_Handshake_Message)'Opaque);
          Binders := Calculate_Binders (PSKs, Get_Hash (Client_Hello_Hash));
-         Extensions_List := [for E in Extensions_List => E when E.Tag /= TLS_Handshake.EXTENSION_PRE_SHARED_KEY];
-         Extensions_List := Append (Extensions_List, TLS_Handshake.CH_Extension'(Tag => TLS_Handshake.EXTENSION_PRE_SHARED_KEY, Length => PSK_CH'Length, Data => PSK_CH)
-            where PSK_CH = TLS_Handshake.Pre_Shared_Key_CH'(Identities_Length => PSK_Identities'Length, Identities => PSK_Identities, Binders_Length => Binders_Length, Binders => Binders));
+         Extensions_List := [for E in Extensions_List => E when E.Tag /= TLS_Handshake_EXTENSION_PRE_SHARED_KEY];
+         Extensions_List := Append (Extensions_List, TLS_Handshake_CH_Extension'(Tag => TLS_Handshake_EXTENSION_PRE_SHARED_KEY, Length => PSK_CH'Length, Data => PSK_CH)
+            where PSK_CH = TLS_Handshake_Pre_Shared_Key_CH'(Identities_Length => PSK_Identities'Length, Identities => PSK_Identities, Binders_Length => Binders_Length, Binders => Binders));
          CH_PSK_Prepared := True;
       transition
          then ERROR_INTERNAL_ERROR
@@ -543,18 +638,18 @@ package TLS_Handshake_Session is
       end WAIT_SH_NO_PSK_EXTENSION;
 
       state WAIT_SH_SEND_CH is
-         Random : GreenTLS.Content;
-         Transcript_Hash_2 : GreenTLS.Content;
+         Random : GreenTLS_Content;
+         Transcript_Hash_2 : GreenTLS_Content;
       begin
          Transcript_Hash_2 := Empty_Hash;
-         Transcript_Hash_2 := Update_Hash (Transcript_Hash_2, TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_MESSAGE_HASH, Length => CH1_Hash'Length, Payload => CH1_Hash.Data)'Opaque)
+         Transcript_Hash_2 := Update_Hash (Transcript_Hash_2, TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_MESSAGE_HASH, Length => CH1_Hash'Length, Payload => CH1_Hash.Data)'Opaque)
             where CH1_Hash = Get_Hash (Client_Hello_1_Hash);
          Transcript_Hash_2 := Update_Hash (Transcript_Hash_2, Server_Hello_Handshake_Message'Opaque);
          Transcript_Hash_2 := Update_Hash (Transcript_Hash_2, Truncate_Client_Hello (Client_Hello_Handshake_Message)'Opaque);
          Random := Client_Hello_Message.Random;
          Client_Hello_Handshake_Message'Reset;
-         Client_Hello_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CLIENT_HELLO, Length => CH'Length, Payload => CH)
-            where CH = TLS_Handshake.Client_Hello'(Legacy_Version => TLS_Handshake.TLS_1_2, Random => Random.Data, Legacy_Session_ID_Length => 0, Cipher_Suites_Length => Configuration.Cipher_Suites'Length, Cipher_Suites => Configuration.Cipher_Suites, Legacy_Compression_Methods_Length => 0, Extensions_Length => Extensions_List'Length, Extensions => Extensions_List);
+         Client_Hello_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CLIENT_HELLO, Length => CH'Length, Payload => CH)
+            where CH = TLS_Handshake_Client_Hello'(Legacy_Version => TLS_Handshake_TLS_1_2, Random => Random.Data, Legacy_Session_ID_Length => 0, Cipher_Suites_Length => Configuration.Cipher_Suites'Length, Cipher_Suites => Configuration.Cipher_Suites, Legacy_Compression_Methods_Length => 0, Extensions_Length => Extensions_List'Length, Extensions => Extensions_List);
          Success := Write (Record_Data_Channel, Client_Hello_Handshake_Message);
          Transcript_Hash := Update_Hash (Transcript_Hash, Client_Hello_Handshake_Message'Opaque);
       transition
@@ -564,31 +659,31 @@ package TLS_Handshake_Session is
       end WAIT_SH_SEND_CH;
 
       state SET_RECORD_KEYS is
-         Derived_Early_Secret : GreenTLS.Content;
-         Handshake_Secret : GreenTLS.Content;
-         Server_Key : GreenTLS.Content;
-         Server_IV : GreenTLS.Content;
-         Client_Key : GreenTLS.Content;
-         Client_IV : GreenTLS.Content;
+         Derived_Early_Secret : GreenTLS_Content;
+         Handshake_Secret : GreenTLS_Content;
+         Server_Key : GreenTLS_Content;
+         Server_IV : GreenTLS_Content;
+         Client_Key : GreenTLS_Content;
+         Client_IV : GreenTLS_Content;
          Success_Client : Boolean;
          Success_Server : Boolean;
       begin
          Derived_Early_Secret := Derive_Secret (Early_Secret, "derived", Get_Hash (Empty_Hash));
          Early_Secret := null;
          Handshake_Secret := HKDF_Extract (Derived_Early_Secret, Key)
-            where Key = Calculate_ECDHE_Key (Client_Share, TLS_Handshake.Key_Share_Entry ([for E in Server_Hello_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE]'Head).Data)
-                     where Client_Share = [for S in TLS_Handshake.Key_Share_CH ([for E in Client_Hello_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE]'Head.Data).Shares => S when S.Group = Selected_Group]'Head;
+            where Key = Calculate_ECDHE_Key (Client_Share, TLS_Handshake_Key_Share_Entry ([for E in Server_Hello_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE]'Head).Data)
+                     where Client_Share = [for S in TLS_Handshake_Key_Share_CH ([for E in Client_Hello_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE]'Head.Data).Shares => S when S.Group = Selected_Group]'Head;
          Derived_Early_Secret := null;
          Client_Handshake_Traffic_Secret := Derive_Secret (Handshake_Secret, "c hs traffic", Get_Hash (Transcript_Hash));
          Server_Handshake_Traffic_Secret := Derive_Secret (Handshake_Secret, "s hs traffic", Get_Hash (Transcript_Hash));
-         Server_Key := HKDF_Expand_Label (GreenTLS.Content'(Data => Server_Handshake_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
-         Server_IV := HKDF_Expand_Label (GreenTLS.Content'(Data => Server_Handshake_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
-         Client_Key := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Handshake_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
-         Client_IV := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Handshake_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
-         Success_Client := Write (Record_Control_Channel, GreenTLS.Control_Message'(Tag => GreenTLS.KEY_UPDATE_CLIENT, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Record_Keys'(Key_Length => Client_Key'Length, Key => Client_Key.Data, IV_Length => Client_IV'Length, IV => Client_IV.Data));
-         Success_Server := Write (Record_Control_Channel, GreenTLS.Control_Message'(Tag => GreenTLS.KEY_UPDATE_SERVER, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Record_Keys'(Key_Length => Server_Key'Length, Key => Server_Key.Data, IV_Length => Server_IV'Length, IV => Server_IV.Data));
+         Server_Key := HKDF_Expand_Label (GreenTLS_Content'(Data => Server_Handshake_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
+         Server_IV := HKDF_Expand_Label (GreenTLS_Content'(Data => Server_Handshake_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
+         Client_Key := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Handshake_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
+         Client_IV := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Handshake_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
+         Success_Client := Write (Record_Control_Channel, GreenTLS_Control_Message'(Tag => GreenTLS_KEY_UPDATE_CLIENT, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Record_Keys'(Key_Length => Client_Key'Length, Key => Client_Key.Data, IV_Length => Client_IV'Length, IV => Client_IV.Data));
+         Success_Server := Write (Record_Control_Channel, GreenTLS_Control_Message'(Tag => GreenTLS_KEY_UPDATE_SERVER, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Record_Keys'(Key_Length => Server_Key'Length, Key => Server_Key.Data, IV_Length => Server_IV'Length, IV => Server_IV.Data));
          Server_Handshake_Traffic_Secret := null;
          Server_Key := null;
          Server_IV := null;
@@ -610,7 +705,7 @@ package TLS_Handshake_Session is
          then ERROR_DECODE_ERROR
             if Encrypted_Extensions_Handshake_Message'Valid = False
          then ERROR_UNEXPECTED_MESSAGE
-            if Encrypted_Extensions_Handshake_Message.Tag /= TLS_Handshake.HANDSHAKE_ENCRYPTED_EXTENSIONS
+            if Encrypted_Extensions_Handshake_Message.Tag /= TLS_Handshake_HANDSHAKE_ENCRYPTED_EXTENSIONS
          then WAIT_EE_PARSE_EXTENSIONS
       end WAIT_EE;
 
@@ -619,54 +714,54 @@ package TLS_Handshake_Session is
       transition
          then ERROR_ILLEGAL_PARAMETER
             if (for some E in Encrypted_Extensions_Message.Extensions =>
-                   E.Tag = TLS_Handshake.EXTENSION_STATUS_REQUEST
-                   or E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS
-                   or E.Tag = TLS_Handshake.EXTENSION_SIGNED_CERTIFICATE_TIMESTAMP
-                   or E.Tag = TLS_Handshake.EXTENSION_PADDING
-                   or E.Tag = TLS_Handshake.EXTENSION_KEY_SHARE
-                   or E.Tag = TLS_Handshake.EXTENSION_PRE_SHARED_KEY
-                   or E.Tag = TLS_Handshake.EXTENSION_PSK_KEY_EXCHANGE_MODES
-                   or E.Tag = TLS_Handshake.EXTENSION_COOKIE
-                   or E.Tag = TLS_Handshake.EXTENSION_SUPPORTED_VERSIONS
-                   or E.Tag = TLS_Handshake.EXTENSION_CERTIFICATE_AUTHORITIES
-                   or E.Tag = TLS_Handshake.EXTENSION_OID_FILTERS
-                   or E.Tag = TLS_Handshake.EXTENSION_POST_HANDSHAKE_AUTH
-                   or E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS_CERT)
+                   E.Tag = TLS_Handshake_EXTENSION_STATUS_REQUEST
+                   or E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS
+                   or E.Tag = TLS_Handshake_EXTENSION_SIGNED_CERTIFICATE_TIMESTAMP
+                   or E.Tag = TLS_Handshake_EXTENSION_PADDING
+                   or E.Tag = TLS_Handshake_EXTENSION_KEY_SHARE
+                   or E.Tag = TLS_Handshake_EXTENSION_PRE_SHARED_KEY
+                   or E.Tag = TLS_Handshake_EXTENSION_PSK_KEY_EXCHANGE_MODES
+                   or E.Tag = TLS_Handshake_EXTENSION_COOKIE
+                   or E.Tag = TLS_Handshake_EXTENSION_SUPPORTED_VERSIONS
+                   or E.Tag = TLS_Handshake_EXTENSION_CERTIFICATE_AUTHORITIES
+                   or E.Tag = TLS_Handshake_EXTENSION_OID_FILTERS
+                   or E.Tag = TLS_Handshake_EXTENSION_POST_HANDSHAKE_AUTH
+                   or E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS_CERT)
          then ERROR_ILLEGAL_PARAMETER
             if Server_Name_Received = False
                and (for some E in Encrypted_Extensions_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_SERVER_NAME)
+                       E.Tag = TLS_Handshake_EXTENSION_SERVER_NAME)
                and Configuration.Server_Name_Enabled = False
          then WAIT_EE_PROCESS_SERVER_NAME
             if Server_Name_Received = False
                and (for some E in Encrypted_Extensions_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_SERVER_NAME)
+                       E.Tag = TLS_Handshake_EXTENSION_SERVER_NAME)
          then WAIT_EE_PROCESS_MAX_FRAGMENT_LENGTH
             if Max_Fragment_Length_Received = False
                and (for some E in Encrypted_Extensions_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_MAX_FRAGMENT_LENGTH)
+                       E.Tag = TLS_Handshake_EXTENSION_MAX_FRAGMENT_LENGTH)
          then WAIT_EE_PROCESS_SUPPORTED_GROUPS
             if Supported_Groups_Received = False
                and (for some E in Encrypted_Extensions_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_SUPPORTED_GROUPS)
+                       E.Tag = TLS_Handshake_EXTENSION_SUPPORTED_GROUPS)
          then WAIT_EE_PROCESS_HEARTBEAT
             if Heartbeat_Received = False
                and (for some E in Encrypted_Extensions_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_HEARTBEAT)
+                       E.Tag = TLS_Handshake_EXTENSION_HEARTBEAT)
          then WAIT_EE_PROCESS_APPLICATION_LAYER_PROTOCOL_NEGOTIATION
             if Application_Layer_Protocol_Negotiation_Received = False
                and (for some E in Encrypted_Extensions_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_APPLICATION_LAYER_PROTOCOL_NEGOTIATION)
+                       E.Tag = TLS_Handshake_EXTENSION_APPLICATION_LAYER_PROTOCOL_NEGOTIATION)
          then WAIT_EE_PROCESS_EARLY_DATA
             if Early_Data_Received = False
                and (for some E in Encrypted_Extensions_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_EARLY_DATA)
+                       E.Tag = TLS_Handshake_EXTENSION_EARLY_DATA)
          then WAIT_EE_CHECK_EXTENSIONS
       end WAIT_EE_PARSE_EXTENSIONS;
 
       state WAIT_EE_PROCESS_SERVER_NAME is
       begin
-         Server_Name_Extension := [for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_SERVER_NAME]'Head;
+         Server_Name_Extension := [for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_SERVER_NAME]'Head;
          Server_Name_Received := True;
       transition
          then ERROR_ILLEGAL_PARAMETER
@@ -676,7 +771,7 @@ package TLS_Handshake_Session is
 
       state WAIT_EE_PROCESS_MAX_FRAGMENT_LENGTH is
       begin
-         Max_Fragment_Length := TLS_Handshake.Max_Fragment_Length ([for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_MAX_FRAGMENT_LENGTH]'Head.Data).Max_Fragment_Length;
+         Max_Fragment_Length := TLS_Handshake_Max_Fragment_Length ([for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_MAX_FRAGMENT_LENGTH]'Head.Data).Max_Fragment_Length;
          Max_Fragment_Length_Received := True;
       transition
          then ERROR_ILLEGAL_PARAMETER
@@ -686,18 +781,18 @@ package TLS_Handshake_Session is
 
       state WAIT_EE_PROCESS_SUPPORTED_GROUPS is
       begin
-         Server_Preferred_Groups := TLS_Handshake.Supported_Groups ([for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_SUPPORTED_GROUPS]'Head.Data).Groups;
+         Server_Preferred_Groups := TLS_Handshake_Supported_Groups ([for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_SUPPORTED_GROUPS]'Head.Data).Groups;
          Supported_Groups_Received := True;
       transition
          then WAIT_EE_PARSE_EXTENSIONS
       end WAIT_EE_PROCESS_SUPPORTED_GROUPS;
 
       state WAIT_EE_PROCESS_HEARTBEAT is
-         Server_Heartbeat_Mode : TLS_Handshake.Heartbeat_Mode;
+         Server_Heartbeat_Mode : TLS_Handshake_Heartbeat_Mode;
       begin
-         Server_Heartbeat_Mode := TLS_Handshake.Heartbeat ([for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_HEARTBEAT]'Head.Data).Mode;
-         Success := Write (Record_Control_Channel, GreenTLS.Control_Message'(Tag => GreenTLS.HEARTBEAT_MODE, Length => Data'Length, Payload => Data)
-            where Data = GreenTLS.Heartbeat_Control_Message'(Local => Configuration.Heartbeat_Mode, Remote => Server_Heartbeat_Mode));
+         Server_Heartbeat_Mode := TLS_Handshake_Heartbeat ([for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_HEARTBEAT]'Head.Data).Mode;
+         Success := Write (Record_Control_Channel, GreenTLS_Control_Message'(Tag => GreenTLS_HEARTBEAT_MODE, Length => Data'Length, Payload => Data)
+            where Data = GreenTLS_Heartbeat_Control_Message'(Local => Configuration.Heartbeat_Mode, Remote => Server_Heartbeat_Mode));
          Heartbeat_Received := True;
       transition
          then ERROR_INTERNAL_ERROR
@@ -706,11 +801,11 @@ package TLS_Handshake_Session is
       end WAIT_EE_PROCESS_HEARTBEAT;
 
       state WAIT_EE_PROCESS_APPLICATION_LAYER_PROTOCOL_NEGOTIATION is
-         Protocols : TLS_Handshake.Protocol_Names;
+         Protocols : TLS_Handshake_Protocol_Names;
       begin
-         Protocols := TLS_Handshake.Protocol_Name_List ([for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_APPLICATION_LAYER_PROTOCOL_NEGOTIATION]'Head.Data).Protocol_Name_List;
-         Success := Write (Application_Control_Channel, GreenTLS.Application_Control_Message'(Tag => GreenTLS.APPLICATION_PROTOCOL, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Application_Protocol_Message'(Protocol => Protocols'Head));
+         Protocols := TLS_Handshake_Protocol_Name_List ([for E in Encrypted_Extensions_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_APPLICATION_LAYER_PROTOCOL_NEGOTIATION]'Head.Data).Protocol_Name_List;
+         Success := Write (Application_Control_Channel, GreenTLS_Application_Control_Message'(Tag => GreenTLS_APPLICATION_PROTOCOL, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Application_Protocol_Message'(Protocol => Protocols'Head));
          Application_Layer_Protocol_Negotiation_Received := True;
       transition
          then ERROR_INTERNAL_ERROR
@@ -748,8 +843,8 @@ package TLS_Handshake_Session is
 
       state WAIT_EE_NO_EARLY_DATA is
       begin
-         Success := Write (Application_Control_Channel, GreenTLS.Application_Control_Message'(Tag => GreenTLS.APPLICATION_NO_EARLY_DATA, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Application_No_Early_Data_Message'(null message));
+         Success := Write (Application_Control_Channel, GreenTLS_Application_Control_Message'(Tag => GreenTLS_APPLICATION_NO_EARLY_DATA, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Application_No_Early_Data_Message'(null message));
       transition
          then ERROR_INTERNAL_ERROR
             if Success = False
@@ -767,16 +862,16 @@ package TLS_Handshake_Session is
       state WAIT_CERT_CR is
       begin
          CCR_Handshake_Message := Read (Record_Data_Channel);
-         Certificate_Authorities := TLS_Handshake.Certificate_Authorities'(Length => 0);
-         OID_Filters := TLS_Handshake.OID_Filters'(Length => 0);
-         Signature_Algorithms := TLS_Handshake.Signature_Algorithms'(Length => 0);
-         Signature_Algorithms_Cert := TLS_Handshake.Signature_Algorithms_Cert'(Length => 0);
+         Certificate_Authorities := TLS_Handshake_Certificate_Authorities'(Length => 0);
+         OID_Filters := TLS_Handshake_OID_Filters'(Length => 0);
+         Signature_Algorithms := TLS_Handshake_Signature_Algorithms'(Length => 0);
+         Signature_Algorithms_Cert := TLS_Handshake_Signature_Algorithms_Cert'(Length => 0);
       transition
          then ERROR_DECODE_ERROR
             if CCR_Handshake_Message'Valid = False
          then ERROR_UNEXPECTED_MESSAGE
-            if CCR_Handshake_Message.Tag /= TLS_Handshake.HANDSHAKE_CERTIFICATE
-               and CCR_Handshake_Message.Tag /= TLS_Handshake.HANDSHAKE_CERTIFICATE_REQUEST
+            if CCR_Handshake_Message.Tag /= TLS_Handshake_HANDSHAKE_CERTIFICATE
+               and CCR_Handshake_Message.Tag /= TLS_Handshake_HANDSHAKE_CERTIFICATE_REQUEST
          then PARSE_CERT
             if Certificate_Message'Valid = True
          then PARSE_CR
@@ -786,7 +881,7 @@ package TLS_Handshake_Session is
 
       state PARSE_CR is
       begin
-         Certificate_Request := TLS_Handshake.Certificate_Request'(Certificate_Request_Context_Length => Certificate_Request_Message.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request_Message.Certificate_Request_Context, Extensions_Length => Certificate_Request_Message.Extensions_Length, Extensions => Certificate_Request_Message.Extensions);
+         Certificate_Request := TLS_Handshake_Certificate_Request'(Certificate_Request_Context_Length => Certificate_Request_Message.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request_Message.Certificate_Request_Context, Extensions_Length => Certificate_Request_Message.Extensions_Length, Extensions => Certificate_Request_Message.Extensions);
       transition
          then PARSE_CR_EXTENSIONS
       end PARSE_CR;
@@ -798,26 +893,26 @@ package TLS_Handshake_Session is
          then PARSE_CR_PARSE_CERTIFICATE_AUTHORITIES
             if Certificate_Authorities_Received = False
                and (for some E in Certificate_Request_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_CERTIFICATE_AUTHORITIES)
+                       E.Tag = TLS_Handshake_EXTENSION_CERTIFICATE_AUTHORITIES)
          then PARSE_CR_PARSE_OID_FILTERS
             if OID_Filters_Received = False
                and (for some E in Certificate_Request_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_OID_FILTERS)
+                       E.Tag = TLS_Handshake_EXTENSION_OID_FILTERS)
          then PARSE_CR_PARSE_SIGNATURE_ALGORITHMS
             if Signature_Algorithms_Received = False
                and (for some E in Certificate_Request_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS)
+                       E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS)
          then PARSE_CR_PARSE_SIGNATURE_ALGORITHMS_CERT
             if Signature_Algorithms_Cert_Received = False
                and (for some E in Certificate_Request_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS_CERT)
+                       E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS_CERT)
          then PARSE_CR_CHECK_EXTENSIONS
       end PARSE_CR_EXTENSIONS;
 
       state PARSE_CR_PARSE_CERTIFICATE_AUTHORITIES is
       begin
          Certificate_Authorities_Received := True;
-         Certificate_Authorities := TLS_Handshake.Certificate_Authorities ([for E in Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_CERTIFICATE_AUTHORITIES]'Head.Data);
+         Certificate_Authorities := TLS_Handshake_Certificate_Authorities ([for E in Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_CERTIFICATE_AUTHORITIES]'Head.Data);
       transition
          then PARSE_CR_EXTENSIONS
       end PARSE_CR_PARSE_CERTIFICATE_AUTHORITIES;
@@ -825,7 +920,7 @@ package TLS_Handshake_Session is
       state PARSE_CR_PARSE_OID_FILTERS is
       begin
          OID_Filters_Received := True;
-         OID_Filters := TLS_Handshake.OID_Filters ([for E in Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_OID_FILTERS]'Head.Data);
+         OID_Filters := TLS_Handshake_OID_Filters ([for E in Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_OID_FILTERS]'Head.Data);
       transition
          then PARSE_CR_EXTENSIONS
       end PARSE_CR_PARSE_OID_FILTERS;
@@ -833,7 +928,7 @@ package TLS_Handshake_Session is
       state PARSE_CR_PARSE_SIGNATURE_ALGORITHMS is
       begin
          Signature_Algorithms_Received := True;
-         Signature_Algorithms := TLS_Handshake.Signature_Algorithms ([for E in Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS]'Head.Data);
+         Signature_Algorithms := TLS_Handshake_Signature_Algorithms ([for E in Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS]'Head.Data);
       transition
          then ERROR_ILLEGAL_PARAMETER
             if (for all A in Configuration.Signature_Algorithms =>
@@ -844,7 +939,7 @@ package TLS_Handshake_Session is
       state PARSE_CR_PARSE_SIGNATURE_ALGORITHMS_CERT is
       begin
          Signature_Algorithms_Cert_Received := True;
-         Signature_Algorithms_Cert := TLS_Handshake.Signature_Algorithms_Cert ([for E in Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS_CERT]'Head.Data);
+         Signature_Algorithms_Cert := TLS_Handshake_Signature_Algorithms_Cert ([for E in Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS_CERT]'Head.Data);
       transition
          then ERROR_ILLEGAL_PARAMETER
             if (for all A in Configuration.Signature_Algorithms_Cert =>
@@ -869,7 +964,7 @@ package TLS_Handshake_Session is
             if CCR_Handshake_Message'Valid = False
                or Certificate_Message'Valid = False
          then ERROR_UNEXPECTED_MESSAGE
-            if CCR_Handshake_Message.Tag /= TLS_Handshake.HANDSHAKE_CERTIFICATE
+            if CCR_Handshake_Message.Tag /= TLS_Handshake_HANDSHAKE_CERTIFICATE
          then ERROR_ILLEGAL_PARAMETER
             if Certificate_Message.Certificate_Request_Context_Length /= 0
          then ERROR_ILLEGAL_PARAMETER
@@ -878,23 +973,23 @@ package TLS_Handshake_Session is
       end WAIT_CERT;
 
       state PARSE_CERT is
-         Validation_Result : GreenTLS.Certificate_Validation_Result;
+         Validation_Result : GreenTLS_Certificate_Validation_Result;
       begin
          Transcript_Hash := Update_Hash (Transcript_Hash, CCR_Handshake_Message'Opaque);
          Validation_Result := Validate_Server_Certificate (Certificate_Message, Configuration, Connection);
       transition
          then WAIT_CV
-            if Validation_Result = GreenTLS.VALID_CERTIFICATE
+            if Validation_Result = GreenTLS_VALID_CERTIFICATE
          then ERROR_BAD_CERTIFICATE
-            if Validation_Result = GreenTLS.BAD_CERTIFICATE
+            if Validation_Result = GreenTLS_BAD_CERTIFICATE
          then ERROR_UNSUPPORTED_CERTIFICATE
-            if Validation_Result = GreenTLS.UNSUPPORTED_CERTIFICATE
+            if Validation_Result = GreenTLS_UNSUPPORTED_CERTIFICATE
          then ERROR_CERTIFICATE_REVOKED
-            if Validation_Result = GreenTLS.CERTIFICATE_REVOKED
+            if Validation_Result = GreenTLS_CERTIFICATE_REVOKED
          then ERROR_CERTIFICATE_EXPIRED
-            if Validation_Result = GreenTLS.CERTIFICATE_EXPIRED
+            if Validation_Result = GreenTLS_CERTIFICATE_EXPIRED
          then ERROR_CERTIFICATE_UNKNOWN
-            if Validation_Result = GreenTLS.CERTIFICATE_UNKNOWN
+            if Validation_Result = GreenTLS_CERTIFICATE_UNKNOWN
          then ERROR_INTERNAL_ERROR
       end PARSE_CERT;
 
@@ -912,26 +1007,26 @@ package TLS_Handshake_Session is
       end WAIT_CV;
 
       state WAIT_CV_VALIDATE is
-         Validation_Result : GreenTLS.Signature_Validation_Result;
+         Validation_Result : GreenTLS_Signature_Validation_Result;
       begin
          Validation_Result := Validate_Certificate_Verify_Signature (Certificate_Message, Certificate_Verify_Message, Get_Hash (Transcript_Hash));
       transition
          then ERROR_ILLEGAL_PARAMETER
-            if Validation_Result = GreenTLS.ILLEGAL_PARAMETER
+            if Validation_Result = GreenTLS_ILLEGAL_PARAMETER
          then ERROR_DECRYPT_ERROR
-            if Validation_Result = GreenTLS.DECRYPT_ERROR
+            if Validation_Result = GreenTLS_DECRYPT_ERROR
          then WAIT_FINISHED
-            if Validation_Result = GreenTLS.VALID_SIGNATURE
+            if Validation_Result = GreenTLS_VALID_SIGNATURE
          then ERROR_INTERNAL_ERROR
       end WAIT_CV_VALIDATE;
 
       state WAIT_FINISHED is
-         Verify_Data : GreenTLS.Content;
-         Master_Secret : GreenTLS.Content;
+         Verify_Data : GreenTLS_Content;
+         Master_Secret : GreenTLS_Content;
       begin
          Hash_Length := Get_Hash_Length (Server_Hello_Message.Cipher_Suite);
          Finished_Handshake_Message := Read (Record_Data_Channel);
-         Finished_Key := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Handshake_Traffic_Secret), "finished", Get_Hash (Empty_Hash), Hash_Length);
+         Finished_Key := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Handshake_Traffic_Secret), "finished", Get_Hash (Empty_Hash), Hash_Length);
          Client_Handshake_Traffic_Secret := null;
          Verify_Data := HMAC (Server_Hello_Message.Cipher_Suite, Finished_Key, Get_Hash (Transcript_Hash));
          Transcript_Hash := Update_Hash (Transcript_Hash, Finished_Handshake_Message'Opaque);
@@ -953,7 +1048,7 @@ package TLS_Handshake_Session is
 
       state SEND_END_OF_EARLY_DATA is
       begin
-         Success := Write (Record_Data_Channel, TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_END_OF_EARLY_DATA, Length => 0));
+         Success := Write (Record_Data_Channel, TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_END_OF_EARLY_DATA, Length => 0));
       transition
          then ERROR_INTERNAL_ERROR
             if Success = False
@@ -970,23 +1065,23 @@ package TLS_Handshake_Session is
 
       state QUERY_CERTIFICATES is
       begin
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_CERTIFICATES, Length => Query'Length, Payload => Query)
-            where Query = GreenTLS.Certificate_Query'(Certificate_Authorities => Certificate_Authorities, OID_Filters => OID_Filters, Signature_Algorithms => Signature_Algorithms, Signature_Algorithms_Cert => Signature_Algorithms_Cert));
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_CERTIFICATES, Length => Query'Length, Payload => Query)
+            where Query = GreenTLS_Certificate_Query'(Certificate_Authorities => Certificate_Authorities, OID_Filters => OID_Filters, Signature_Algorithms => Signature_Algorithms, Signature_Algorithms_Cert => Signature_Algorithms_Cert));
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
-               or GreenTLS.Certificate (Keystore_Message.Payload)'Valid = False
+               or GreenTLS_Certificate (Keystore_Message.Payload)'Valid = False
          then SEND_CERTIFICATE
-            if GreenTLS.Certificate (Keystore_Message.Payload).Length > 0
+            if GreenTLS_Certificate (Keystore_Message.Payload).Length > 0
          then SEND_EMPTY_CERTIFICATE
       end QUERY_CERTIFICATES;
 
       state SEND_CERTIFICATE is
-         Client_Certificate_Handshake_Message : TLS_Handshake.Handshake;
+         Client_Certificate_Handshake_Message : TLS_Handshake_Handshake;
       begin
-         Client_Certificate_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CERTIFICATE, Length => Certificate'Length, Payload => Certificate)
-            where Certificate = TLS_Handshake.Certificate'(Certificate_Request_Context_Length => Certificate_Request.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request.Certificate_Request_Context, Certificate_List_Length => C.Length, Certificate_List => C.Certificate_List)
-                     where C = GreenTLS.Certificate (Keystore_Message.Payload);
+         Client_Certificate_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CERTIFICATE, Length => Certificate'Length, Payload => Certificate)
+            where Certificate = TLS_Handshake_Certificate'(Certificate_Request_Context_Length => Certificate_Request.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request.Certificate_Request_Context, Certificate_List_Length => C.Length, Certificate_List => C.Certificate_List)
+                     where C = GreenTLS_Certificate (Keystore_Message.Payload);
          Success := Write (Record_Data_Channel, Client_Certificate_Handshake_Message);
          Transcript_Hash := Update_Hash (Transcript_Hash, Client_Certificate_Handshake_Message'Opaque);
       transition
@@ -996,10 +1091,10 @@ package TLS_Handshake_Session is
       end SEND_CERTIFICATE;
 
       state SEND_EMPTY_CERTIFICATE is
-         Client_Certificate_Handshake_Message : TLS_Handshake.Handshake;
+         Client_Certificate_Handshake_Message : TLS_Handshake_Handshake;
       begin
-         Client_Certificate_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CERTIFICATE, Length => Certificate'Length, Payload => Certificate)
-            where Certificate = TLS_Handshake.Certificate'(Certificate_Request_Context_Length => Certificate_Request.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request.Certificate_Request_Context, Certificate_List_Length => 0);
+         Client_Certificate_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CERTIFICATE, Length => Certificate'Length, Payload => Certificate)
+            where Certificate = TLS_Handshake_Certificate'(Certificate_Request_Context_Length => Certificate_Request.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request.Certificate_Request_Context, Certificate_List_Length => 0);
          Success := Write (Record_Data_Channel, Client_Certificate_Handshake_Message);
          Transcript_Hash := Update_Hash (Transcript_Hash, Client_Certificate_Handshake_Message'Opaque);
       transition
@@ -1010,21 +1105,21 @@ package TLS_Handshake_Session is
 
       state QUERY_SIGNATURE is
       begin
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_SIGNATURE, Length => Query'Length, Payload => Query)
-            where Query = GreenTLS.Signature_Query'(ID => GreenTLS.Certificate (Keystore_Message.Payload).ID, Length => Hash'Length, Data => Hash)
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_SIGNATURE, Length => Query'Length, Payload => Query)
+            where Query = GreenTLS_Signature_Query'(ID => GreenTLS_Certificate (Keystore_Message.Payload).ID, Length => Hash'Length, Data => Hash)
                      where Hash = Get_Hash (Transcript_Hash).Data);
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
-               or TLS_Handshake.Certificate_Verify (Keystore_Message.Payload)'Valid = False
+               or TLS_Handshake_Certificate_Verify (Keystore_Message.Payload)'Valid = False
          then SEND_CERTIFICATE_VERIFY
       end QUERY_SIGNATURE;
 
       state SEND_CERTIFICATE_VERIFY is
-         Client_Certificate_Verify_Handshake_Message : TLS_Handshake.Handshake;
+         Client_Certificate_Verify_Handshake_Message : TLS_Handshake_Handshake;
       begin
-         Client_Certificate_Verify_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CERTIFICATE_VERIFY, Length => Certificate_Verify'Length, Payload => Certificate_Verify)
-            where Certificate_Verify = TLS_Handshake.Certificate_Verify (Keystore_Message.Payload);
+         Client_Certificate_Verify_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CERTIFICATE_VERIFY, Length => Certificate_Verify'Length, Payload => Certificate_Verify)
+            where Certificate_Verify = TLS_Handshake_Certificate_Verify (Keystore_Message.Payload);
          Success := Write (Record_Data_Channel, Client_Certificate_Verify_Handshake_Message);
          Transcript_Hash := Update_Hash (Transcript_Hash, Client_Certificate_Verify_Handshake_Message'Opaque);
       transition
@@ -1034,12 +1129,12 @@ package TLS_Handshake_Session is
       end SEND_CERTIFICATE_VERIFY;
 
       state SEND_FINISHED is
-         Verify_Data : GreenTLS.Content;
+         Verify_Data : GreenTLS_Content;
       begin
          Verify_Data := HMAC (Server_Hello_Message.Cipher_Suite, Finished_Key, Get_Hash (Transcript_Hash));
          Finished_Key := null;
-         Finished_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_FINISHED, Length => Finished'Length, Payload => Finished)
-            where Finished = TLS_Handshake.Finished'(Verify_Data => Verify_Data);
+         Finished_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_FINISHED, Length => Finished'Length, Payload => Finished)
+            where Finished = TLS_Handshake_Finished'(Verify_Data => Verify_Data);
          Success := Write (Record_Data_Channel, Finished_Handshake_Message);
       transition
          then ERROR_INTERNAL_ERROR
@@ -1048,21 +1143,21 @@ package TLS_Handshake_Session is
       end SEND_FINISHED;
 
       state SEND_APPLICATION_RECORD_KEYS is
-         Server_Key : GreenTLS.Content;
-         Server_IV : GreenTLS.Content;
-         Client_Key : GreenTLS.Content;
-         Client_IV : GreenTLS.Content;
+         Server_Key : GreenTLS_Content;
+         Server_IV : GreenTLS_Content;
+         Client_Key : GreenTLS_Content;
+         Client_IV : GreenTLS_Content;
          Success_Client : Boolean;
          Success_Server : Boolean;
       begin
-         Server_Key := HKDF_Expand_Label (GreenTLS.Content'(Data => Server_Application_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
-         Server_IV := HKDF_Expand_Label (GreenTLS.Content'(Data => Server_Application_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
-         Client_Key := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Application_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
-         Client_IV := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Application_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
-         Success_Client := Write (Record_Control_Channel, GreenTLS.Control_Message'(Tag => GreenTLS.KEY_UPDATE_CLIENT, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Record_Keys'(Key_Length => Client_Key'Length, Key => Client_Key.Data, IV_Length => Client_IV'Length, IV => Client_IV.Data));
-         Success_Server := Write (Record_Control_Channel, GreenTLS.Control_Message'(Tag => GreenTLS.KEY_UPDATE_SERVER, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Record_Keys'(Key_Length => Server_Key'Length, Key => Server_Key.Data, IV_Length => Server_IV'Length, IV => Server_IV.Data));
+         Server_Key := HKDF_Expand_Label (GreenTLS_Content'(Data => Server_Application_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
+         Server_IV := HKDF_Expand_Label (GreenTLS_Content'(Data => Server_Application_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
+         Client_Key := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Application_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
+         Client_IV := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Application_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
+         Success_Client := Write (Record_Control_Channel, GreenTLS_Control_Message'(Tag => GreenTLS_KEY_UPDATE_CLIENT, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Record_Keys'(Key_Length => Client_Key'Length, Key => Client_Key.Data, IV_Length => Client_IV'Length, IV => Client_IV.Data));
+         Success_Server := Write (Record_Control_Channel, GreenTLS_Control_Message'(Tag => GreenTLS_KEY_UPDATE_SERVER, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Record_Keys'(Key_Length => Server_Key'Length, Key => Server_Key.Data, IV_Length => Server_IV'Length, IV => Server_IV.Data));
          Server_Application_Traffic_Secret := null;
       transition
          then ERROR_INTERNAL_ERROR
@@ -1077,32 +1172,32 @@ package TLS_Handshake_Session is
       transition
          then ERROR_DECODE_ERROR
             if Post_Handshake_Handshake_Message'Valid = False
-               or (Post_Handshake_Handshake_Message.Tag = TLS_Handshake.HANDSHAKE_NEW_SESSION_TICKET
+               or (Post_Handshake_Handshake_Message.Tag = TLS_Handshake_HANDSHAKE_NEW_SESSION_TICKET
                    and New_Session_Ticket_Message'Valid = False)
-               or (Post_Handshake_Handshake_Message.Tag = TLS_Handshake.HANDSHAKE_CERTIFICATE_REQUEST
+               or (Post_Handshake_Handshake_Message.Tag = TLS_Handshake_HANDSHAKE_CERTIFICATE_REQUEST
                    and PHA_Certificate_Request_Message'Valid = False)
-               or (Post_Handshake_Handshake_Message.Tag = TLS_Handshake.HANDSHAKE_KEY_UPDATE
+               or (Post_Handshake_Handshake_Message.Tag = TLS_Handshake_HANDSHAKE_KEY_UPDATE
                    and Key_Update_Message'Valid = False)
          then CONNECTED_NEW_SESSION_TICKET
-            if Post_Handshake_Handshake_Message.Tag = TLS_Handshake.HANDSHAKE_NEW_SESSION_TICKET
+            if Post_Handshake_Handshake_Message.Tag = TLS_Handshake_HANDSHAKE_NEW_SESSION_TICKET
                and New_Session_Ticket_Message'Valid = True
          then CONNECTED_POST_HANDSHAKE_AUTH
-            if Post_Handshake_Handshake_Message.Tag = TLS_Handshake.HANDSHAKE_CERTIFICATE_REQUEST
+            if Post_Handshake_Handshake_Message.Tag = TLS_Handshake_HANDSHAKE_CERTIFICATE_REQUEST
                and Configuration.Post_Handshake_Auth_Enabled = True
          then ERROR_UNEXPECTED_MESSAGE
-            if Post_Handshake_Handshake_Message.Tag = TLS_Handshake.HANDSHAKE_CERTIFICATE_REQUEST
+            if Post_Handshake_Handshake_Message.Tag = TLS_Handshake_HANDSHAKE_CERTIFICATE_REQUEST
                and Configuration.Post_Handshake_Auth_Enabled = False
          then CONNECTED_KEY_UPDATE
-            if Post_Handshake_Handshake_Message.Tag = TLS_Handshake.HANDSHAKE_KEY_UPDATE
+            if Post_Handshake_Handshake_Message.Tag = TLS_Handshake_HANDSHAKE_KEY_UPDATE
          then ERROR_UNEXPECTED_MESSAGE
       end CONNECTED;
 
       state CONNECTED_NEW_SESSION_TICKET is
-         PSK : GreenTLS.Content;
+         PSK : GreenTLS_Content;
       begin
-         PSK := HKDF_Expand_Label (GreenTLS.Content'(Data => Resumption_Master_Secret.Data), "resumption", GreenTLS.Content'(Data => New_Session_Ticket_Message.Ticket_Nonce), Hash_Length);
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_NEW_SESSION_TICKET, Length => NST'Length, Payload => NST)
-            where NST = GreenTLS.New_Session_Ticket'(Connection => Connection, Session => New_Session_Ticket_Message, PSK_Length => PSK'Length, PSK => PSK));
+         PSK := HKDF_Expand_Label (GreenTLS_Content'(Data => Resumption_Master_Secret.Data), "resumption", GreenTLS_Content'(Data => New_Session_Ticket_Message.Ticket_Nonce), Hash_Length);
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_NEW_SESSION_TICKET, Length => NST'Length, Payload => NST)
+            where NST = GreenTLS_New_Session_Ticket'(Connection => Connection, Session => New_Session_Ticket_Message, PSK_Length => PSK'Length, PSK => PSK));
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
@@ -1121,7 +1216,7 @@ package TLS_Handshake_Session is
 
       state CONNECTED_PHA_PARSE_CR is
       begin
-         Certificate_Request := TLS_Handshake.Certificate_Request'(Certificate_Request_Context_Length => PHA_Certificate_Request_Message.Certificate_Request_Context_Length, Certificate_Request_Context => PHA_Certificate_Request_Message.Certificate_Request_Context, Extensions_Length => PHA_Certificate_Request_Message.Extensions_Length, Extensions => PHA_Certificate_Request_Message.Extensions);
+         Certificate_Request := TLS_Handshake_Certificate_Request'(Certificate_Request_Context_Length => PHA_Certificate_Request_Message.Certificate_Request_Context_Length, Certificate_Request_Context => PHA_Certificate_Request_Message.Certificate_Request_Context, Extensions_Length => PHA_Certificate_Request_Message.Extensions_Length, Extensions => PHA_Certificate_Request_Message.Extensions);
       transition
          then CONNECTED_PHA_PARSE_CR_EXTENSIONS
       end CONNECTED_PHA_PARSE_CR;
@@ -1132,26 +1227,26 @@ package TLS_Handshake_Session is
          then CONNECTED_PHA_PARSE_CR_PARSE_CERTIFICATE_AUTHORITIES
             if Certificate_Authorities_Received = False
                and (for some E in PHA_Certificate_Request_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_CERTIFICATE_AUTHORITIES)
+                       E.Tag = TLS_Handshake_EXTENSION_CERTIFICATE_AUTHORITIES)
          then CONNECTED_PHA_PARSE_CR_PARSE_OID_FILTERS
             if OID_Filters_Received = False
                and (for some E in PHA_Certificate_Request_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_OID_FILTERS)
+                       E.Tag = TLS_Handshake_EXTENSION_OID_FILTERS)
          then CONNECTED_PHA_PARSE_CR_PARSE_SIGNATURE_ALGORITHMS
             if Signature_Algorithms_Received = False
                and (for some E in PHA_Certificate_Request_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS)
+                       E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS)
          then CONNECTED_PHA_PARSE_CR_PARSE_SIGNATURE_ALGORITHMS_CERT
             if Signature_Algorithms_Cert_Received = False
                and (for some E in PHA_Certificate_Request_Message.Extensions =>
-                       E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS_CERT)
+                       E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS_CERT)
          then CONNECTED_PHA_PARSE_CR_CHECK_EXTENSIONS
       end CONNECTED_PHA_PARSE_CR_EXTENSIONS;
 
       state CONNECTED_PHA_PARSE_CR_PARSE_CERTIFICATE_AUTHORITIES is
       begin
          Certificate_Authorities_Received := True;
-         Certificate_Authorities := TLS_Handshake.Certificate_Authorities ([for E in PHA_Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_CERTIFICATE_AUTHORITIES]'Head.Data);
+         Certificate_Authorities := TLS_Handshake_Certificate_Authorities ([for E in PHA_Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_CERTIFICATE_AUTHORITIES]'Head.Data);
       transition
          then CONNECTED_PHA_PARSE_CR_EXTENSIONS
       end CONNECTED_PHA_PARSE_CR_PARSE_CERTIFICATE_AUTHORITIES;
@@ -1159,7 +1254,7 @@ package TLS_Handshake_Session is
       state CONNECTED_PHA_PARSE_CR_PARSE_OID_FILTERS is
       begin
          OID_Filters_Received := True;
-         OID_Filters := TLS_Handshake.OID_Filters ([for E in PHA_Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_OID_FILTERS]'Head.Data);
+         OID_Filters := TLS_Handshake_OID_Filters ([for E in PHA_Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_OID_FILTERS]'Head.Data);
       transition
          then CONNECTED_PHA_PARSE_CR_EXTENSIONS
       end CONNECTED_PHA_PARSE_CR_PARSE_OID_FILTERS;
@@ -1167,7 +1262,7 @@ package TLS_Handshake_Session is
       state CONNECTED_PHA_PARSE_CR_PARSE_SIGNATURE_ALGORITHMS is
       begin
          Signature_Algorithms_Received := True;
-         Signature_Algorithms := TLS_Handshake.Signature_Algorithms ([for E in PHA_Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS]'Head.Data);
+         Signature_Algorithms := TLS_Handshake_Signature_Algorithms ([for E in PHA_Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS]'Head.Data);
       transition
          then ERROR_ILLEGAL_PARAMETER
             if (for all A in Configuration.Signature_Algorithms =>
@@ -1178,7 +1273,7 @@ package TLS_Handshake_Session is
       state CONNECTED_PHA_PARSE_CR_PARSE_SIGNATURE_ALGORITHMS_CERT is
       begin
          Signature_Algorithms_Cert_Received := True;
-         Signature_Algorithms_Cert := TLS_Handshake.Signature_Algorithms_Cert ([for E in PHA_Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake.EXTENSION_SIGNATURE_ALGORITHMS_CERT]'Head.Data);
+         Signature_Algorithms_Cert := TLS_Handshake_Signature_Algorithms_Cert ([for E in PHA_Certificate_Request_Message.Extensions => E when E.Tag = TLS_Handshake_EXTENSION_SIGNATURE_ALGORITHMS_CERT]'Head.Data);
       transition
          then ERROR_ILLEGAL_PARAMETER
             if (for all A in Configuration.Signature_Algorithms_Cert =>
@@ -1197,23 +1292,23 @@ package TLS_Handshake_Session is
 
       state CONNECTED_PHA_QUERY_CERTIFICATES is
       begin
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_CERTIFICATES, Length => Query'Length, Payload => Query)
-            where Query = GreenTLS.Certificate_Query'(Certificate_Authorities => Certificate_Authorities, OID_Filters => OID_Filters, Signature_Algorithms => Signature_Algorithms, Signature_Algorithms_Cert => Signature_Algorithms_Cert));
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_CERTIFICATES, Length => Query'Length, Payload => Query)
+            where Query = GreenTLS_Certificate_Query'(Certificate_Authorities => Certificate_Authorities, OID_Filters => OID_Filters, Signature_Algorithms => Signature_Algorithms, Signature_Algorithms_Cert => Signature_Algorithms_Cert));
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
-               or GreenTLS.Certificate (Keystore_Message.Payload)'Valid = False
+               or GreenTLS_Certificate (Keystore_Message.Payload)'Valid = False
          then CONNECTED_PHA_SEND_CERTIFICATE
-            if GreenTLS.Certificate (Keystore_Message.Payload).Length > 0
+            if GreenTLS_Certificate (Keystore_Message.Payload).Length > 0
          then CONNECTED_PHA_SEND_EMPTY_CERTIFICATE
       end CONNECTED_PHA_QUERY_CERTIFICATES;
 
       state CONNECTED_PHA_SEND_CERTIFICATE is
-         Client_Certificate_Handshake_Message : TLS_Handshake.Handshake;
+         Client_Certificate_Handshake_Message : TLS_Handshake_Handshake;
       begin
-         Client_Certificate_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CERTIFICATE, Length => Certificate'Length, Payload => Certificate)
-            where Certificate = TLS_Handshake.Certificate'(Certificate_Request_Context_Length => Certificate_Request.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request.Certificate_Request_Context, Certificate_List_Length => C.Length, Certificate_List => C.Certificate_List)
-                     where C = GreenTLS.Certificate (Keystore_Message.Payload);
+         Client_Certificate_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CERTIFICATE, Length => Certificate'Length, Payload => Certificate)
+            where Certificate = TLS_Handshake_Certificate'(Certificate_Request_Context_Length => Certificate_Request.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request.Certificate_Request_Context, Certificate_List_Length => C.Length, Certificate_List => C.Certificate_List)
+                     where C = GreenTLS_Certificate (Keystore_Message.Payload);
          Success := Write (Record_Data_Channel, Client_Certificate_Handshake_Message);
          Transcript_Hash := Update_Hash (Transcript_Hash, Client_Certificate_Handshake_Message'Opaque);
       transition
@@ -1223,10 +1318,10 @@ package TLS_Handshake_Session is
       end CONNECTED_PHA_SEND_CERTIFICATE;
 
       state CONNECTED_PHA_SEND_EMPTY_CERTIFICATE is
-         Client_Certificate_Handshake_Message : TLS_Handshake.Handshake;
+         Client_Certificate_Handshake_Message : TLS_Handshake_Handshake;
       begin
-         Client_Certificate_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CERTIFICATE, Length => Certificate'Length, Payload => Certificate)
-            where Certificate = TLS_Handshake.Certificate'(Certificate_Request_Context_Length => Certificate_Request.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request.Certificate_Request_Context, Certificate_List_Length => 0);
+         Client_Certificate_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CERTIFICATE, Length => Certificate'Length, Payload => Certificate)
+            where Certificate = TLS_Handshake_Certificate'(Certificate_Request_Context_Length => Certificate_Request.Certificate_Request_Context_Length, Certificate_Request_Context => Certificate_Request.Certificate_Request_Context, Certificate_List_Length => 0);
          Success := Write (Record_Data_Channel, Client_Certificate_Handshake_Message);
          Transcript_Hash := Update_Hash (Transcript_Hash, Client_Certificate_Handshake_Message'Opaque);
       transition
@@ -1237,21 +1332,21 @@ package TLS_Handshake_Session is
 
       state CONNECTED_PHA_QUERY_SIGNATURE is
       begin
-         Keystore_Message := Call (Keystore_Channel, GreenTLS.Keystore_Message'(Tag => GreenTLS.KEYSTORE_REQUEST, Request => GreenTLS.KEYSTORE_REQUEST_SIGNATURE, Length => Query'Length, Payload => Query)
-            where Query = GreenTLS.Signature_Query'(ID => GreenTLS.Certificate (Keystore_Message.Payload).ID, Length => Hash'Length, Data => Hash)
+         Keystore_Message := Call (Keystore_Channel, GreenTLS_Keystore_Message'(Tag => GreenTLS_KEYSTORE_REQUEST, Request => GreenTLS_KEYSTORE_REQUEST_SIGNATURE, Length => Query'Length, Payload => Query)
+            where Query = GreenTLS_Signature_Query'(ID => GreenTLS_Certificate (Keystore_Message.Payload).ID, Length => Hash'Length, Data => Hash)
                      where Hash = Get_Hash (Transcript_Hash).Data);
       transition
          then ERROR_INTERNAL_ERROR
             if Keystore_Message'Valid = False
-               or TLS_Handshake.Certificate_Verify (Keystore_Message.Payload)'Valid = False
+               or TLS_Handshake_Certificate_Verify (Keystore_Message.Payload)'Valid = False
          then CONNECTED_PHA_SEND_CERTIFICATE_VERIFY
       end CONNECTED_PHA_QUERY_SIGNATURE;
 
       state CONNECTED_PHA_SEND_CERTIFICATE_VERIFY is
-         Client_Certificate_Verify_Handshake_Message : TLS_Handshake.Handshake;
+         Client_Certificate_Verify_Handshake_Message : TLS_Handshake_Handshake;
       begin
-         Client_Certificate_Verify_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_CERTIFICATE_VERIFY, Length => Certificate_Verify'Length, Payload => Certificate_Verify)
-            where Certificate_Verify = TLS_Handshake.Certificate_Verify (Keystore_Message.Payload);
+         Client_Certificate_Verify_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_CERTIFICATE_VERIFY, Length => Certificate_Verify'Length, Payload => Certificate_Verify)
+            where Certificate_Verify = TLS_Handshake_Certificate_Verify (Keystore_Message.Payload);
          Success := Write (Record_Data_Channel, Client_Certificate_Verify_Handshake_Message);
          Transcript_Hash := Update_Hash (Transcript_Hash, Client_Certificate_Verify_Handshake_Message'Opaque);
       transition
@@ -1261,12 +1356,12 @@ package TLS_Handshake_Session is
       end CONNECTED_PHA_SEND_CERTIFICATE_VERIFY;
 
       state CONNECTED_PHA_SEND_FINISHED is
-         Verify_Data : GreenTLS.Content;
+         Verify_Data : GreenTLS_Content;
       begin
          Verify_Data := HMAC (Server_Hello_Message.Cipher_Suite, Finished_Key, Get_Hash (Transcript_Hash));
          Finished_Key := null;
-         Finished_Handshake_Message := TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_FINISHED, Length => Finished'Length, Payload => Finished)
-            where Finished = TLS_Handshake.Finished'(Verify_Data => Verify_Data);
+         Finished_Handshake_Message := TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_FINISHED, Length => Finished'Length, Payload => Finished)
+            where Finished = TLS_Handshake_Finished'(Verify_Data => Verify_Data);
          Success := Write (Record_Data_Channel, Finished_Handshake_Message);
       transition
          then ERROR_INTERNAL_ERROR
@@ -1275,35 +1370,35 @@ package TLS_Handshake_Session is
       end CONNECTED_PHA_SEND_FINISHED;
 
       state CONNECTED_KEY_UPDATE is
-         Server_Key : GreenTLS.Content;
-         Server_IV : GreenTLS.Content;
+         Server_Key : GreenTLS_Content;
+         Server_IV : GreenTLS_Content;
          Success_Server : Boolean;
       begin
-         Server_Application_Traffic_Secret := HKDF_Expand_Label (GreenTLS.Content'(Data => Server_Application_Traffic_Secret.Data), "traffic upd", Get_Hash (Empty_Hash), Hash_Length);
-         Server_Key := HKDF_Expand_Label (GreenTLS.Content'(Data => Server_Application_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
-         Server_IV := HKDF_Expand_Label (GreenTLS.Content'(Data => Server_Application_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
-         Success_Server := Write (Record_Control_Channel, GreenTLS.Control_Message'(Tag => GreenTLS.KEY_UPDATE_SERVER, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Record_Keys'(Key_Length => Server_Key'Length, Key => Server_Key.Data, IV_Length => Server_IV'Length, IV => Server_IV.Data));
+         Server_Application_Traffic_Secret := HKDF_Expand_Label (GreenTLS_Content'(Data => Server_Application_Traffic_Secret.Data), "traffic upd", Get_Hash (Empty_Hash), Hash_Length);
+         Server_Key := HKDF_Expand_Label (GreenTLS_Content'(Data => Server_Application_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
+         Server_IV := HKDF_Expand_Label (GreenTLS_Content'(Data => Server_Application_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
+         Success_Server := Write (Record_Control_Channel, GreenTLS_Control_Message'(Tag => GreenTLS_KEY_UPDATE_SERVER, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Record_Keys'(Key_Length => Server_Key'Length, Key => Server_Key.Data, IV_Length => Server_IV'Length, IV => Server_IV.Data));
       transition
          then ERROR_INTERNAL_ERROR
             if Success_Server = False
          then CONNECTED_SEND_KEY_UPDATE
-            if Key_Update_Message.Request_Update = TLS_Handshake.UPDATE_REQUESTED
+            if Key_Update_Message.Request_Update = TLS_Handshake_UPDATE_REQUESTED
          then CONNECTED
       end CONNECTED_KEY_UPDATE;
 
       state CONNECTED_SEND_KEY_UPDATE is
-         Client_Key : GreenTLS.Content;
-         Client_IV : GreenTLS.Content;
+         Client_Key : GreenTLS_Content;
+         Client_IV : GreenTLS_Content;
          Success_Client : Boolean;
       begin
-         Success := Write (Record_Data_Channel, TLS_Handshake.Handshake'(Tag => TLS_Handshake.HANDSHAKE_KEY_UPDATE, Length => KU'Length, Payload => KU)
-            where KU = TLS_Handshake.Key_Update'(Request_Update => TLS_Handshake.UPDATE_NOT_REQUESTED));
-         Client_Application_Traffic_Secret := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Application_Traffic_Secret), "traffic upd", Get_Hash (Empty_Hash), Hash_Length);
-         Client_Key := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Application_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
-         Client_IV := HKDF_Expand_Label (GreenTLS.Content'(Data => Client_Application_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
-         Success_Client := Write (Record_Control_Channel, GreenTLS.Control_Message'(Tag => GreenTLS.KEY_UPDATE_CLIENT, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Record_Keys'(Key_Length => Client_Key'Length, Key => Client_Key.Data, IV_Length => Client_IV'Length, IV => Client_IV.Data));
+         Success := Write (Record_Data_Channel, TLS_Handshake_Handshake'(Tag => TLS_Handshake_HANDSHAKE_KEY_UPDATE, Length => KU'Length, Payload => KU)
+            where KU = TLS_Handshake_Key_Update'(Request_Update => TLS_Handshake_UPDATE_NOT_REQUESTED));
+         Client_Application_Traffic_Secret := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Application_Traffic_Secret), "traffic upd", Get_Hash (Empty_Hash), Hash_Length);
+         Client_Key := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Application_Traffic_Secret.Data), "key", Get_Hash (Empty_Hash), Keystore_Message.Key_Length);
+         Client_IV := HKDF_Expand_Label (GreenTLS_Content'(Data => Client_Application_Traffic_Secret.Data), "iv", Get_Hash (Empty_Hash), Keystore_Message.IV_Length);
+         Success_Client := Write (Record_Control_Channel, GreenTLS_Control_Message'(Tag => GreenTLS_KEY_UPDATE_CLIENT, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Record_Keys'(Key_Length => Client_Key'Length, Key => Client_Key.Data, IV_Length => Client_IV'Length, IV => Client_IV.Data));
       transition
          then ERROR_INTERNAL_ERROR
             if Success = False
@@ -1313,107 +1408,107 @@ package TLS_Handshake_Session is
 
       state ERROR_INVALID_CONFIGURATION is
       begin
-         Error := TLS_Alert.ILLEGAL_PARAMETER;
+         Error := TLS_Alert_ILLEGAL_PARAMETER;
       transition
          then ERROR_SEND_LOCAL
       end ERROR_INVALID_CONFIGURATION;
 
       state ERROR_UNEXPECTED_MESSAGE is
       begin
-         Error := TLS_Alert.UNEXPECTED_MESSAGE;
+         Error := TLS_Alert_UNEXPECTED_MESSAGE;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_UNEXPECTED_MESSAGE;
 
       state ERROR_BAD_CERTIFICATE is
       begin
-         Error := TLS_Alert.BAD_CERTIFICATE;
+         Error := TLS_Alert_BAD_CERTIFICATE;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_BAD_CERTIFICATE;
 
       state ERROR_UNSUPPORTED_CERTIFICATE is
       begin
-         Error := TLS_Alert.UNSUPPORTED_CERTIFICATE;
+         Error := TLS_Alert_UNSUPPORTED_CERTIFICATE;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_UNSUPPORTED_CERTIFICATE;
 
       state ERROR_CERTIFICATE_REVOKED is
       begin
-         Error := TLS_Alert.CERTIFICATE_REVOKED;
+         Error := TLS_Alert_CERTIFICATE_REVOKED;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_CERTIFICATE_REVOKED;
 
       state ERROR_CERTIFICATE_EXPIRED is
       begin
-         Error := TLS_Alert.CERTIFICATE_EXPIRED;
+         Error := TLS_Alert_CERTIFICATE_EXPIRED;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_CERTIFICATE_EXPIRED;
 
       state ERROR_CERTIFICATE_UNKNOWN is
       begin
-         Error := TLS_Alert.CERTIFICATE_UNKNOWN;
+         Error := TLS_Alert_CERTIFICATE_UNKNOWN;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_CERTIFICATE_UNKNOWN;
 
       state ERROR_ILLEGAL_PARAMETER is
       begin
-         Error := TLS_Alert.ILLEGAL_PARAMETER;
+         Error := TLS_Alert_ILLEGAL_PARAMETER;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_ILLEGAL_PARAMETER;
 
       state ERROR_DECODE_ERROR is
       begin
-         Error := TLS_Alert.DECODE_ERROR;
+         Error := TLS_Alert_DECODE_ERROR;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_DECODE_ERROR;
 
       state ERROR_DECRYPT_ERROR is
       begin
-         Error := TLS_Alert.DECRYPT_ERROR;
+         Error := TLS_Alert_DECRYPT_ERROR;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_DECRYPT_ERROR;
 
       state ERROR_PROTOCOL_VERSION is
       begin
-         Error := TLS_Alert.PROTOCOL_VERSION;
+         Error := TLS_Alert_PROTOCOL_VERSION;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_PROTOCOL_VERSION;
 
       state ERROR_INTERNAL_ERROR is
       begin
-         Error := TLS_Alert.INTERNAL_ERROR;
+         Error := TLS_Alert_INTERNAL_ERROR;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_INTERNAL_ERROR;
 
       state ERROR_MISSING_EXTENSION is
       begin
-         Error := TLS_Alert.MISSING_EXTENSION;
+         Error := TLS_Alert_MISSING_EXTENSION;
       transition
          then ERROR_SEND_REMOTE
       end ERROR_MISSING_EXTENSION;
 
       state ERROR_SEND_REMOTE is
       begin
-         Success := Write (Record_Control_Channel, GreenTLS.Control_Message'(Tag => TLS_Alert.ALERT, Length => Alert_Message'Length, Data => Alert_Message)
-            where Alert_Message = GreenTLS.Alert_Message'(Description => Error));
+         Success := Write (Record_Control_Channel, GreenTLS_Control_Message'(Tag => TLS_Alert_ALERT, Length => Alert_Message'Length, Data => Alert_Message)
+            where Alert_Message = GreenTLS_Alert_Message'(Description => Error));
       transition
          then ERROR_SEND_LOCAL
       end ERROR_SEND_REMOTE;
 
       state ERROR_SEND_LOCAL is
       begin
-         Success := Write (Application_Control_Channel, GreenTLS.Application_Control_Message'(Tag => GreenTLS.APPLICATION_ALERT, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Alert_Message'(Description => Error));
+         Success := Write (Application_Control_Channel, GreenTLS_Application_Control_Message'(Tag => GreenTLS_APPLICATION_ALERT, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Alert_Message'(Description => Error));
       transition
          then TERMINATED
       end ERROR_SEND_LOCAL;

--- a/tests/tls_record_session.rflx
+++ b/tests/tls_record_session.rflx
@@ -7,38 +7,61 @@ package TLS_Record_Session is
       Handshake_Control_Channel : Channel with Readable;
       Handshake_Data_Channel : Channel with Readable, Writable;
       Heartbeat_Data_Channel : Channel with Readable, Writable;
-      with function Decrypt (Server_Key_Update_Message : GreenTLS.Key_Update_Message; Server_Sequence_Number : GreenTLS.Sequence_Number; Encrypted_Record : Payload) return TLS_Record.TLS_Inner_Plaintext;
-      with function Encrypt (Client_Key_Update_Message : GreenTLS.Key_Update_Message; Client_Sequence_Number : GreenTLS.Sequence_Number; Fragment : Payload) return GreenTLS.Content;
+      with function Decrypt (Server_Key_Update_Message : GreenTLS_Key_Update_Message; Server_Sequence_Number : GreenTLS_Sequence_Number; Encrypted_Record : Payload) return TLS_Record_TLS_Inner_Plaintext;
+      with function Encrypt (Client_Key_Update_Message : GreenTLS_Key_Update_Message; Client_Sequence_Number : GreenTLS_Sequence_Number; Fragment : Payload) return GreenTLS_Content;
    session Client with
       Initial => IDLE,
       Final => TERMINATED
    is
-      GreenTLS : Dummy;
-      TLS_Record : Dummy;
-      TLS_Alert : Dummy;
-      Alert_Message : TLS_Alert.Alert;
-      Application_Control_Message : GreenTLS.Application_Control_Message;
-      Ciphertext : GreenTLS.Content;
-      Client_Key_Update_Message : GreenTLS.Key_Update_Message;
-      Client_Sequence_Number : GreenTLS.Sequence_Number := 0;
+      GreenTLS_ALERT : Dummy;
+      GreenTLS_APPLICATION_ALERT : Dummy;
+      GreenTLS_APPLICATION_SHUTDOWN : Dummy;
+      GreenTLS_Heartbeat_Control_Message : Dummy;
+      GreenTLS_HEARTBEAT_ENABLED : Dummy;
+      GreenTLS_HEARTBEAT_MODE : Dummy;
+      GreenTLS_KEY_UPDATE_CLIENT : Dummy;
+      GreenTLS_Key_Update_Message : Dummy;
+      GreenTLS_KEY_UPDATE_SERVER : Dummy;
+      TLS_Alert_Alert : Dummy;
+      TLS_Alert_BAD_RECORD_MAC : Dummy;
+      TLS_Alert_CLOSE_NOTIFY : Dummy;
+      TLS_Alert_DECODE_ERROR : Dummy;
+      TLS_Alert_FATAL : Dummy;
+      TLS_Alert_INTERNAL_ERROR : Dummy;
+      TLS_Alert_UNEXPECTED_MESSAGE : Dummy;
+      TLS_Alert_WARNING : Dummy;
+      TLS_Record_ALERT : Dummy;
+      TLS_Record_APPLICATION_DATA : Dummy;
+      TLS_Record_APPLICATION : Dummy;
+      TLS_Record_CHANGE_CIPHER_SPEC : Dummy;
+      TLS_Record_HANDSHAKE : Dummy;
+      TLS_Record_HEARTBEAT : Dummy;
+      TLS_Record_TLS_1_2 : Dummy;
+      GreenTLS_Alert_Message : Dummy;
+
+      Alert_Message : TLS_Alert_Alert;
+      Application_Control_Message : GreenTLS_Application_Control_Message;
+      Ciphertext : GreenTLS_Content;
+      Client_Key_Update_Message : GreenTLS_Key_Update_Message;
+      Client_Sequence_Number : GreenTLS_Sequence_Number := 0;
       Client_Write_Key_Received : Boolean := False;
-      Error : TLS_Alert.Alert_Description;
+      Error : TLS_Alert_Alert_Description;
       Error_Sent : Boolean := False;
-      Handshake_Control_Message : GreenTLS.Control_Message;
-      Handshake_Message : GreenTLS.Content;
-      Heartbeat_Data_Message : GreenTLS.Content;
-      Heartbeat_Control_Message : GreenTLS.Heartbeat_Control_Message;
+      Handshake_Control_Message : GreenTLS_Control_Message;
+      Handshake_Message : GreenTLS_Content;
+      Heartbeat_Data_Message : GreenTLS_Content;
+      Heartbeat_Control_Message : GreenTLS_Heartbeat_Control_Message;
       Heartbeat_Receive_Enabled : Boolean := False;
       Heartbeat_Send_Enabled : Boolean := False;
       Network_Receive_Enabled : Boolean := True;
       Network_Send_Enabled : Boolean := True;
-      Plaintext : GreenTLS.Content;
+      Plaintext : GreenTLS_Content;
       Record_Protection : Boolean := False;
-      Server_Key_Update_Message : GreenTLS.Key_Update_Message;
-      Server_Sequence_Number : GreenTLS.Sequence_Number := 0;
+      Server_Key_Update_Message : GreenTLS_Key_Update_Message;
+      Server_Sequence_Number : GreenTLS_Sequence_Number := 0;
       Server_Write_Key_Received : Boolean := False;
-      TLS_Inner_Plaintext : TLS_Record.TLS_Inner_Plaintext;
-      TLS_Record_Message : TLS_Record.TLS_Record;
+      TLS_Inner_Plaintext : TLS_Record_TLS_Inner_Plaintext;
+      TLS_Record_Message : TLS_Record_TLS_Record;
    begin
       state IDLE is
       begin
@@ -117,15 +140,15 @@ package TLS_Record_Session is
          then ERROR_INTERNAL_ERROR
             if Application_Control_Message'Valid = False
          then SHUTDOWN
-            if Application_Control_Message.Tag = GreenTLS.APPLICATION_SHUTDOWN
+            if Application_Control_Message.Tag = GreenTLS_APPLICATION_SHUTDOWN
          then ERROR_INTERNAL_ERROR
       end CONTROL;
 
       state SHUTDOWN is
          Success : Boolean;
       begin
-         Alert_Message := TLS_Alert.Alert'(Level => TLS_Alert.WARNING, Description => TLS_Alert.CLOSE_NOTIFY);
-         Success := Write (Network_Channel, TLS_Record.TLS_Record'(Tag => TLS_Record.ALERT, Legacy_Record_Version => TLS_Record.TLS_1_2, Length => Alert_Message'Length, Fragment => Alert_Message));
+         Alert_Message := TLS_Alert_Alert'(Level => TLS_Alert_WARNING, Description => TLS_Alert_CLOSE_NOTIFY);
+         Success := Write (Network_Channel, TLS_Record_TLS_Record'(Tag => TLS_Record_ALERT, Legacy_Record_Version => TLS_Record_TLS_1_2, Length => Alert_Message'Length, Fragment => Alert_Message));
          Network_Send_Enabled := False;
       transition
          then ERROR_INTERNAL_ERROR
@@ -140,19 +163,19 @@ package TLS_Record_Session is
          then ERROR_INTERNAL_ERROR
             if Handshake_Control_Message'Valid = False
          then KEY_UPDATE_CLIENT
-            if Handshake_Control_Message.Tag = GreenTLS.KEY_UPDATE_CLIENT
+            if Handshake_Control_Message.Tag = GreenTLS_KEY_UPDATE_CLIENT
          then KEY_UPDATE_SERVER
-            if Handshake_Control_Message.Tag = GreenTLS.KEY_UPDATE_SERVER
+            if Handshake_Control_Message.Tag = GreenTLS_KEY_UPDATE_SERVER
          then HEARTBEAT_CONTROL
-            if Handshake_Control_Message.Tag = GreenTLS.HEARTBEAT_MODE
+            if Handshake_Control_Message.Tag = GreenTLS_HEARTBEAT_MODE
          then HANDSHAKE_ALERT
-            if Handshake_Control_Message.Tag = GreenTLS.ALERT
+            if Handshake_Control_Message.Tag = GreenTLS_ALERT
          then ERROR_INTERNAL_ERROR
       end HANDSHAKE_CONTROL;
 
       state KEY_UPDATE_CLIENT is
       begin
-         Client_Key_Update_Message := GreenTLS.Key_Update_Message (Handshake_Control_Message.Payload);
+         Client_Key_Update_Message := GreenTLS_Key_Update_Message (Handshake_Control_Message.Payload);
          Client_Write_Key_Received := True;
          Client_Sequence_Number := 0;
          Record_Protection := True;
@@ -164,7 +187,7 @@ package TLS_Record_Session is
 
       state KEY_UPDATE_SERVER is
       begin
-         Server_Key_Update_Message := GreenTLS.Key_Update_Message (Handshake_Control_Message.Payload);
+         Server_Key_Update_Message := GreenTLS_Key_Update_Message (Handshake_Control_Message.Payload);
          Server_Write_Key_Received := True;
          Server_Sequence_Number := 0;
       transition
@@ -175,8 +198,8 @@ package TLS_Record_Session is
 
       state HANDSHAKE_ALERT is
       begin
-         TLS_Record_Message := TLS_Record.TLS_Record'(Tag => TLS_Record.ALERT, Legacy_Record_Version => TLS_Record.TLS_1_2, Length => Alert_Message'Length, Fragment => Alert_Message.Data)
-            where Alert_Message = TLS_Alert.TLS_Alert'(Level => TLS_Alert.FATAL, Description => GreenTLS.Alert_Message (Handshake_Control_Message.Data).Description);
+         TLS_Record_Message := TLS_Record_TLS_Record'(Tag => TLS_Record_ALERT, Legacy_Record_Version => TLS_Record_TLS_1_2, Length => Alert_Message'Length, Fragment => Alert_Message.Data)
+            where Alert_Message = TLS_Alert_TLS_Alert'(Level => TLS_Alert_FATAL, Description => GreenTLS_Alert_Message (Handshake_Control_Message.Data).Description);
       transition
          then NETWORK_OUT_SEND
       end HANDSHAKE_ALERT;
@@ -184,7 +207,7 @@ package TLS_Record_Session is
       state HANDSHAKE is
       begin
          Handshake_Message := Read (Handshake_Data_Channel);
-         TLS_Record_Message := TLS_Record.TLS_Record'(Tag => TLS_Record.HANDSHAKE, Legacy_Record_Version => TLS_Record.TLS_1_2, Length => Handshake_Message'Length, Fragment => Handshake_Message.Data);
+         TLS_Record_Message := TLS_Record_TLS_Record'(Tag => TLS_Record_HANDSHAKE, Legacy_Record_Version => TLS_Record_TLS_1_2, Length => Handshake_Message'Length, Fragment => Handshake_Message.Data);
       transition
          then ERROR_INTERNAL_ERROR
             if Handshake_Message'Valid = False
@@ -198,21 +221,21 @@ package TLS_Record_Session is
          then ERROR_DECODE_ERROR
             if TLS_Record_Message'Valid = False
          then ERROR_UNEXPECTED_MESSAGE
-            if TLS_Record_Message.Tag = TLS_Record.APPLICATION_DATA
+            if TLS_Record_Message.Tag = TLS_Record_APPLICATION_DATA
                and Server_Write_Key_Received = False
          then NETWORK_IN_DECRYPT
-            if TLS_Record_Message.Tag = TLS_Record.APPLICATION_DATA
+            if TLS_Record_Message.Tag = TLS_Record_APPLICATION_DATA
                and Server_Write_Key_Received = True
          then NETWORK_IN_CONTENT
-            if TLS_Record_Message.Tag = TLS_Record.HANDSHAKE
-               or TLS_Record_Message.Tag = TLS_Record.ALERT
+            if TLS_Record_Message.Tag = TLS_Record_HANDSHAKE
+               or TLS_Record_Message.Tag = TLS_Record_ALERT
          then NETWORK_IN_HANDSHAKE
-            if TLS_Record_Message.Tag = TLS_Record.CHANGE_CIPHER_SPEC
+            if TLS_Record_Message.Tag = TLS_Record_CHANGE_CIPHER_SPEC
          then NETWORK_IN_HEARTBEAT
-            if TLS_Record_Message.Tag = TLS_Record.HEARTBEAT
+            if TLS_Record_Message.Tag = TLS_Record_HEARTBEAT
                and Heartbeat_Receive_Enabled = True
          then ERROR_UNEXPECTED_MESSAGE
-            if TLS_Record_Message.Tag = TLS_Record.HEARTBEAT
+            if TLS_Record_Message.Tag = TLS_Record_HEARTBEAT
                and Heartbeat_Receive_Enabled = False
          then ERROR_INTERNAL_ERROR
       end NETWORK_IN;
@@ -221,31 +244,31 @@ package TLS_Record_Session is
       begin
          TLS_Inner_Plaintext := Decrypt (Server_Key_Update_Message, Server_Sequence_Number, TLS_Record_Message.Encrypted_Record);
          Server_Sequence_Number := Server_Sequence_Number + 1;
-         Plaintext := GreenTLS.Content'(Data => TLS_Inner_Plaintext.Content);
+         Plaintext := GreenTLS_Content'(Data => TLS_Inner_Plaintext.Content);
       transition
          then ERROR_BAD_RECORD_MAC
             if TLS_Inner_Plaintext'Valid = False
          then ERROR_INTERNAL_ERROR
             if Plaintext'Valid = False
          then NETWORK_IN_APPLICATION
-            if TLS_Inner_Plaintext.Tag = TLS_Record.APPLICATION_DATA
+            if TLS_Inner_Plaintext.Tag = TLS_Record_APPLICATION_DATA
          then NETWORK_IN_HANDSHAKE
-            if TLS_Inner_Plaintext.Tag = TLS_Record.HANDSHAKE
+            if TLS_Inner_Plaintext.Tag = TLS_Record_HANDSHAKE
          then NETWORK_IN_ALERT
-            if TLS_Inner_Plaintext.Tag = TLS_Record.ALERT
+            if TLS_Inner_Plaintext.Tag = TLS_Record_ALERT
          then ERROR_INTERNAL_ERROR
       end NETWORK_IN_DECRYPT;
 
       state NETWORK_IN_CONTENT is
       begin
-         Plaintext := GreenTLS.Content'(Data => TLS_Record_Message.Fragment);
+         Plaintext := GreenTLS_Content'(Data => TLS_Record_Message.Fragment);
       transition
          then ERROR_INTERNAL_ERROR
             if Plaintext'Valid = False
          then NETWORK_IN_HANDSHAKE
-            if TLS_Record_Message.Tag = TLS_Record.HANDSHAKE
+            if TLS_Record_Message.Tag = TLS_Record_HANDSHAKE
          then NETWORK_IN_ALERT
-            if TLS_Record_Message.Tag = TLS_Record.ALERT
+            if TLS_Record_Message.Tag = TLS_Record_ALERT
          then ERROR_INTERNAL_ERROR
       end NETWORK_IN_CONTENT;
 
@@ -281,12 +304,12 @@ package TLS_Record_Session is
 
       state NETWORK_IN_ALERT is
       begin
-         Alert_Message := TLS_Alert.Alert (Plaintext.Data);
+         Alert_Message := TLS_Alert_Alert (Plaintext.Data);
       transition
          then ERROR_DECODE_ERROR
             if Alert_Message'Valid = False
          then NETWORK_IN_ALERT_CLOSE
-            if Alert_Message.Description = TLS_Alert.CLOSE_NOTIFY
+            if Alert_Message.Description = TLS_Alert_CLOSE_NOTIFY
          then NETWORK_IN_ALERT_TERMINATE
       end NETWORK_IN_ALERT;
 
@@ -294,7 +317,7 @@ package TLS_Record_Session is
          Success : Boolean;
       begin
          Network_Receive_Enabled := False;
-         Success := Write (Application_Control_Channel, GreenTLS.Application_Control_Message'(Tag => GreenTLS.APPLICATION_ALERT, Length => Description'Length, Data => Description)
+         Success := Write (Application_Control_Channel, GreenTLS_Application_Control_Message'(Tag => GreenTLS_APPLICATION_ALERT, Length => Description'Length, Data => Description)
             where Description = Alert_Message.Description);
       transition
          then ERROR_INTERNAL_ERROR
@@ -314,7 +337,7 @@ package TLS_Record_Session is
       state NETWORK_OUT_APPLICATION is
       begin
          Plaintext := Read (Data_Channel);
-         TLS_Record_Message := TLS_Record.TLS_Record'(Tag => TLS_Record.APPLICATION, Legacy_Record_Version => TLS_Record.TLS_1_2, Length => Plaintext.Data'Length, Fragment => Plaintext.Data);
+         TLS_Record_Message := TLS_Record_TLS_Record'(Tag => TLS_Record_APPLICATION, Legacy_Record_Version => TLS_Record_TLS_1_2, Length => Plaintext.Data'Length, Fragment => Plaintext.Data);
       transition
          then NETWORK_OUT_SEND_ENCRYPTED
       end NETWORK_OUT_APPLICATION;
@@ -361,14 +384,14 @@ package TLS_Record_Session is
       state HEARTBEAT is
       begin
          Heartbeat_Data_Message := Read (Heartbeat_Data_Channel);
-         TLS_Record_Message := TLS_Record.TLS_Record'(Tag => TLS_Record.HEARTBEAT, Legacy_Record_Version => TLS_Record.TLS_1_2, Length => Heartbeat_Data_Message.Length, Fragment => Heartbeat_Data_Message.Data);
+         TLS_Record_Message := TLS_Record_TLS_Record'(Tag => TLS_Record_HEARTBEAT, Legacy_Record_Version => TLS_Record_TLS_1_2, Length => Heartbeat_Data_Message.Length, Fragment => Heartbeat_Data_Message.Data);
       transition
          then NETWORK_OUT_SEND_ENCRYPTED
       end HEARTBEAT;
 
       state HEARTBEAT_CONTROL is
       begin
-         Heartbeat_Control_Message := GreenTLS.Heartbeat_Control_Message (Handshake_Control_Message.Payload);
+         Heartbeat_Control_Message := GreenTLS_Heartbeat_Control_Message (Handshake_Control_Message.Payload);
       transition
          then ERROR_INTERNAL_ERROR
             if Heartbeat_Control_Message'Valid = False
@@ -377,36 +400,36 @@ package TLS_Record_Session is
 
       state HEARTBEAT_CONTROL_CONFIGURE is
       begin
-         Heartbeat_Receive_Enabled := Heartbeat_Control_Message.Receive = GreenTLS.HEARTBEAT_ENABLED;
-         Heartbeat_Send_Enabled := Heartbeat_Control_Message.Send = GreenTLS.HEARTBEAT_ENABLED;
+         Heartbeat_Receive_Enabled := Heartbeat_Control_Message.Receive = GreenTLS_HEARTBEAT_ENABLED;
+         Heartbeat_Send_Enabled := Heartbeat_Control_Message.Send = GreenTLS_HEARTBEAT_ENABLED;
       transition
          then IDLE
       end HEARTBEAT_CONTROL_CONFIGURE;
 
       state ERROR_UNEXPECTED_MESSAGE is
       begin
-         Error := TLS_Alert.UNEXPECTED_MESSAGE;
+         Error := TLS_Alert_UNEXPECTED_MESSAGE;
       transition
          then ERROR_SEND_LOCAL
       end ERROR_UNEXPECTED_MESSAGE;
 
       state ERROR_BAD_RECORD_MAC is
       begin
-         Error := TLS_Alert.BAD_RECORD_MAC;
+         Error := TLS_Alert_BAD_RECORD_MAC;
       transition
          then ERROR_SEND_LOCAL
       end ERROR_BAD_RECORD_MAC;
 
       state ERROR_DECODE_ERROR is
       begin
-         Error := TLS_Alert.DECODE_ERROR;
+         Error := TLS_Alert_DECODE_ERROR;
       transition
          then ERROR_SEND_LOCAL
       end ERROR_DECODE_ERROR;
 
       state ERROR_INTERNAL_ERROR is
       begin
-         Error := TLS_Alert.INTERNAL_ERROR;
+         Error := TLS_Alert_INTERNAL_ERROR;
       transition
          then ERROR_SEND_LOCAL
       end ERROR_INTERNAL_ERROR;
@@ -414,8 +437,8 @@ package TLS_Record_Session is
       state ERROR_SEND_LOCAL is
          Success : Boolean;
       begin
-         Success := Write (Application_Control_Channel, GreenTLS.Application_Control_Message'(Tag => GreenTLS.APPLICATION_ALERT, Length => Data'Length, Data => Data)
-            where Data = GreenTLS.Alert_Message'(Description => Error));
+         Success := Write (Application_Control_Channel, GreenTLS_Application_Control_Message'(Tag => GreenTLS_APPLICATION_ALERT, Length => Data'Length, Data => Data)
+            where Data = GreenTLS_Alert_Message'(Description => Error));
       transition
          then ERROR_SEND_REMOTE
             if Network_Send_Enabled = True
@@ -424,8 +447,8 @@ package TLS_Record_Session is
 
       state ERROR_SEND_REMOTE is
       begin
-         Alert_Message := TLS_Alert.TLS_Alert'(Level => TLS_Alert.FATAL, Description => Error);
-         TLS_Record_Message := TLS_Record.TLS_Record'(Tag => TLS_Record.ALERT, Legacy_Record_Version => TLS_Record.TLS_1_2, Length => Alert_Message'Length, Fragment => Alert_Message);
+         Alert_Message := TLS_Alert_TLS_Alert'(Level => TLS_Alert_FATAL, Description => Error);
+         TLS_Record_Message := TLS_Record_TLS_Record'(Tag => TLS_Record_ALERT, Legacy_Record_Version => TLS_Record_TLS_1_2, Length => Alert_Message'Length, Fragment => Alert_Message);
          Error_Sent := True;
       transition
          then NETWORK_OUT_SEND_UNENCRYPTED

--- a/tests/type_refinement.rflx
+++ b/tests/type_refinement.rflx
@@ -2,9 +2,9 @@ with Message_Type;
 
 package Type_Refinement is
 
-   for Message_Type.Simple_PDU use (Bar => Message_Type.PDU)
+   for Message_Type::Simple_PDU use (Bar => Message_Type::PDU)
       if Baz = 42;
 
-   for Message_Type.PDU use (Bar => Message_Type.Simple_PDU);
+   for Message_Type::PDU use (Bar => Message_Type::Simple_PDU);
 
 end Type_Refinement;

--- a/tests/unit/ada_test.py
+++ b/tests/unit/ada_test.py
@@ -2,6 +2,34 @@ import rflx.ada as ada
 from tests.utils import assert_equal, multilinestr
 
 
+def test_id_str() -> None:
+    assert str(ada.ID("A.B.C")) == "A.B.C"
+
+
+def test_id_add() -> None:
+    assert ada.ID("A") + ada.ID("B.C") == ada.ID("AB.C")
+    assert ada.ID("B.C") + ada.ID("D") == ada.ID("B.CD")
+
+
+def test_id_add_str() -> None:
+    assert "A" + ada.ID("B.C") == ada.ID("AB.C")
+    assert ada.ID("B.C") + "D" == ada.ID("B.CD")
+    assert ada.ID("B.C") + "" == ada.ID("B.C")
+    assert "" + ada.ID("B.C") == ada.ID("B.C")
+
+
+def test_id_mul_id() -> None:
+    assert ada.ID("A") * ada.ID("B.C") == ada.ID("A.B.C")
+    assert ada.ID("B.C") * ada.ID("D") == ada.ID("B.C.D")
+
+
+def test_id_mul_str() -> None:
+    assert "A" * ada.ID("B.C") == ada.ID("A.B.C")
+    assert ada.ID("B.C") * "D" == ada.ID("B.C.D")
+    assert "" * ada.ID("B.C") == ada.ID("B.C")
+    assert ada.ID("B.C") * "" == ada.ID("B.C")
+
+
 def test_bool_expr_str() -> None:
     assert_equal(
         str(

--- a/tests/unit/expression_test.py
+++ b/tests/unit/expression_test.py
@@ -1650,16 +1650,16 @@ def test_binding_simplified_list_comprehension() -> None:
         Comprehension(
             "E",
             Variable("List"),
-            Variable("E.Bar"),
-            Equal(Variable("E.Tag"), Variable("Foo")),
+            Selected(Variable("E"), "Bar"),
+            Equal(Selected(Variable("E"), "Tag"), Variable("Foo")),
         ),
         {"List": Variable("Foo")},
     )
     expected = Comprehension(
         "E",
         Variable("Foo"),
-        Variable("E.Bar"),
-        Equal(Variable("E.Tag"), Variable("Foo")),
+        Selected(Variable("E"), "Bar"),
+        Equal(Selected(Variable("E"), "Tag"), Variable("Foo")),
     )
     result = binding.simplified()
     assert result == expected

--- a/tests/unit/identifier_test.py
+++ b/tests/unit/identifier_test.py
@@ -20,6 +20,12 @@ def test_id_invalid_type() -> None:
 
 @pytest.mark.skipif(not __debug__, reason="depends on assertion")
 def test_id_invalid_empty() -> None:
+    with pytest.raises(AssertionError, match=r"^empty identifier$"):
+        ID([])
+
+
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
+def test_id_invalid_empty_string() -> None:
     with pytest.raises(AssertionError, match=r"^empty part in identifier$"):
         ID("")
 
@@ -88,6 +94,12 @@ def test_id_name() -> None:
 
 def test_id_parent() -> None:
     assert ID("A::B::C").parent == ID("A::B")
+
+
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
+def test_id_parent_error() -> None:
+    with pytest.raises(AssertionError, match=r"^empty identifier$"):
+        ID("A").parent  # pylint: disable=expression-not-assigned
 
 
 def test_id_sorted() -> None:

--- a/tests/unit/identifier_test.py
+++ b/tests/unit/identifier_test.py
@@ -5,83 +5,89 @@ from rflx.identifier import ID
 
 def test_id_constructor() -> None:
     assert ID(["A"]) == ID("A")
-    assert ID(["A", "B"]) == ID("A.B")
-    assert ID(["A", "B", "C"]) == ID("A.B.C")
+    assert ID(["A", "B"]) == ID("A::B")
+    assert ID(["A", "B", "C"]) == ID("A::B::C")
     assert ID(ID("A")) == ID("A")
-    assert ID(ID("A.B")) == ID("A.B")
-    assert ID(ID("A.B.C")) == ID("A.B.C")
+    assert ID(ID("A::B")) == ID("A::B")
+    assert ID(ID("A::B::C")) == ID("A::B::C")
 
 
-@pytest.mark.skipif(not __debug__, reason="depends on contract")
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
 def test_id_invalid_type() -> None:
     with pytest.raises(AssertionError, match=r'^unexpected identifier type "int"$'):
         ID(0)  # type: ignore
 
 
-@pytest.mark.skipif(not __debug__, reason="depends on contract")
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
 def test_id_invalid_empty() -> None:
-    with pytest.raises(AssertionError, match=r"empty part in identifier"):
+    with pytest.raises(AssertionError, match=r"^empty part in identifier$"):
         ID("")
 
 
-@pytest.mark.skipif(not __debug__, reason="depends on contract")
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
 def test_id_invalid_empty_part() -> None:
-    with pytest.raises(AssertionError, match=r"empty part in identifier"):
-        ID("A..B")
+    with pytest.raises(AssertionError, match=r"^empty part in identifier$"):
+        ID("A::::B")
 
 
-@pytest.mark.skipif(not __debug__, reason="depends on contract")
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
 def test_id_invalid_empty_first_part() -> None:
-    with pytest.raises(AssertionError, match=r"empty part in identifier"):
-        ID(".A.B")
+    with pytest.raises(AssertionError, match=r"^empty part in identifier$"):
+        ID("::A::B")
 
 
-@pytest.mark.skipif(not __debug__, reason="depends on contract")
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
 def test_id_invalid_empty_last_part() -> None:
-    with pytest.raises(AssertionError, match=r"empty part in identifier"):
-        ID("A.B.")
+    with pytest.raises(AssertionError, match=r"^empty part in identifier$"):
+        ID("A::B::")
 
 
-@pytest.mark.skipif(not __debug__, reason="depends on contract")
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
 def test_id_invalid_whitespace() -> None:
-    with pytest.raises(AssertionError, match=r"whitespace in identifier"):
-        ID("A.B C.D")
+    with pytest.raises(AssertionError, match=r'^" " in identifier parts$'):
+        ID("A::B C::D")
+
+
+@pytest.mark.skipif(not __debug__, reason="depends on assertion")
+def test_id_invalid_colon() -> None:
+    with pytest.raises(AssertionError, match=r'^":" in identifier parts$'):
+        ID("A::B:C::D")
 
 
 def test_id_str() -> None:
-    assert str(ID("A.B.C")) == "A.B.C"
+    assert str(ID("A::B::C")) == "A::B::C"
 
 
 def test_id_add() -> None:
-    assert ID("A") + ID("B.C") == ID("AB.C")
-    assert ID("B.C") + ID("D") == ID("B.CD")
+    assert ID("A") + ID("B::C") == ID("AB::C")
+    assert ID("B::C") + ID("D") == ID("B::CD")
 
 
 def test_id_add_str() -> None:
-    assert "A" + ID("B.C") == ID("AB.C")
-    assert ID("B.C") + "D" == ID("B.CD")
-    assert ID("B.C") + "" == ID("B.C")
-    assert "" + ID("B.C") == ID("B.C")
+    assert "A" + ID("B::C") == ID("AB::C")
+    assert ID("B::C") + "D" == ID("B::CD")
+    assert ID("B::C") + "" == ID("B::C")
+    assert "" + ID("B::C") == ID("B::C")
 
 
 def test_id_mul_id() -> None:
-    assert ID("A") * ID("B.C") == ID("A.B.C")
-    assert ID("B.C") * ID("D") == ID("B.C.D")
+    assert ID("A") * ID("B::C") == ID("A::B::C")
+    assert ID("B::C") * ID("D") == ID("B::C::D")
 
 
 def test_id_mul_str() -> None:
-    assert "A" * ID("B.C") == ID("A.B.C")
-    assert ID("B.C") * "D" == ID("B.C.D")
-    assert "" * ID("B.C") == ID("B.C")
-    assert ID("B.C") * "" == ID("B.C")
+    assert "A" * ID("B::C") == ID("A::B::C")
+    assert ID("B::C") * "D" == ID("B::C::D")
+    assert "" * ID("B::C") == ID("B::C")
+    assert ID("B::C") * "" == ID("B::C")
 
 
 def test_id_name() -> None:
-    assert ID("A.B.C").name == ID("C")
+    assert ID("A::B::C").name == ID("C")
 
 
 def test_id_parent() -> None:
-    assert ID("A.B.C").parent == ID("A.B")
+    assert ID("A::B::C").parent == ID("A::B")
 
 
 def test_id_sorted() -> None:

--- a/tests/unit/model/message_test.py
+++ b/tests/unit/model/message_test.py
@@ -65,7 +65,7 @@ from tests.utils import (
 )
 
 M_NO_REF = UnprovenMessage(
-    "P.No_Ref",
+    "P::No_Ref",
     [
         Link(INITIAL, Field("F1"), length=Number(16)),
         Link(Field("F1"), Field("F2")),
@@ -88,14 +88,14 @@ M_NO_REF = UnprovenMessage(
 )
 
 M_SMPL_REF = UnprovenMessage(
-    "P.Smpl_Ref",
+    "P::Smpl_Ref",
     [Link(INITIAL, Field("NR")), Link(Field("NR"), FINAL)],
     {Field("NR"): deepcopy(M_NO_REF)},
 )
 
 
 M_CMPLX_REF = UnprovenMessage(
-    "P.Cmplx_Ref",
+    "P::Cmplx_Ref",
     [
         Link(INITIAL, Field("F1")),
         Link(Field("F1"), Field("F2"), LessEqual(Variable("F1"), Number(100))),
@@ -119,14 +119,14 @@ M_CMPLX_REF = UnprovenMessage(
 
 
 M_DBL_REF = UnprovenMessage(
-    "P.Dbl_Ref",
+    "P::Dbl_Ref",
     [Link(INITIAL, Field("SR")), Link(Field("SR"), Field("NR")), Link(Field("NR"), FINAL)],
     {Field("SR"): deepcopy(M_SMPL_REF), Field("NR"): deepcopy(M_NO_REF)},
 )
 
 
 M_NO_REF_DERI = UnprovenDerivedMessage(
-    "P.No_Ref_Deri",
+    "P::No_Ref_Deri",
     M_NO_REF,
     [
         Link(INITIAL, Field("F1"), length=Number(16)),
@@ -151,7 +151,7 @@ M_NO_REF_DERI = UnprovenDerivedMessage(
 
 
 M_SMPL_REF_DERI = UnprovenDerivedMessage(
-    "P.Smpl_Ref_Deri",
+    "P::Smpl_Ref_Deri",
     M_SMPL_REF,
     [Link(INITIAL, Field("NR")), Link(Field("NR"), FINAL)],
     {Field("NR"): deepcopy(M_NO_REF_DERI)},
@@ -180,12 +180,12 @@ def test_missing_type() -> None:
     assert_message_model_error(
         structure,
         {},
-        '^<stdin>:5:6: model: error: missing type for field "X" in "P.M"$',
+        '^<stdin>:5:6: model: error: missing type for field "X" in "P::M"$',
     )
 
 
 def test_unused_type() -> None:
-    t = ModularInteger("P.T", Number(2))
+    t = ModularInteger("P::T", Number(2))
 
     structure = [
         Link(INITIAL, Field("X")),
@@ -195,12 +195,12 @@ def test_unused_type() -> None:
     types = {Field("X"): t, Field(ID("Y", Location((5, 6)))): t}
 
     assert_message_model_error(
-        structure, types, '^<stdin>:5:6: model: error: unused field "Y" in "P.M"$'
+        structure, types, '^<stdin>:5:6: model: error: unused field "Y" in "P::M"$'
     )
 
 
 def test_ambiguous_first_field() -> None:
-    t = ModularInteger("P.T", Number(2))
+    t = ModularInteger("P::T", Number(2))
 
     structure = [
         Link(INITIAL, Field(ID("X", Location((2, 6))))),
@@ -215,7 +215,7 @@ def test_ambiguous_first_field() -> None:
     assert_message_model_error(
         structure,
         types,
-        '^<stdin>:10:8: model: error: ambiguous first field in "P.M"\n'
+        '^<stdin>:10:8: model: error: ambiguous first field in "P::M"\n'
         "<stdin>:2:6: model: info: duplicate\n"
         "<stdin>:3:6: model: info: duplicate",
         location=Location((10, 8)),
@@ -224,7 +224,7 @@ def test_ambiguous_first_field() -> None:
 
 def test_name_conflict_field_enum() -> None:
     t = Enumeration(
-        "P.T",
+        "P::T",
         [(ID("X", Location((3, 27))), Number(1)), (ID("Y", Location((3, 32))), Number(2))],
         Number(8),
         False,
@@ -240,13 +240,13 @@ def test_name_conflict_field_enum() -> None:
     assert_message_model_error(
         structure,
         types,
-        '^<stdin>:5:6: model: error: name conflict for field "X" in "P.M"\n'
+        '^<stdin>:5:6: model: error: name conflict for field "X" in "P::M"\n'
         "<stdin>:3:27: model: info: conflicting enumeration literal",
     )
 
 
 def test_duplicate_link() -> None:
-    t = ModularInteger("P.T", Number(2))
+    t = ModularInteger("P::T", Number(2))
     x = Field(ID("X", location=Location((1, 5))))
 
     structure = [
@@ -267,7 +267,7 @@ def test_duplicate_link() -> None:
 
 
 def test_multiple_duplicate_links() -> None:
-    t = ModularInteger("P.T", Number(2))
+    t = ModularInteger("P::T", Number(2))
     x = Field(ID("X", location=Location((1, 5))))
     y = Field(ID("Y", location=Location((2, 5))))
 
@@ -318,7 +318,7 @@ def test_unsupported_expression() -> None:
     assert_message_model_error(
         structure,
         types,
-        '^<stdin>:10:19: model: error: unsupported expression in "P.M"\n'
+        '^<stdin>:10:19: model: error: unsupported expression in "P::M"\n'
         '<stdin>:10:23: model: info: variable "X" in exponent',
     )
 
@@ -336,12 +336,12 @@ def test_unreachable_field() -> None:
     assert_message_model_error(
         structure,
         types,
-        '^<stdin>:20:3: model: error: unreachable field "Y" in "P.M"$',
+        '^<stdin>:20:3: model: error: unreachable field "Y" in "P::M"$',
     )
 
 
 def test_cycle() -> None:
-    t = ModularInteger("P.T", Number(2))
+    t = ModularInteger("P::T", Number(2))
 
     structure = [
         Link(INITIAL, Field("X")),
@@ -356,7 +356,7 @@ def test_cycle() -> None:
     assert_message_model_error(
         structure,
         types,
-        '^<stdin>:10:8: model: error: structure of "P.M" contains cycle',
+        '^<stdin>:10:8: model: error: structure of "P::M" contains cycle',
         # ISSUE: Componolit/RecordFlux#256
         # '\n'
         # '<stdin>:3:5: model: info: field "X" links to "Y"\n'
@@ -568,7 +568,7 @@ def test_field_locations() -> None:
     f3 = Field(ID("F3", Location((3, 2))))
 
     message = UnprovenMessage(
-        "P.M",
+        "P::M",
         [Link(INITIAL, f2), Link(f2, f3), Link(f3, FINAL)],
         {Field("F2"): MODULAR_INTEGER, Field("F3"): MODULAR_INTEGER},
         location=Location((17, 9)),
@@ -584,7 +584,7 @@ class NewType(Type):
 def test_invalid_message_field_type() -> None:
     with pytest.raises(AssertionError, match=r"rflx/model/message.py"):
         Message(
-            "P.M",
+            "P::M",
             [Link(INITIAL, Field("F")), Link(Field("F"), FINAL)],
             {Field("F"): NewType("T")},
         )
@@ -607,8 +607,8 @@ def test_invalid_message_field_type() -> None:
 def test_undefined_variable(
     operation: Callable[[Expr, Expr], Expr], condition: Tuple[Expr, Expr]
 ) -> None:
-    mod_type = ModularInteger("P.MT", Pow(Number(2), Number(32)))
-    enum_type = Enumeration("P.ET", [("Val1", Number(0)), ("Val2", Number(1))], Number(8), True)
+    mod_type = ModularInteger("P::MT", Pow(Number(2), Number(32)))
+    enum_type = Enumeration("P::ET", [("Val1", Number(0)), ("Val2", Number(1))], Number(8), True)
 
     structure = [
         Link(INITIAL, Field("F1")),
@@ -657,7 +657,7 @@ def test_undefined_variables() -> None:
 def test_subsequent_variable() -> None:
     f1 = Field("F1")
     f2 = Field("F2")
-    t = ModularInteger("P.T", Pow(Number(2), Number(32)))
+    t = ModularInteger("P::T", Pow(Number(2), Number(32)))
     structure = [
         Link(INITIAL, f1),
         Link(f1, f2, Equal(Variable("F2", location=Location((1024, 57))), Number(42))),
@@ -748,7 +748,7 @@ def test_invalid_element_in_relation_to_aggregate() -> None:
     assert_message_model_error(
         structure,
         types,
-        r'^<stdin>:10:20: model: error: expected integer type "P.Modular" \(0 .. 255\)\n'
+        r'^<stdin>:10:20: model: error: expected integer type "P::Modular" \(0 .. 255\)\n'
         r"<stdin>:10:20: model: info: found aggregate with element type universal integer"
         r" \(1 .. 2\)\n"
         r"model: info: on path F1 -> Final$",
@@ -798,13 +798,13 @@ def test_array_aggregate_out_of_range() -> None:
         ),
     ]
 
-    types = {Field("F"): Array("P.Array", ModularInteger("P.Element", Number(64)))}
+    types = {Field("F"): Array("P::Array", ModularInteger("P::Element", Number(64)))}
 
     assert_message_model_error(
         structure,
         types,
-        r'^<stdin>:10:20: model: error: expected composite type "P.Array"'
-        r' with element integer type "P.Element" \(0 .. 63\)\n'
+        r'^<stdin>:10:20: model: error: expected composite type "P::Array"'
+        r' with element integer type "P::Element" \(0 .. 63\)\n'
         r"<stdin>:10:20: model: info: found aggregate"
         r" with element type universal integer \(1 .. 64\)\n"
         r"model: info: on path F -> Final$",
@@ -813,11 +813,11 @@ def test_array_aggregate_out_of_range() -> None:
 
 def test_array_aggregate_invalid_element_type() -> None:
     inner = Message(
-        "P.I",
+        "P::I",
         [Link(INITIAL, Field("F")), Link(Field("F"), FINAL)],
         {Field("F"): MODULAR_INTEGER},
     )
-    array_type = Array("P.Array", inner)
+    array_type = Array("P::Array", inner)
     f = Field("F")
 
     structure = [
@@ -837,8 +837,8 @@ def test_array_aggregate_invalid_element_type() -> None:
     assert_message_model_error(
         structure,
         types,
-        r'^<stdin>:10:20: model: error: expected composite type "P.Array"'
-        r' with element message type "P.I"\n'
+        r'^<stdin>:10:20: model: error: expected composite type "P::Array"'
+        r' with element message type "P::I"\n'
         r"<stdin>:10:20: model: info: found aggregate with element type universal integer"
         r" \(1 .. 64\)\n"
         r"model: info: on path F -> Final$",
@@ -853,9 +853,9 @@ def test_opaque_not_byte_aligned() -> None:
     ):
         o = Field(ID("O", location=Location((44, 3))))
         Message(
-            "P.M",
+            "P::M",
             [Link(INITIAL, Field("P")), Link(Field("P"), o, length=Number(128)), Link(o, FINAL)],
-            {Field("P"): ModularInteger("P.T", Number(4)), o: Opaque()},
+            {Field("P"): ModularInteger("P::T", Number(4)), o: Opaque()},
         )
 
 
@@ -867,7 +867,7 @@ def test_opaque_not_byte_aligned_dynamic() -> None:
     ):
         o2 = Field(ID("O2", location=Location((44, 3))))
         Message(
-            "P.M",
+            "P::M",
             [
                 Link(INITIAL, Field("L1")),
                 Link(
@@ -882,7 +882,7 @@ def test_opaque_not_byte_aligned_dynamic() -> None:
             ],
             {
                 Field("L1"): MODULAR_INTEGER,
-                Field("L2"): ModularInteger("P.T", Number(4)),
+                Field("L2"): ModularInteger("P::T", Number(4)),
                 Field("O1"): Opaque(),
                 o2: Opaque(),
             },
@@ -891,7 +891,7 @@ def test_opaque_not_byte_aligned_dynamic() -> None:
 
 def test_opaque_valid_byte_aligned_dynamic_mul() -> None:
     Message(
-        "P.M",
+        "P::M",
         [
             Link(INITIAL, Field("L")),
             Link(Field("L"), Field("O1"), length=Mul(Number(8), Variable("L"))),
@@ -903,7 +903,7 @@ def test_opaque_valid_byte_aligned_dynamic_mul() -> None:
 
 def test_opaque_valid_byte_aligned_dynamic_cond() -> None:
     Message(
-        "P.M",
+        "P::M",
         [
             Link(INITIAL, Field("L")),
             Link(
@@ -927,7 +927,7 @@ def test_opaque_length_not_multiple_of_8() -> None:
     ):
         o = Field(ID("O", location=Location((44, 3))))
         Message(
-            "P.M",
+            "P::M",
             [Link(INITIAL, o, length=Number(68)), Link(o, FINAL)],
             {o: Opaque()},
         )
@@ -941,7 +941,7 @@ def test_opaque_length_not_multiple_of_8_dynamic() -> None:
     ):
         o = Field(ID("O", location=Location((44, 3))))
         Message(
-            "P.M",
+            "P::M",
             [Link(INITIAL, Field("L")), Link(Field("L"), o, length=Variable("L")), Link(o, FINAL)],
             {Field("L"): MODULAR_INTEGER, o: Opaque()},
         )
@@ -949,7 +949,7 @@ def test_opaque_length_not_multiple_of_8_dynamic() -> None:
 
 def test_opaque_length_valid_multiple_of_8_dynamic_cond() -> None:
     Message(
-        "P.M",
+        "P::M",
         [
             Link(INITIAL, Field("L")),
             Link(
@@ -966,7 +966,7 @@ def test_opaque_length_valid_multiple_of_8_dynamic_cond() -> None:
 
 def test_prefixed_message_attribute() -> None:
     result = Message(
-        "P.M",
+        "P::M",
         [
             Link(INITIAL, Field("F1")),
             Link(
@@ -994,7 +994,7 @@ def test_prefixed_message_attribute() -> None:
     ).prefixed("X_")
 
     expected = Message(
-        "P.M",
+        "P::M",
         [
             Link(INITIAL, Field("X_F1")),
             Link(
@@ -1035,7 +1035,7 @@ def test_exclusive_valid() -> None:
         Field("F1"): MODULAR_INTEGER,
         Field("F2"): MODULAR_INTEGER,
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_exclusive_enum_valid() -> None:
@@ -1049,26 +1049,26 @@ def test_exclusive_enum_valid() -> None:
         Field("F1"): ENUMERATION,
         Field("F2"): MODULAR_INTEGER,
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_exclusive_prefixed_enum_valid() -> None:
     structure = [
         Link(INITIAL, Field("F1")),
         Link(Field("F1"), FINAL, condition=Equal(Variable("F1"), Variable("ONE"))),
-        Link(Field("F1"), Field("F2"), condition=Equal(Variable("F1"), Variable("P.TWO"))),
+        Link(Field("F1"), Field("F2"), condition=Equal(Variable("F1"), Variable("P::TWO"))),
         Link(Field("F2"), FINAL),
     ]
     types = {
         Field("F1"): ENUMERATION,
         Field("F2"): Enumeration(
-            "P2.Enumeration",
+            "P2::Enumeration",
             [("ONE", Number(2)), ("TWO", Number(1))],
             Number(8),
             False,
         ),
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_exclusive_conflict() -> None:
@@ -1113,7 +1113,7 @@ def test_exclusive_with_length_valid() -> None:
         Field("F1"): Opaque(),
         Field("F2"): MODULAR_INTEGER,
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_exclusive_with_length_invalid() -> None:
@@ -1159,18 +1159,18 @@ def test_no_valid_path() -> None:
         structure,
         types,
         r"^"
-        r'<stdin>:11:6: model: error: unreachable field "F2" in "P.M"\n'
+        r'<stdin>:11:6: model: error: unreachable field "F2" in "P::M"\n'
         r"<stdin>:11:6: model: info: path 0 [(]F1 -> F2[)]:\n"
         r'<stdin>:20:2: model: info: unsatisfied "F1 <= 80"\n'
         r'<stdin>:11:6: model: info: unsatisfied "F1 > 80"\n'
-        r'<stdin>:12:7: model: error: unreachable field "F3" in "P.M"\n'
+        r'<stdin>:12:7: model: error: unreachable field "F3" in "P::M"\n'
         r"<stdin>:12:7: model: info: path 0 [(]F1 -> F2 -> F3[)]:\n"
         r'<stdin>:20:2: model: info: unsatisfied "F1 <= 80"\n'
         r'<stdin>:22:4: model: info: unsatisfied "F1 > 80"\n'
         r"<stdin>:12:7: model: info: path 1 [(]F1 -> F3[)]:\n"
         r'<stdin>:21:3: model: info: unsatisfied "F1 > 80"\n'
         r'<stdin>:12:7: model: info: unsatisfied "F1 <= 80"\n'
-        r'model: error: unreachable field "Final" in "P.M"\n'
+        r'model: error: unreachable field "Final" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2 -> F3 -> Final[)]:\n"
         r'<stdin>:20:2: model: info: unsatisfied "F1 <= 80"\n'
         r'<stdin>:22:4: model: info: unsatisfied "F1 > 80"\n'
@@ -1194,7 +1194,7 @@ def test_invalid_path_1(monkeypatch: Any) -> None:
         structure,
         types,
         r"^"
-        r'<stdin>:5:10: model: error: contradicting condition in "P.M"\n'
+        r'<stdin>:5:10: model: error: contradicting condition in "P::M"\n'
         r'<stdin>:20:10: model: info: on path: "F1"\n'
         r'<stdin>:5:10: model: info: unsatisfied "1 = 2"',
     )
@@ -1215,7 +1215,7 @@ def test_invalid_path_2(monkeypatch: Any) -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "F1"\n'
         r'model: info: unsatisfied "1 = 2"',
     )
@@ -1235,7 +1235,7 @@ def test_contradiction() -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "F1"\n'
         r'model: info: unsatisfied "F1 <= 100"\n'
         r'model: info: unsatisfied "F1 > 1000"',
@@ -1256,7 +1256,7 @@ def test_invalid_type_condition_range_low() -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "F1"\n'
         r'model: info: unsatisfied "F1 >= 1"\n'
         r'model: info: unsatisfied "F1 < 1"',
@@ -1277,7 +1277,7 @@ def test_invalid_type_condition_range_high() -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "F1"\n'
         r'model: info: unsatisfied "F1 <= 100"\n'
         r'model: info: unsatisfied "F1 > 200"',
@@ -1298,7 +1298,7 @@ def test_invalid_type_condition_modular_upper() -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "F1"\n'
         r'model: info: unsatisfied "F1 < 256"\n'
         r'model: info: unsatisfied "F1 > 65537"',
@@ -1319,7 +1319,7 @@ def test_invalid_type_condition_modular_lower() -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "F1"\n'
         r'model: info: unsatisfied "F1 >= 0"\n'
         r'model: info: unsatisfied "F1 < 0"',
@@ -1341,14 +1341,14 @@ def test_invalid_type_condition_enum() -> None:
         Link(Field("F2"), FINAL),
     ]
     e1 = Enumeration(
-        "P.E1",
+        "P::E1",
         [("E1", Number(1)), ("E2", Number(2)), ("E3", Number(3))],
         Number(8),
         False,
         Location((10, 4)),
     )
     e2 = Enumeration(
-        "P.E2",
+        "P::E2",
         [("E4", Number(1)), ("E5", Number(2)), ("E6", Number(3))],
         Number(8),
         False,
@@ -1361,8 +1361,8 @@ def test_invalid_type_condition_enum() -> None:
     assert_message_model_error(
         structure,
         types,
-        r'^<stdin>:10:20: model: error: expected enumeration type "P.E1"\n'
-        r'<stdin>:10:20: model: info: found enumeration type "P.E2"\n'
+        r'^<stdin>:10:20: model: error: expected enumeration type "P::E1"\n'
+        r'<stdin>:10:20: model: info: found enumeration type "P::E2"\n'
         r"<stdin>:10:10: model: info: on path F1 -> F2$",
     )
 
@@ -1386,7 +1386,7 @@ def test_tlv_valid_enum() -> None:
         Field("T"): ENUMERATION,
         Field("V"): Opaque(),
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_invalid_fixed_size_field_with_length() -> None:
@@ -1416,7 +1416,7 @@ def test_valid_first() -> None:
         Field("F1"): MODULAR_INTEGER,
         Field("F2"): MODULAR_INTEGER,
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_invalid_first() -> None:
@@ -1485,7 +1485,7 @@ def test_valid_length_reference() -> None:
         Field("F1"): MODULAR_INTEGER,
         Field("F2"): Opaque(),
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_invalid_length_forward_reference() -> None:
@@ -1580,8 +1580,8 @@ def test_incongruent_overlay() -> None:
         Link(Field("F3"), Field("F4")),
         Link(Field("F4"), FINAL),
     ]
-    u8 = ModularInteger("P.U8", Number(256))
-    u16 = ModularInteger("P.U16", Number(65536))
+    u8 = ModularInteger("P::U8", Number(256))
+    u16 = ModularInteger("P::U16", Number(65536))
     types = {
         Field("F1"): u8,
         Field("F2"): u8,
@@ -1680,7 +1680,7 @@ def test_valid_use_message_length() -> None:
         Link(Field("Verify_Data"), FINAL),
     ]
     types = {Field("Verify_Data"): Opaque()}
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_valid_use_message_first_last() -> None:
@@ -1693,7 +1693,7 @@ def test_valid_use_message_first_last() -> None:
         Link(Field("Verify_Data"), FINAL),
     ]
     types = {Field("Verify_Data"): Opaque()}
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_no_path_to_final() -> None:
@@ -1712,7 +1712,7 @@ def test_no_path_to_final() -> None:
         Field("F4"): MODULAR_INTEGER,
     }
     assert_message_model_error(
-        structure, types, '^model: error: no path to FINAL for field "F4" in "P.M"$'
+        structure, types, '^model: error: no path to FINAL for field "F4" in "P::M"$'
     )
 
 
@@ -1739,9 +1739,9 @@ def test_no_path_to_final_transitive() -> None:
         structure,
         types,
         r"^"
-        r'model: error: no path to FINAL for field "F4" in "P.M"\n'
-        r'model: error: no path to FINAL for field "F5" in "P.M"\n'
-        r'model: error: no path to FINAL for field "F6" in "P.M"'
+        r'model: error: no path to FINAL for field "F4" in "P::M"\n'
+        r'model: error: no path to FINAL for field "F5" in "P::M"\n'
+        r'model: error: no path to FINAL for field "F6" in "P::M"'
         r"$",
     )
 
@@ -1760,15 +1760,15 @@ def test_conditionally_unreachable_field_mod_first() -> None:
         structure,
         types,
         r"^"
-        r'model: error: unreachable field "F1" in "P.M"\n'
+        r'model: error: unreachable field "F1" in "P::M"\n'
         r"model: info: path 0 [(]F1[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"\n'
-        r'model: error: unreachable field "F2" in "P.M"\n'
+        r'model: error: unreachable field "F2" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"\n'
-        r'model: error: unreachable field "Final" in "P.M"\n'
+        r'model: error: unreachable field "Final" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2 -> Final[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"',
@@ -1789,12 +1789,12 @@ def test_conditionally_unreachable_field_mod_last() -> None:
         structure,
         types,
         r"^"
-        r'model: error: unreachable field "F2" in "P.M"\n'
+        r'model: error: unreachable field "F2" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2[)]:\n"
         r'model: info: unsatisfied "F2\'Last = [(]F1\'Last [+] 1 [+] 8[)] - 1"\n'
         r'model: info: unsatisfied "Message\'Last >= F2\'Last"\n'
         r'model: info: unsatisfied "F1\'Last = Message\'Last"\n'
-        r'model: error: unreachable field "Final" in "P.M"\n'
+        r'model: error: unreachable field "Final" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2 -> Final[)]:\n"
         r'model: info: unsatisfied "F2\'Last = [(]F1\'Last [+] 1 [+] 8[)] - 1"\n'
         r'model: info: unsatisfied "Message\'Last >= F2\'Last"\n'
@@ -1816,15 +1816,15 @@ def test_conditionally_unreachable_field_range_first() -> None:
         structure,
         types,
         r"^"
-        r'model: error: unreachable field "F1" in "P.M"\n'
+        r'model: error: unreachable field "F1" in "P::M"\n'
         r"model: info: path 0 [(]F1[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"\n'
-        r'model: error: unreachable field "F2" in "P.M"\n'
+        r'model: error: unreachable field "F2" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"\n'
-        r'model: error: unreachable field "Final" in "P.M"\n'
+        r'model: error: unreachable field "Final" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2 -> Final[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"',
@@ -1845,12 +1845,12 @@ def test_conditionally_unreachable_field_range_last() -> None:
         structure,
         types,
         r"^"
-        r'model: error: unreachable field "F2" in "P.M"\n'
+        r'model: error: unreachable field "F2" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2[)]:\n"
         r'model: info: unsatisfied "F2\'Last = [(]F1\'Last [+] 1 [+] 8[)] - 1"\n'
         r'model: info: unsatisfied "Message\'Last >= F2\'Last"\n'
         r'model: info: unsatisfied "F1\'Last = Message\'Last"\n'
-        r'model: error: unreachable field "Final" in "P.M"\n'
+        r'model: error: unreachable field "Final" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2 -> Final[)]:\n"
         r'model: info: unsatisfied "F2\'Last = [(]F1\'Last [+] 1 [+] 8[)] - 1"\n'
         r'model: info: unsatisfied "Message\'Last >= F2\'Last"\n'
@@ -1872,15 +1872,15 @@ def test_conditionally_unreachable_field_enum_first() -> None:
         structure,
         types,
         r"^"
-        r'model: error: unreachable field "F1" in "P.M"\n'
+        r'model: error: unreachable field "F1" in "P::M"\n'
         r"model: info: path 0 [(]F1[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"\n'
-        r'model: error: unreachable field "F2" in "P.M"\n'
+        r'model: error: unreachable field "F2" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"\n'
-        r'model: error: unreachable field "Final" in "P.M"\n'
+        r'model: error: unreachable field "Final" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2 -> Final[)]:\n"
         r'model: info: unsatisfied "F1\'First = Message\'First"\n'
         r'model: info: unsatisfied "F1\'First > Message\'First"',
@@ -1901,12 +1901,12 @@ def test_conditionally_unreachable_field_enum_last() -> None:
         structure,
         types,
         r"^"
-        r'model: error: unreachable field "F2" in "P.M"\n'
+        r'model: error: unreachable field "F2" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2[)]:\n"
         r'model: info: unsatisfied "F2\'Last = [(]F1\'Last [+] 1 [+] 8[)] - 1"\n'
         r'model: info: unsatisfied "Message\'Last >= F2\'Last"\n'
         r'model: info: unsatisfied "F1\'Last = Message\'Last"\n'
-        r'model: error: unreachable field "Final" in "P.M"\n'
+        r'model: error: unreachable field "Final" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2 -> Final[)]:\n"
         r'model: info: unsatisfied "F2\'Last = [(]F1\'Last [+] 1 [+] 8[)] - 1"\n'
         r'model: info: unsatisfied "Message\'Last >= F2\'Last"\n'
@@ -1929,7 +1929,7 @@ def test_conditionally_unreachable_field_outgoing() -> None:
         structure,
         types,
         r"^"
-        r'model: error: unreachable field "F2" in "P.M"\n'
+        r'model: error: unreachable field "F2" in "P::M"\n'
         r"model: info: path 0 [(]F1 -> F2[)]:\n"
         r'model: info: unsatisfied "F1 <= 32"\n'
         r'model: info: unsatisfied "F1 > 32"',
@@ -1963,7 +1963,7 @@ def test_conditionally_unreachable_field_outgoing_multi() -> None:
         structure,
         types,
         r"^"
-        r'<stdin>:90:12: model: error: unreachable field "F2" in "P.M"\n'
+        r'<stdin>:90:12: model: error: unreachable field "F2" in "P::M"\n'
         r"<stdin>:90:12: model: info: path 0 [(]F1 -> F2[)]:\n"
         r'<stdin>:66:3: model: info: unsatisfied "F1 <= 32"\n'
         r'<stdin>:90:12: model: info: unsatisfied "[(]F1 > 32 and F1 <= 48[)] or F1 > 48"',
@@ -1981,7 +1981,7 @@ def test_length_attribute_final() -> None:
         Field("F2"): MODULAR_INTEGER,
     }
     assert_message_model_error(
-        structure, types, '^<stdin>:4:12: model: error: length attribute for final field in "P.M"$'
+        structure, types, '^<stdin>:4:12: model: error: length attribute for final field in "P::M"$'
     )
 
 
@@ -2000,7 +2000,7 @@ def test_aggregate_equal_valid_length() -> None:
     types = {
         Field("Magic"): Opaque(),
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_aggregate_equal_invalid_length1() -> None:
@@ -2019,7 +2019,7 @@ def test_aggregate_equal_invalid_length1() -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "Magic"\n'
         r'model: info: unsatisfied "2 [*] 8 = Magic\'Length"\n'
         r'model: info: unsatisfied "Magic\'Length = 40"',
@@ -2042,7 +2042,7 @@ def test_aggregate_equal_invalid_length2() -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "Magic"\n'
         r'model: info: unsatisfied "2 [*] 8 = Magic\'Length"\n'
         r'model: info: unsatisfied "Magic\'Length = 40"',
@@ -2064,7 +2064,7 @@ def test_aggregate_inequal_valid_length() -> None:
     types = {
         Field("Magic"): Opaque(),
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_aggregate_inequal_invalid_length() -> None:
@@ -2083,7 +2083,7 @@ def test_aggregate_inequal_invalid_length() -> None:
         structure,
         types,
         r"^"
-        r'model: error: contradicting condition in "P.M"\n'
+        r'model: error: contradicting condition in "P::M"\n'
         r'model: info: on path: "Magic"\n'
         r'model: info: unsatisfied "2 [*] 8 = Magic\'Length"\n'
         r'model: info: unsatisfied "Magic\'Length = 40"',
@@ -2100,9 +2100,9 @@ def test_aggregate_equal_array_valid_length() -> None:
         ),
     ]
     types = {
-        Field("Magic"): Array("P.Arr", ModularInteger("P.Modular", Number(128))),
+        Field("Magic"): Array("P::Arr", ModularInteger("P::Modular", Number(128))),
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 def test_aggregate_equal_array_invalid_length() -> None:
@@ -2119,14 +2119,14 @@ def test_aggregate_equal_array_invalid_length() -> None:
     ]
     types = {
         Field("Magic"): Array(
-            "P.Arr", ModularInteger("P.Modular", Number(128), location=Location((66, 3)))
+            "P::Arr", ModularInteger("P::Modular", Number(128), location=Location((66, 3)))
         ),
     }
     assert_message_model_error(
         structure,
         types,
         r"^"
-        r'<stdin>:17:3: model: error: contradicting condition in "P.M"\n'
+        r'<stdin>:17:3: model: error: contradicting condition in "P::M"\n'
         r'<stdin>:3:5: model: info: on path: "Magic"\n'
         r'<stdin>:17:3: model: info: unsatisfied "2 [*] Modular\'Length = Magic\'Length"\n'
         r'<stdin>:66:3: model: info: unsatisfied "Modular\'Length = 7"\n'
@@ -2152,7 +2152,7 @@ def test_aggregate_equal_invalid_length_field() -> None:
     ]
     types = {
         Field("Length"): RangeInteger(
-            "P.Length_Type", Number(10), Number(100), Number(8), Location((5, 10))
+            "P::Length_Type", Number(10), Number(100), Number(8), Location((5, 10))
         ),
         Field(ID("Magic", Location((17, 3)))): Opaque(),
     }
@@ -2160,7 +2160,7 @@ def test_aggregate_equal_invalid_length_field() -> None:
         structure,
         types,
         r"^"
-        r'<stdin>:10:5: model: error: contradicting condition in "P.M"\n'
+        r'<stdin>:10:5: model: error: contradicting condition in "P::M"\n'
         r'<stdin>:2:5: model: info: on path: "Length"\n'
         r'<stdin>:3:5: model: info: on path: "Magic"\n'
         r'<stdin>:6:5: model: info: unsatisfied "Magic\'Length = 8 [*] Length"\n'
@@ -2190,7 +2190,7 @@ def test_no_contradiction_multi() -> None:
         Field("F4"): RANGE_INTEGER,
         Field("F5"): RANGE_INTEGER,
     }
-    Message("P.M", structure, types)
+    Message("P::M", structure, types)
 
 
 @pytest.mark.parametrize(
@@ -2236,7 +2236,7 @@ def test_checksum(checksums: Mapping[ID, Sequence[Expr]], condition: Expr) -> No
     aspects = {
         ID("Checksum"): checksums,
     }
-    message = Message("P.M", structure, types, aspects=aspects)
+    message = Message("P::M", structure, types, aspects=aspects)
     assert message.checksums == checksums
 
 
@@ -2300,7 +2300,7 @@ def test_checksum_error(
 
 def test_field_size() -> None:
     message = Message(
-        "P.M",
+        "P::M",
         [Link(INITIAL, Field("F")), Link(Field("F"), FINAL)],
         {Field("F"): MODULAR_INTEGER},
         location=Location((30, 10)),
@@ -2316,14 +2316,14 @@ def test_field_size() -> None:
 
 def test_copy() -> None:
     message = Message(
-        "P.M",
+        "P::M",
         [Link(INITIAL, Field("F")), Link(Field("F"), FINAL)],
         {Field("F"): MODULAR_INTEGER},
     )
     assert_equal(
-        message.copy(identifier="A.B"),
+        message.copy(identifier="A::B"),
         Message(
-            "A.B",
+            "A::B",
             [Link(INITIAL, Field("F")), Link(Field("F"), FINAL)],
             {Field("F"): MODULAR_INTEGER},
         ),
@@ -2334,7 +2334,7 @@ def test_copy() -> None:
             types={Field("C"): RANGE_INTEGER},
         ),
         Message(
-            "P.M",
+            "P::M",
             [Link(INITIAL, Field("C")), Link(Field("C"), FINAL)],
             {Field("C"): RANGE_INTEGER},
         ),
@@ -2343,7 +2343,7 @@ def test_copy() -> None:
 
 def test_proven() -> None:
     message = Message(
-        "P.M",
+        "P::M",
         [Link(INITIAL, Field("F")), Link(Field("F"), FINAL)],
         {Field("F"): MODULAR_INTEGER},
     )
@@ -2355,10 +2355,10 @@ def test_is_possibly_empty() -> None:
     b = Field("B")
     c = Field("C")
 
-    array = Array("P.Array", MODULAR_INTEGER)
+    array = Array("P::Array", MODULAR_INTEGER)
 
     message = Message(
-        "P.M",
+        "P::M",
         [
             Link(INITIAL, a),
             Link(a, c, condition=Less(Variable("A"), Number(10)), length=Variable("A")),
@@ -2378,14 +2378,14 @@ def test_derived_message_incorrect_base_name() -> None:
     with pytest.raises(
         RecordFluxError, match='^<stdin>:40:8: model: error: unexpected format of type name "M"$'
     ):
-        DerivedMessage("P.M", Message("M", [], {}, location=Location((40, 8))))
+        DerivedMessage("P::M", Message("M", [], {}, location=Location((40, 8))))
 
 
 def test_derived_message_proven() -> None:
     message = DerivedMessage(
-        "P.M",
+        "P::M",
         Message(
-            "X.M",
+            "X::M",
             [Link(INITIAL, Field("F")), Link(Field("F"), FINAL)],
             {Field("F"): MODULAR_INTEGER},
         ),
@@ -2396,7 +2396,7 @@ def test_derived_message_proven() -> None:
 def test_prefixed_message() -> None:
     assert_equal(
         UnprovenMessage(
-            "P.M",
+            "P::M",
             [
                 Link(INITIAL, Field("F1")),
                 Link(
@@ -2423,7 +2423,7 @@ def test_prefixed_message() -> None:
             },
         ).prefixed("X_"),
         UnprovenMessage(
-            "P.M",
+            "P::M",
             [
                 Link(INITIAL, Field("X_F1")),
                 Link(
@@ -2456,10 +2456,10 @@ def test_merge_message_simple() -> None:
     assert_equal(
         deepcopy(M_SMPL_REF).merged(),
         UnprovenMessage(
-            "P.Smpl_Ref",
+            "P::Smpl_Ref",
             [
                 Link(INITIAL, Field("NR_F1"), length=Number(16)),
-                Link(Field("NR_F3"), FINAL, Equal(Variable("NR_F3"), Variable("P.ONE"))),
+                Link(Field("NR_F3"), FINAL, Equal(Variable("NR_F3"), Variable("P::ONE"))),
                 Link(Field("NR_F4"), FINAL),
                 Link(Field("NR_F1"), Field("NR_F2")),
                 Link(
@@ -2489,7 +2489,7 @@ def test_merge_message_complex() -> None:
     assert_equal(
         deepcopy(M_CMPLX_REF).merged(),
         UnprovenMessage(
-            "P.Cmplx_Ref",
+            "P::Cmplx_Ref",
             [
                 Link(INITIAL, Field("F1")),
                 Link(Field("F1"), Field("F2"), LessEqual(Variable("F1"), Number(100))),
@@ -2511,7 +2511,7 @@ def test_merge_message_complex() -> None:
                     Field("F5"),
                     And(
                         LessEqual(Variable("F1"), Number(100)),
-                        Equal(Variable("NR_F3"), Variable("P.ONE")),
+                        Equal(Variable("NR_F3"), Variable("P::ONE")),
                     ),
                 ),
                 Link(Field("NR_F4"), Field("F5"), LessEqual(Variable("F1"), Number(100))),
@@ -2520,7 +2520,7 @@ def test_merge_message_complex() -> None:
                     Field("F6"),
                     And(
                         GreaterEqual(Variable("F1"), Number(200)),
-                        Equal(Variable("NR_F3"), Variable("P.ONE")),
+                        Equal(Variable("NR_F3"), Variable("P::ONE")),
                     ),
                 ),
                 Link(Field("NR_F4"), Field("F6"), GreaterEqual(Variable("F1"), Number(200))),
@@ -2559,17 +2559,17 @@ def test_merge_message_recursive() -> None:
     assert_equal(
         deepcopy(M_DBL_REF).merged(),
         UnprovenMessage(
-            "P.Dbl_Ref",
+            "P::Dbl_Ref",
             [
                 Link(INITIAL, Field("SR_NR_F1"), length=Number(16)),
                 Link(
                     Field("SR_NR_F3"),
                     Field("NR_F1"),
-                    Equal(Variable("SR_NR_F3"), Variable("P.ONE")),
+                    Equal(Variable("SR_NR_F3"), Variable("P::ONE")),
                     length=Number(16),
                 ),
                 Link(Field("SR_NR_F4"), Field("NR_F1"), length=Number(16)),
-                Link(Field("NR_F3"), FINAL, Equal(Variable("NR_F3"), Variable("P.ONE"))),
+                Link(Field("NR_F3"), FINAL, Equal(Variable("NR_F3"), Variable("P::ONE"))),
                 Link(Field("NR_F4"), FINAL),
                 Link(Field("SR_NR_F1"), Field("SR_NR_F2")),
                 Link(
@@ -2616,11 +2616,11 @@ def test_merge_message_simple_derived() -> None:
     assert_equal(
         deepcopy(M_SMPL_REF_DERI).merged(),
         UnprovenDerivedMessage(
-            "P.Smpl_Ref_Deri",
+            "P::Smpl_Ref_Deri",
             M_SMPL_REF,
             [
                 Link(INITIAL, Field("NR_F1"), length=Number(16)),
-                Link(Field("NR_F3"), FINAL, Equal(Variable("NR_F3"), Variable("P.ONE"))),
+                Link(Field("NR_F3"), FINAL, Equal(Variable("NR_F3"), Variable("P::ONE"))),
                 Link(Field("NR_F4"), FINAL),
                 Link(Field("NR_F1"), Field("NR_F2")),
                 Link(
@@ -2648,7 +2648,7 @@ def test_merge_message_simple_derived() -> None:
 
 def test_merge_message_constrained() -> None:
     m1 = UnprovenMessage(
-        "P.M1",
+        "P::M1",
         [
             Link(INITIAL, Field("F1")),
             Link(Field("F1"), Field("F3"), Equal(Variable("F1"), Variable("True"))),
@@ -2659,7 +2659,7 @@ def test_merge_message_constrained() -> None:
         {Field("F1"): BOOLEAN, Field("F2"): BOOLEAN, Field("F3"): BOOLEAN},
     )
     m2 = UnprovenMessage(
-        "P.M2",
+        "P::M2",
         [
             Link(INITIAL, Field("F4")),
             Link(
@@ -2674,7 +2674,7 @@ def test_merge_message_constrained() -> None:
         {Field("F4"): m1},
     )
     expected = UnprovenMessage(
-        "P.M2",
+        "P::M2",
         [
             Link(
                 INITIAL,
@@ -2698,7 +2698,7 @@ def test_merge_message_constrained() -> None:
 
 def test_merge_message_constrained_empty() -> None:
     m1 = UnprovenMessage(
-        "P.M1",
+        "P::M1",
         [
             Link(INITIAL, Field("F1")),
             Link(Field("F1"), Field("F2"), Equal(Variable("F1"), Variable("True"))),
@@ -2708,7 +2708,7 @@ def test_merge_message_constrained_empty() -> None:
         {Field("F1"): BOOLEAN, Field("F2"): BOOLEAN},
     )
     m2 = UnprovenMessage(
-        "P.M2",
+        "P::M2",
         [
             Link(INITIAL, Field("F3")),
             Link(
@@ -2733,7 +2733,7 @@ def test_merge_message_error_name_conflict() -> None:
     m2_f2 = Field(ID("F2", Location((10, 5))))
 
     m2 = UnprovenMessage(
-        "P.M2",
+        "P::M2",
         [Link(INITIAL, m2_f2), Link(m2_f2, FINAL)],
         {Field("F2"): MODULAR_INTEGER},
         location=Location((15, 3)),
@@ -2743,7 +2743,7 @@ def test_merge_message_error_name_conflict() -> None:
     m1_f1_f2 = Field(ID("F1_F2", Location((30, 5))))
 
     m1 = UnprovenMessage(
-        "P.M1",
+        "P::M1",
         [Link(INITIAL, m1_f1), Link(m1_f1, m1_f1_f2), Link(m1_f1_f2, FINAL)],
         {Field("F1"): m2, Field("F1_F2"): MODULAR_INTEGER},
         location=Location((2, 9)),
@@ -2752,43 +2752,45 @@ def test_merge_message_error_name_conflict() -> None:
     assert_type_model_error(
         m1.merged(),
         r"^"
-        r'<stdin>:30:5: model: error: name conflict for "F1_F2" in "P.M1"\n'
-        r'<stdin>:15:3: model: info: when merging message "P.M2"\n'
+        r'<stdin>:30:5: model: error: name conflict for "F1_F2" in "P::M1"\n'
+        r'<stdin>:15:3: model: info: when merging message "P::M2"\n'
         r'<stdin>:20:8: model: info: into field "F1"$',
     )
 
 
 def test_refinement_invalid_package() -> None:
     assert_type_model_error(
-        Refinement(ID("A.B", Location((22, 10))), ETHERNET_FRAME, Field("Payload"), ETHERNET_FRAME),
-        r'^<stdin>:22:10: model: error: unexpected format of package name "A.B"$',
+        Refinement(
+            ID("A::B", Location((22, 10))), ETHERNET_FRAME, Field("Payload"), ETHERNET_FRAME
+        ),
+        r'^<stdin>:22:10: model: error: unexpected format of package name "A::B"$',
     )
 
 
 def test_refinement_invalid_field_type() -> None:
     x = Field(ID("X", Location((20, 10))))
 
-    message = Message("P.M", [Link(INITIAL, x), Link(x, FINAL)], {x: MODULAR_INTEGER})
+    message = Message("P::M", [Link(INITIAL, x), Link(x, FINAL)], {x: MODULAR_INTEGER})
 
     assert_type_model_error(
         Refinement("P", message, Field(ID("X", Location((33, 22)))), message),
-        r'^<stdin>:33:22: model: error: invalid type of field "X" in refinement of "P.M"\n'
+        r'^<stdin>:33:22: model: error: invalid type of field "X" in refinement of "P::M"\n'
         r"<stdin>:20:10: model: info: expected field of type Opaque",
     )
 
 
 def test_refinement_invalid_field() -> None:
-    message = Message("P.M", [], {})
+    message = Message("P::M", [], {})
 
     assert_type_model_error(
         Refinement("P", message, Field(ID("X", Location((33, 22)))), message),
-        r'^<stdin>:33:22: model: error: invalid field "X" in refinement of "P.M"$',
+        r'^<stdin>:33:22: model: error: invalid field "X" in refinement of "P::M"$',
     )
 
 
 def test_paths() -> None:
     message = Message(
-        "P.M",
+        "P::M",
         [
             Link(INITIAL, Field("L")),
             Link(Field("L"), Field("O"), condition=Greater(Variable("L"), Number(100))),
@@ -2811,7 +2813,7 @@ def test_paths() -> None:
 
 def test_message_str() -> None:
     message = Message(
-        "P.M",
+        "P::M",
         [
             Link(INITIAL, Field("L")),
             Link(Field("L"), Field("O"), condition=Greater(Variable("L"), Number(100))),

--- a/tests/unit/model/model_test.py
+++ b/tests/unit/model/model_test.py
@@ -28,7 +28,7 @@ def assert_model_error(types: Sequence[Type], regex: str) -> None:
 
 
 def test_type_name() -> None:
-    t = ModularInteger("Package.Type_Name", Number(256))
+    t = ModularInteger("Package::Type_Name", Number(256))
     assert t.name == "Type_Name"
     assert t.package == ID("Package")
     assert_type_model_error(
@@ -36,8 +36,8 @@ def test_type_name() -> None:
         r'^<stdin>:10:20: model: error: unexpected format of type name "X"$',
     )
     assert_type_model_error(
-        ModularInteger("X.Y.Z", Number(256), Location((10, 20))),
-        '^<stdin>:10:20: model: error: unexpected format of type name "X.Y.Z"$',
+        ModularInteger("X::Y::Z", Number(256), Location((10, 20))),
+        '^<stdin>:10:20: model: error: unexpected format of type name "X::Y::Z"$',
     )
 
 
@@ -45,59 +45,59 @@ def test_type_type() -> None:
     class NewType(Type):
         pass
 
-    assert NewType("P.T").type_ == rty.Undefined()
+    assert NewType("P::T").type_ == rty.Undefined()
 
 
 def test_modular_size() -> None:
-    assert ModularInteger("P.T", Pow(Number(2), Number(32))).size == Number(32)
-    assert ModularInteger("P.T", Pow(Number(2), Number(32))).size_expr == Number(32)
+    assert ModularInteger("P::T", Pow(Number(2), Number(32))).size == Number(32)
+    assert ModularInteger("P::T", Pow(Number(2), Number(32))).size_expr == Number(32)
 
 
 def test_modular_first() -> None:
-    mod = ModularInteger("P.T", Pow(Number(2), Number(32)))
+    mod = ModularInteger("P::T", Pow(Number(2), Number(32)))
     assert mod.first == Number(0)
 
 
 def test_modular_last() -> None:
-    mod = ModularInteger("P.T", Pow(Number(2), Number(32)))
+    mod = ModularInteger("P::T", Pow(Number(2), Number(32)))
     assert mod.last == Number(2 ** 32 - 1)
 
 
 def test_modular_invalid_modulus_power_of_two() -> None:
     assert_type_model_error(
-        ModularInteger("P.T", Number(255), Location((65, 3))),
+        ModularInteger("P::T", Number(255), Location((65, 3))),
         r'^<stdin>:65:3: model: error: modulus of "T" not power of two$',
     )
 
 
 def test_modular_invalid_modulus_variable() -> None:
     assert_type_model_error(
-        ModularInteger("P.T", Pow(Number(2), Variable("X")), Location((3, 23))),
+        ModularInteger("P::T", Pow(Number(2), Variable("X")), Location((3, 23))),
         r'^<stdin>:3:23: model: error: modulus of "T" contains variable$',
     )
 
 
 def test_modular_invalid_modulus_limit() -> None:
     assert_type_model_error(
-        ModularInteger("P.T", Pow(Number(2), Number(128), Location((55, 3)))),
+        ModularInteger("P::T", Pow(Number(2), Number(128), Location((55, 3)))),
         r'^<stdin>:55:3: model: error: modulus of "T" exceeds limit \(2\*\*64\)$',
     )
 
 
 def test_range_size() -> None:
     assert_equal(
-        RangeInteger("P.T", Number(16), Number(128), Pow(Number(2), Number(5))).size,
+        RangeInteger("P::T", Number(16), Number(128), Pow(Number(2), Number(5))).size,
         Number(32),
     )
     assert_equal(
-        RangeInteger("P.T", Number(16), Number(128), Pow(Number(2), Number(5))).size_expr,
+        RangeInteger("P::T", Number(16), Number(128), Pow(Number(2), Number(5))).size_expr,
         Pow(Number(2), Number(5)),
     )
 
 
 def test_range_first() -> None:
     integer = RangeInteger(
-        "P.T", Pow(Number(2), Number(4)), Sub(Pow(Number(2), Number(32)), Number(1)), Number(32)
+        "P::T", Pow(Number(2), Number(4)), Sub(Pow(Number(2), Number(32)), Number(1)), Number(32)
     )
     assert integer.first == Number(16)
     assert integer.first_expr == Pow(Number(2), Number(4))
@@ -105,7 +105,7 @@ def test_range_first() -> None:
 
 def test_range_last() -> None:
     integer = RangeInteger(
-        "P.T", Pow(Number(2), Number(4)), Sub(Pow(Number(2), Number(32)), Number(1)), Number(32)
+        "P::T", Pow(Number(2), Number(4)), Sub(Pow(Number(2), Number(32)), Number(1)), Number(32)
     )
     assert integer.last == Number(2 ** 32 - 1)
     assert integer.last_expr == Sub(Pow(Number(2), Number(32)), Number(1))
@@ -113,35 +113,39 @@ def test_range_last() -> None:
 
 def test_range_invalid_first_variable() -> None:
     assert_type_model_error(
-        RangeInteger("P.T", Add(Number(1), Variable("X")), Number(15), Number(4), Location((5, 3))),
+        RangeInteger(
+            "P::T", Add(Number(1), Variable("X")), Number(15), Number(4), Location((5, 3))
+        ),
         r'^<stdin>:5:3: model: error: first of "T" contains variable$',
     )
 
 
 def test_range_invalid_last_variable() -> None:
     assert_type_model_error(
-        RangeInteger("P.T", Number(1), Add(Number(1), Variable("X")), Number(4), Location((80, 6))),
+        RangeInteger(
+            "P::T", Number(1), Add(Number(1), Variable("X")), Number(4), Location((80, 6))
+        ),
         r'^<stdin>:80:6: model: error: last of "T" contains variable$',
     )
 
 
 def test_range_invalid_last_exceeds_limit() -> None:
     assert_type_model_error(
-        RangeInteger("P.T", Number(1), Pow(Number(2), Number(63)), Number(64)),
+        RangeInteger("P::T", Number(1), Pow(Number(2), Number(63)), Number(64)),
         r'^model: error: last of "T" exceeds limit \(2\*\*63 - 1\)$',
     )
 
 
 def test_range_invalid_first_negative() -> None:
     assert_type_model_error(
-        RangeInteger("P.T", Number(-1), Number(0), Number(1), Location((6, 4))),
+        RangeInteger("P::T", Number(-1), Number(0), Number(1), Location((6, 4))),
         r'^<stdin>:6:4: model: error: first of "T" negative$',
     )
 
 
 def test_range_invalid_range() -> None:
     assert_type_model_error(
-        RangeInteger("P.T", Number(1), Number(0), Number(1), Location((10, 5))),
+        RangeInteger("P::T", Number(1), Number(0), Number(1), Location((10, 5))),
         r'^<stdin>:10:5: model: error: range of "T" negative$',
     )
 
@@ -149,7 +153,7 @@ def test_range_invalid_range() -> None:
 def test_range_invalid_size_variable() -> None:
     assert_type_model_error(
         RangeInteger(
-            "P.T", Number(0), Number(256), Add(Number(8), Variable("X")), Location((22, 4))
+            "P::T", Number(0), Number(256), Add(Number(8), Variable("X")), Location((22, 4))
         ),
         r'^<stdin>:22:4: model: error: size of "T" contains variable$',
     )
@@ -157,7 +161,7 @@ def test_range_invalid_size_variable() -> None:
 
 def test_range_invalid_size_too_small() -> None:
     assert_type_model_error(
-        RangeInteger("P.T", Number(0), Number(256), Number(8), Location((10, 4))),
+        RangeInteger("P::T", Number(0), Number(256), Number(8), Location((10, 4))),
         r'^<stdin>:10:4: model: error: size of "T" too small$',
     )
 
@@ -165,7 +169,7 @@ def test_range_invalid_size_too_small() -> None:
 def test_range_invalid_size_exceeds_limit() -> None:
     # ISSUE: Componolit/RecordFlux#238
     assert_type_model_error(
-        RangeInteger("P.T", Number(0), Number(256), Number(128), Location((50, 3))),
+        RangeInteger("P::T", Number(0), Number(256), Number(128), Location((50, 3))),
         r'^<stdin>:50:3: model: error: size of "T" exceeds limit \(2\*\*64\)$',
     )
 
@@ -173,13 +177,13 @@ def test_range_invalid_size_exceeds_limit() -> None:
 def test_enumeration_size() -> None:
     assert_equal(
         Enumeration(
-            "P.T", [("A", Number(1))], Pow(Number(2), Number(5)), False, Location((34, 3))
+            "P::T", [("A", Number(1))], Pow(Number(2), Number(5)), False, Location((34, 3))
         ).size,
         Number(32),
     )
     assert_equal(
         Enumeration(
-            "P.T", [("A", Number(1))], Pow(Number(2), Number(5)), False, Location((34, 3))
+            "P::T", [("A", Number(1))], Pow(Number(2), Number(5)), False, Location((34, 3))
         ).size_expr,
         Pow(Number(2), Number(5)),
     )
@@ -188,7 +192,7 @@ def test_enumeration_size() -> None:
 def test_enumeration_invalid_size_variable() -> None:
     assert_type_model_error(
         Enumeration(
-            "P.T", [("A", Number(1))], Add(Number(8), Variable("X")), False, Location((34, 3))
+            "P::T", [("A", Number(1))], Add(Number(8), Variable("X")), False, Location((34, 3))
         ),
         r'^<stdin>:34:3: model: error: size of "T" contains variable$',
     )
@@ -196,7 +200,7 @@ def test_enumeration_invalid_size_variable() -> None:
 
 def test_enumeration_invalid_literal_value() -> None:
     assert_type_model_error(
-        Enumeration("P.T", [("A", Number(2 ** 63))], Number(64), False, Location((10, 5))),
+        Enumeration("P::T", [("A", Number(2 ** 63))], Number(64), False, Location((10, 5))),
         r'^<stdin>:10:5: model: error: enumeration value of "T"'
         r" outside of permitted range \(0 .. 2\*\*63 - 1\)$",
     )
@@ -204,14 +208,14 @@ def test_enumeration_invalid_literal_value() -> None:
 
 def test_enumeration_invalid_size_too_small() -> None:
     assert_type_model_error(
-        Enumeration("P.T", [("A", Number(256))], Number(8), False, Location((10, 5))),
+        Enumeration("P::T", [("A", Number(256))], Number(8), False, Location((10, 5))),
         r'^<stdin>:10:5: model: error: size of "T" too small$',
     )
 
 
 def test_enumeration_invalid_size_exceeds_limit() -> None:
     assert_type_model_error(
-        Enumeration("P.T", [("A", Number(256))], Number(128), False, Location((8, 20))),
+        Enumeration("P::T", [("A", Number(256))], Number(128), False, Location((8, 20))),
         r'^<stdin>:8:20: model: error: size of "T" exceeds limit \(2\*\*64\)$',
     )
 
@@ -220,33 +224,33 @@ def test_enumeration_invalid_always_valid_aspect() -> None:
     with pytest.raises(
         RecordFluxError, match=r'^model: error: unnecessary always-valid aspect on "T"$'
     ):
-        Enumeration("P.T", [("A", Number(0)), ("B", Number(1))], Number(1), True).error.propagate()
+        Enumeration("P::T", [("A", Number(0)), ("B", Number(1))], Number(1), True).error.propagate()
 
 
 def test_enumeration_invalid_literal() -> None:
     assert_type_model_error(
-        Enumeration("P.T", [("A B", Number(1))], Number(8), False, Location(((1, 2)))),
+        Enumeration("P::T", [("A B", Number(1))], Number(8), False, Location(((1, 2)))),
         r'^<stdin>:1:2: model: error: invalid literal name "A B" in "T"$',
     )
     assert_type_model_error(
-        Enumeration("P.T", [("A.B", Number(1))], Number(8), False, Location((6, 4))),
+        Enumeration("P::T", [("A.B", Number(1))], Number(8), False, Location((6, 4))),
         r'^<stdin>:6:4: model: error: invalid literal name "A.B" in "T"$',
     )
 
 
 def test_array_invalid_element_type() -> None:
     assert_type_model_error(
-        Array("P.A", Array("P.B", MODULAR_INTEGER, Location((3, 4))), Location((5, 4))),
+        Array("P::A", Array("P::B", MODULAR_INTEGER, Location((3, 4))), Location((5, 4))),
         r'^<stdin>:5:4: model: error: invalid element type of array "A"\n'
         r'<stdin>:3:4: model: info: type "B" must be scalar or non-null message$',
     )
     assert_type_model_error(
-        Array("P.A", Message("P.B", [], {}, location=Location((3, 4))), Location((5, 4))),
+        Array("P::A", Message("P::B", [], {}, location=Location((3, 4))), Location((5, 4))),
         r'^<stdin>:5:4: model: error: invalid element type of array "A"\n'
         r'<stdin>:3:4: model: info: type "B" must be scalar or non-null message$',
     )
     assert_type_model_error(
-        Array("P.A", OPAQUE, Location((5, 4))),
+        Array("P::A", OPAQUE, Location((5, 4))),
         r'^<stdin>:5:4: model: error: invalid element type of array "A"\n'
         r'__BUILTINS__:0:0: model: info: type "Opaque" must be scalar or non-null message$',
     )
@@ -255,15 +259,15 @@ def test_array_invalid_element_type() -> None:
 def test_array_unsupported_element_type() -> None:
     assert_type_model_error(
         Array(
-            "P.A",
-            ModularInteger("P.B", Pow(Number(2), Number(4)), Location((3, 4))),
+            "P::A",
+            ModularInteger("P::B", Pow(Number(2), Number(4)), Location((3, 4))),
             Location((5, 4)),
         ),
         r'^<stdin>:5:4: model: error: unsupported element type size of array "A"\n'
         r'<stdin>:3:4: model: info: type "B" has size 4, must be multiple of 8$',
     )
     assert_type_model_error(
-        Array("P.A", BOOLEAN, Location((5, 4))),
+        Array("P::A", BOOLEAN, Location((5, 4))),
         r'^<stdin>:5:4: model: error: unsupported element type size of array "A"\n'
         r'__BUILTINS__:0:0: model: info: type "Boolean" has size 1, must be multiple of 8$',
     )
@@ -272,7 +276,7 @@ def test_array_unsupported_element_type() -> None:
 def test_invalid_enumeration_type_duplicate_elements() -> None:
     assert_type_model_error(
         Enumeration(
-            "P.T",
+            "P::T",
             [(ID("Foo", Location((3, 27))), Number(1)), (ID("Foo", Location((3, 32))), Number(2))],
             Number(1),
             False,
@@ -285,7 +289,7 @@ def test_invalid_enumeration_type_duplicate_elements() -> None:
 def test_invalid_enumeration_type_multiple_duplicate_elements() -> None:
     assert_type_model_error(
         Enumeration(
-            "P.T",
+            "P::T",
             [
                 (ID("Foo", Location((3, 27))), Number(1)),
                 (ID("Bar", Location((3, 32))), Number(2)),
@@ -306,7 +310,7 @@ def test_conflicting_literal_builtin_type() -> None:
     assert_model_error(
         [
             Enumeration(
-                "P.T",
+                "P::T",
                 [
                     (ID("E1", Location((3, 27))), Number(1)),
                     (ID("Boolean", Location((3, 31))), Number(2)),
@@ -324,7 +328,7 @@ def test_name_conflict_between_literal_and_type() -> None:
     assert_model_error(
         [
             Enumeration(
-                "P.T",
+                "P::T",
                 [
                     (ID("Foo", Location((3, 27))), Number(1)),
                     (ID("Bar", Location((3, 32))), Number(2)),
@@ -332,8 +336,8 @@ def test_name_conflict_between_literal_and_type() -> None:
                 Number(1),
                 False,
             ),
-            ModularInteger("T.Foo", Number(256), Location((4, 16))),
-            ModularInteger("T.Bar", Number(256), Location((5, 16))),
+            ModularInteger("T::Foo", Number(256), Location((4, 16))),
+            ModularInteger("T::Bar", Number(256), Location((5, 16))),
         ],
         r'<stdin>:3:32: model: error: literal conflicts with type "Bar"\n'
         r"<stdin>:5:16: model: info: conflicting type declaration\n"
@@ -346,7 +350,7 @@ def test_invalid_enumeration_type_builtin_literals() -> None:
     assert_model_error(
         [
             Enumeration(
-                "P.T",
+                "P::T",
                 [("True", Number(1)), ("False", Number(2))],
                 Number(1),
                 False,
@@ -363,13 +367,13 @@ def test_invalid_enumeration_type_identical_literals() -> None:
     assert_model_error(
         [
             Enumeration(
-                "P.T1",
+                "P::T1",
                 [("Foo", Number(1)), (ID("Bar", Location((3, 33))), Number(2))],
                 Number(1),
                 False,
             ),
             Enumeration(
-                "P.T2",
+                "P::T2",
                 [("Bar", Number(1)), ("Baz", Number(2))],
                 Number(1),
                 False,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,7 +24,7 @@ def assert_message_model_error(
     location: Location = None,
 ) -> None:
     with pytest.raises(RecordFluxError, match=regex):
-        Message("P.M", structure, types, aspects=aspects, location=location)
+        Message("P::M", structure, types, aspects=aspects, location=location)
 
 
 def assert_type_model_error(instance: Type, regex: str) -> None:


### PR DESCRIPTION
Closes #441