### PR TITLE
Fix ping example

### DIFF
--- a/examples/apps/ping/ping.py
+++ b/examples/apps/ping/ping.py
@@ -58,6 +58,9 @@ def create_request(src: int, dst: int, seq: int) -> bytes:
     msg.set("Sequence_Number", seq)
     msg.set("Data", ICMP_DATA)
     msg.set("Checksum", icmp_checksum(msg.bytestring))
+    msg.set("Identifier", 0)
+    msg.set("Sequence_Number", seq)
+    msg.set("Data", ICMP_DATA)
 
     pkt = IP["Packet"]
     pkt.set("Version", 4)

--- a/examples/apps/ping/ping.py
+++ b/examples/apps/ping/ping.py
@@ -49,6 +49,7 @@ def ping(target: str) -> None:
             create_request(0, int(ipaddress.IPv4Address(target_ip)), seq),
             (target, 0),
         )
+        seq = (seq + 1) % 2 ** 16
 
         packet = parse_reply(sock_in.recv(4096))
         packet_src = str(ipaddress.IPv4Address(packet.get("Source")))
@@ -58,16 +59,16 @@ def ping(target: str) -> None:
         reply = packet.get("Payload")
         assert isinstance(reply, MessageValue)
 
+        if reply.get("Tag") != "Echo_Reply":
+            continue
+
         reply_seq = str(reply.get("Sequence_Number"))
         print(f"{int(reply.size) // 8} bytes from {packet_src}: icmp_seq={reply_seq}", flush=True)
 
-        if reply.get("Tag") != "Echo_Reply":
-            print("unexpected type")
         if reply.get("Data") != ICMP_DATA:
             print("mismatch between sent and received data")
 
         time.sleep(1)
-        seq = (seq + 1) % 2 ** 16
 
 
 def create_request(src: int, dst: int, seq: int) -> bytes:

--- a/examples/apps/ping/specs/icmp.rflx
+++ b/examples/apps/ping/specs/icmp.rflx
@@ -109,7 +109,10 @@ package ICMP is
          Receive_Timestamp : Timestamp;
          Transmit_Timestamp : Timestamp
             then null;
-         Data : Opaque;
-      end message;
+         Data : Opaque
+            then null
+               if Checksum'Valid_Checksum;
+      end message with
+         Checksum => (Checksum => (Tag'First .. Checksum'First - 1, Checksum'Size, Checksum'Last + 1 .. Message'Last));
 
 end ICMP;

--- a/rflx/pyrflx/package.py
+++ b/rflx/pyrflx/package.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterator
+from typing import Callable, Dict, Iterator
 
 from rflx.common import Base
 from rflx.pyrflx.typevalue import MessageValue
@@ -21,3 +21,7 @@ class Package(Base):
 
     def __iter__(self) -> Iterator:
         return self.__messages.values().__iter__()
+
+    def set_checksum_functions(self, functions: Dict[str, Dict[str, Callable]]) -> None:
+        for key, value in functions.items():
+            self.__messages[key].set_checksum_function(value)

--- a/rflx/pyrflx/pyrflx.py
+++ b/rflx/pyrflx/pyrflx.py
@@ -1,7 +1,8 @@
 import logging
 from pathlib import Path
-from typing import Dict, Iterator, Sequence, Tuple
+from typing import Dict, Iterator, Sequence
 
+from rflx.identifier import ID
 from rflx.model import Model
 from rflx.pyrflx.typevalue import MessageValue, RefinementValue
 from rflx.specification import Parser
@@ -18,19 +19,19 @@ class PyRFLX:
         skip_message_verification: bool = False,
     ) -> None:
         self.__packages: Dict[str, Package] = {}
-        messages: Dict[Tuple[str, str], MessageValue] = {}
+        messages: Dict[ID, MessageValue] = {}
 
         for m in model.messages:
             p = str(m.package)
             if p not in self.__packages:
                 self.__packages[p] = Package(p)
             message = MessageValue(m, skip_verification=skip_message_verification)
-            messages[(p, str(m.name))] = message
+            messages[m.identifier] = message
             self.__packages[p][str(m.name)] = message
 
         for r in model.refinements:
-            messages[(str(r.pdu.package.name), str(r.pdu.name))].add_refinement(
-                RefinementValue(r, messages[(str(r.sdu.package.name), str(r.sdu.name))])
+            messages[r.pdu.identifier].add_refinement(
+                RefinementValue(r, messages[r.sdu.identifier])
             )
 
     @classmethod

--- a/tests/data/fixtures/pyrflx.py
+++ b/tests/data/fixtures/pyrflx.py
@@ -86,6 +86,37 @@ def fixture_icmp_checksum_message_value(icmp_message: model.Message) -> pyrflx.M
     )
 
 
+@pytest.fixture(name="icmp_checksum_message_first")
+def fixture_icmp_checksum_message_first(icmp_message: model.Message) -> pyrflx.MessageValue:
+    return pyrflx.MessageValue(
+        icmp_message.copy(
+            structure=[
+                model.Link(
+                    l.source,
+                    l.target,
+                    condition=expr.And(l.condition, expr.ValidChecksum("Checksum")),
+                )
+                if l.target == model.FINAL
+                else l
+                for l in icmp_message.structure
+            ],
+            aspects={
+                ID("Checksum"): {
+                    ID("Checksum"): [
+                        expr.ValueRange(
+                            expr.First("Message"), expr.Sub(expr.First("Checksum"), expr.Number(1))
+                        ),
+                        expr.Size("Checksum"),
+                        expr.ValueRange(
+                            expr.Add(expr.Last("Checksum"), expr.Number(1)), expr.Last("Message")
+                        ),
+                    ]
+                }
+            },
+        )
+    )
+
+
 @pytest.fixture(name="ipv4_package", scope="session")
 def fixture_ipv4_package(pyrflx_: pyrflx.PyRFLX) -> pyrflx.Package:
     return pyrflx_["IPv4"]

--- a/tests/data/specs/refinement_with_checksum.rflx
+++ b/tests/data/specs/refinement_with_checksum.rflx
@@ -1,0 +1,22 @@
+with TLV_With_Checksum;
+
+package Refinement_With_Checksum is
+
+   type Length is mod 2 ** 8;
+   type Checksum is mod 2 ** 8;
+
+   type Message is
+      message
+         Length   : Length;
+         Checksum : Checksum
+            then Payload
+               with Size => Length * 8;
+         Payload  : Opaque
+            then null
+               if Checksum'Valid_Checksum;
+      end message
+         with Checksum => (Checksum => (Payload'First .. Payload'Last));
+
+   for Message use (Payload => TLV_With_Checksum::Message);
+
+end Refinement_With_Checksum;


### PR DESCRIPTION
The ping example has been broken for quite a while. The current version uses an ICMP spec without a checksum aspect. Originally the checksum has been calculated after setting all fields (including the checksum field itself) and then replaced the original checksum. With the current version of PyRFLX setting a field while skipping verification leads to all following fields being invalidated. To generate a valid message these fields have to be set again with the same values.