### PR TITLE
Issue 581: Adapt to pylint 2.7.0 and add Python 3.9 to tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         target: ["python"]
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         include:
           - target: "python_unit"
             python-version: 3.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           ~/.cache/pip
           ~/.local/lib/python${{ matrix.python-version }}/site-packages
           ~/.local/bin
-        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('setup.py', '*.cfg', '*.ini', '.pylintrc', '.flake8') }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -104,7 +104,7 @@ jobs:
           ~/.cache/pip
           ~/.local/lib/python${{ matrix.python-version }}/site-packages
           ~/.local/bin
-        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('setup.py', '*.cfg', '*.ini', '.pylintrc', '.flake8') }}
     - name: Install dependencies
       run: |
         sudo apt install graphviz
@@ -152,7 +152,7 @@ jobs:
           ~/.cache/pip
           ~/.local/lib/python${{ matrix.python-version }}/site-packages
           ~/.local/bin
-        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('setup.py', '*.cfg', '*.ini', '.pylintrc', '.flake8') }}
     - name: Install dependencies
       run: |
         sudo apt install graphviz
@@ -256,7 +256,7 @@ jobs:
           ~/.cache/pip
           ~/.local/lib/python${{ matrix.python-version }}/site-packages
           ~/.local/bin
-        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('setup.py', '*.cfg', '*.ini', '.pylintrc', '.flake8') }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -307,7 +307,7 @@ jobs:
           ~/.cache/pip
           ~/.local/lib/python${{ matrix.python-version }}/site-packages
           ~/.local/bin
-        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('setup.py', '*.cfg', '*.ini', '.pylintrc', '.flake8') }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pylintrc
+++ b/.pylintrc
@@ -12,7 +12,8 @@ disable=missing-docstring,
         bad-continuation,
         unnecessary-lambda,
         inconsistent-return-statements,
-        unsubscriptable-object  # ISSUE: PyCQA/pylint#3045
+        unsubscriptable-object,  # ISSUE: PyCQA/pylint#3045
+        duplicate-code,  # ISSUE: PyCQA/pylint#4118
 
 [BASIC]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [![RecordFlux](doc/img/logo.svg)](https://github.com/Componolit/RecordFlux/)
 
 [![PyPI](https://img.shields.io/pypi/v/RecordFlux?color=blue)](https://pypi.org/project/RecordFlux/)
-[![Python Versions](https://img.shields.io/badge/python-3.7%20%7C%203.8-blue.svg)](https://python.org/)
+[![Python Versions](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue.svg)](https://python.org/)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Tests](https://github.com/Componolit/RecordFlux/workflows/tests/badge.svg)](https://github.com/Componolit/RecordFlux/actions)
 

--- a/rflx/ada.py
+++ b/rflx/ada.py
@@ -42,14 +42,14 @@ StrID = Union[str, ID]
 
 
 class Precedence(Enum):
-    undefined = 0
-    boolean_operator = 1
-    relational_operator = 2
-    binary_adding_operator = 3
-    unary_adding_operator = 4
-    multiplying_operator = 5
-    highest_precedence_operator = 6
-    literal = 7
+    UNDEFINED = 0
+    BOOLEAN_OPERATOR = 1
+    RELATIONAL_OPERATOR = 2
+    BINARY_ADDING_OPERATOR = 3
+    UNARY_ADDING_OPERATOR = 4
+    MULTIPLYING_OPERATOR = 5
+    HIGHEST_PRECEDENCE_OPERATOR = 6
+    LITERAL = 7
 
 
 class Expr(Base):
@@ -90,7 +90,7 @@ class Not(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.highest_precedence_operator
+        return Precedence.HIGHEST_PRECEDENCE_OPERATOR
 
 
 class BinExpr(Expr):
@@ -161,7 +161,7 @@ class BoolAssExpr(AssExpr):
 class And(BoolAssExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.boolean_operator
+        return Precedence.BOOLEAN_OPERATOR
 
     @property
     def symbol(self) -> str:
@@ -177,7 +177,7 @@ class AndThen(And):
 class Or(BoolAssExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.boolean_operator
+        return Precedence.BOOLEAN_OPERATOR
 
     @property
     def symbol(self) -> str:
@@ -217,7 +217,7 @@ class Number(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
 
 class Add(AssExpr):
@@ -232,7 +232,7 @@ class Add(AssExpr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.binary_adding_operator
+        return Precedence.BINARY_ADDING_OPERATOR
 
     @property
     def symbol(self) -> str:
@@ -242,7 +242,7 @@ class Add(AssExpr):
 class Mul(AssExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.multiplying_operator
+        return Precedence.MULTIPLYING_OPERATOR
 
     @property
     def symbol(self) -> str:
@@ -252,7 +252,7 @@ class Mul(AssExpr):
 class Sub(BinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.binary_adding_operator
+        return Precedence.BINARY_ADDING_OPERATOR
 
     @property
     def symbol(self) -> str:
@@ -262,7 +262,7 @@ class Sub(BinExpr):
 class Div(BinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.multiplying_operator
+        return Precedence.MULTIPLYING_OPERATOR
 
     @property
     def symbol(self) -> str:
@@ -272,7 +272,7 @@ class Div(BinExpr):
 class Pow(BinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.highest_precedence_operator
+        return Precedence.HIGHEST_PRECEDENCE_OPERATOR
 
     @property
     def symbol(self) -> str:
@@ -282,7 +282,7 @@ class Pow(BinExpr):
 class Mod(BinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.multiplying_operator
+        return Precedence.MULTIPLYING_OPERATOR
 
     @property
     def symbol(self) -> str:
@@ -305,7 +305,7 @@ class Name(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
 
 class Variable(Name):
@@ -483,7 +483,7 @@ class Aggregate(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
 
 class String(Aggregate):
@@ -496,7 +496,7 @@ class String(Aggregate):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
 
 class NamedAggregate(Expr):
@@ -517,7 +517,7 @@ class NamedAggregate(Expr):
 class Relation(BinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.relational_operator
+        return Precedence.RELATIONAL_OPERATOR
 
 
 class Less(Relation):
@@ -597,7 +597,7 @@ class IfExpr(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
 
 def Case(control_expression: Expr, case_expressions: Sequence[Tuple[Expr, Expr]]) -> Expr:
@@ -630,7 +630,7 @@ class CaseExpr(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
 
 class QuantifiedExpr(Expr):
@@ -648,7 +648,7 @@ class QuantifiedExpr(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     @property
     @abstractmethod
@@ -716,7 +716,7 @@ class Conversion(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
 
 class Declaration(Base):

--- a/rflx/expression.py
+++ b/rflx/expression.py
@@ -23,27 +23,27 @@ class Z3TypeError(TypeError):
 
 
 class Precedence(Enum):
-    undefined = 0
-    boolean_operator = 1
-    relational_operator = 2
-    binary_adding_operator = 3
-    unary_adding_operator = 4
-    multiplying_operator = 5
-    highest_precedence_operator = 6
-    literal = 7
+    UNDEFINED = 0
+    BOOLEAN_OPERATOR = 1
+    RELATIONAL_OPERATOR = 2
+    BINARY_ADDING_OPERATOR = 3
+    UNARY_ADDING_OPERATOR = 4
+    MULTIPLYING_OPERATOR = 5
+    HIGHEST_PRECEDENCE_OPERATOR = 6
+    LITERAL = 7
 
 
 class ProofResult(Enum):
-    sat = z3.sat
-    unsat = z3.unsat
-    unknown = z3.unknown
+    SAT = z3.sat
+    UNSAT = z3.unsat
+    UNKNOWN = z3.unknown
 
 
 class Proof:
     def __init__(self, expr: "Expr", facts: Optional[Sequence["Expr"]] = None):
         self.__expr = expr
         self.__facts = facts or []
-        self.__result = ProofResult.unsat
+        self.__result = ProofResult.UNSAT
 
         solver = z3.Solver()
         solver.add(self.__expr.z3expr())
@@ -58,7 +58,7 @@ class Proof:
 
     @property
     def error(self) -> List[Tuple[str, Optional[Location]]]:
-        assert self.__result == ProofResult.unsat
+        assert self.__result == ProofResult.UNSAT
         solver = z3.Solver()
         solver.set(unsat_core=True)
         facts = {f"H{index}": fact for index, fact in enumerate(self.__facts)}
@@ -207,7 +207,7 @@ class BooleanLiteral(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     def simplified(self) -> Expr:
         return self
@@ -274,7 +274,7 @@ class Not(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.highest_precedence_operator
+        return Precedence.HIGHEST_PRECEDENCE_OPERATOR
 
     def simplified(self) -> Expr:
         for relation, inverse_relation in [
@@ -401,7 +401,7 @@ class AssExpr(Expr):
     def __le__(self, other: object) -> bool:
         if isinstance(other, AssExpr):
             if len(self.terms) == len(other.terms):
-                return all([x <= y for x, y in zip(self.terms, other.terms)])
+                return all(x <= y for x, y in zip(self.terms, other.terms))
             return False
         return NotImplemented
 
@@ -417,7 +417,7 @@ class AssExpr(Expr):
     def __ge__(self, other: object) -> bool:
         if isinstance(other, AssExpr):
             if len(self.terms) == len(other.terms):
-                return all([x >= y for x, y in zip(self.terms, other.terms)])
+                return all(x >= y for x, y in zip(self.terms, other.terms))
             return False
         return NotImplemented
 
@@ -538,7 +538,7 @@ class And(BoolAssExpr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.boolean_operator
+        return Precedence.BOOLEAN_OPERATOR
 
     def simplified(self) -> Expr:
         simplified_expr = super().simplified()
@@ -583,7 +583,7 @@ class Or(BoolAssExpr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.boolean_operator
+        return Precedence.BOOLEAN_OPERATOR
 
     def simplified(self) -> Expr:
         simplified_expr = super().simplified()
@@ -725,7 +725,7 @@ class Number(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     def simplified(self) -> Expr:
         return self
@@ -769,7 +769,7 @@ class Add(MathAssExpr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.binary_adding_operator
+        return Precedence.BINARY_ADDING_OPERATOR
 
     def operation(self, left: int, right: int) -> int:
         return left + right
@@ -816,7 +816,7 @@ class Mul(MathAssExpr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.multiplying_operator
+        return Precedence.MULTIPLYING_OPERATOR
 
     def operation(self, left: int, right: int) -> int:
         return left * right
@@ -856,7 +856,7 @@ class MathBinExpr(BinExpr):
 class Sub(MathBinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.binary_adding_operator
+        return Precedence.BINARY_ADDING_OPERATOR
 
     def simplified(self) -> Expr:
         left = self.left.simplified()
@@ -884,7 +884,7 @@ class Sub(MathBinExpr):
 class Div(MathBinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.multiplying_operator
+        return Precedence.MULTIPLYING_OPERATOR
 
     def simplified(self) -> Expr:
         left = self.left.simplified()
@@ -912,7 +912,7 @@ class Div(MathBinExpr):
 class Pow(MathBinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.highest_precedence_operator
+        return Precedence.HIGHEST_PRECEDENCE_OPERATOR
 
     def simplified(self) -> Expr:
         left = self.left.simplified()
@@ -940,7 +940,7 @@ class Pow(MathBinExpr):
 class Mod(MathBinExpr):
     @property
     def precedence(self) -> Precedence:
-        return Precedence.multiplying_operator
+        return Precedence.MULTIPLYING_OPERATOR
 
     def simplified(self) -> Expr:
         left = self.left.simplified()
@@ -983,7 +983,7 @@ class Name(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     @property
     @abstractmethod
@@ -1445,7 +1445,7 @@ class Aggregate(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     def substituted(
         self, func: Callable[[Expr], Expr] = None, mapping: Mapping[Name, Expr] = None
@@ -1486,7 +1486,7 @@ class String(Aggregate):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     def substituted(
         self, func: Callable[[Expr], Expr] = None, mapping: Mapping[Name, Expr] = None
@@ -1524,7 +1524,7 @@ class Relation(BinExpr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.relational_operator
+        return Precedence.RELATIONAL_OPERATOR
 
 
 class Less(Relation):
@@ -1773,7 +1773,7 @@ class QuantifiedExpression(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     @property
     @abstractmethod
@@ -1959,7 +1959,7 @@ class Conversion(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     def substituted(
         self, func: Callable[[Expr], Expr] = None, mapping: Mapping[Name, Expr] = None
@@ -2066,7 +2066,7 @@ class Comprehension(Expr):
 
     @property
     def precedence(self) -> Precedence:
-        return Precedence.literal
+        return Precedence.LITERAL
 
     def ada_expr(self) -> ada.Expr:
         raise NotImplementedError

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -646,7 +646,7 @@ class Message(AbstractMessage):
                 continue
             empty_field = expr.Equal(expr.Size(field.name), expr.Number(0))
             proof = self.__prove_path_property(empty_field, p)
-            if proof.result == expr.ProofResult.sat:
+            if proof.result == expr.ProofResult.SAT:
                 return True
 
         return False
@@ -674,7 +674,7 @@ class Message(AbstractMessage):
                 try:
                     # check for contradictions in conditions of path
                     proof = self.__prove_path_property(expr.TRUE, p)
-                    if proof.result == expr.ProofResult.unsat:
+                    if proof.result == expr.ProofResult.UNSAT:
                         break
                 except expr.Z3TypeError:
                     pass
@@ -868,7 +868,7 @@ class Message(AbstractMessage):
                     if i1 < i2:
                         conflict = expr.And(c1.condition, c2.condition)
                         proof = conflict.check(self.type_constraints(conflict))
-                        if proof.result == expr.ProofResult.sat:
+                        if proof.result == expr.ProofResult.SAT:
                             c1_message = str(c1.condition).replace("\n", " ")
                             c2_message = str(c2.condition).replace("\n", " ")
                             self.error.append(
@@ -924,7 +924,7 @@ class Message(AbstractMessage):
                         )
                     )
                 proof = expr.TRUE.check(facts)
-                if proof.result == expr.ProofResult.sat:
+                if proof.result == expr.ProofResult.SAT:
                     break
 
                 paths.append((path, proof.error))
@@ -960,7 +960,7 @@ class Message(AbstractMessage):
                     contradiction = c.condition
                     constraints = self.type_constraints(contradiction)
                     proof = contradiction.check([*constraints, *facts])
-                    if proof.result == expr.ProofResult.sat:
+                    if proof.result == expr.ProofResult.SAT:
                         continue
 
                     contradictions.append((path, c.condition, proof.error))
@@ -1036,7 +1036,7 @@ class Message(AbstractMessage):
 
             # Coverage expression must be False, i.e. no bits left
             proof = expr.TRUE.check(facts)
-            if proof.result == expr.ProofResult.sat:
+            if proof.result == expr.ProofResult.SAT:
                 self.error.append(
                     "path does not cover whole message",
                     Subsystem.MODEL,
@@ -1065,7 +1065,7 @@ class Message(AbstractMessage):
                         self.__target_last(l), expr.Last(l.first.prefix), l.location
                     )
                     proof = overlaid.check(facts)
-                    if proof.result != expr.ProofResult.sat:
+                    if proof.result != expr.ProofResult.SAT:
                         self.error.append(
                             f'field "{f.name}" not congruent with'
                             f' overlaid field "{l.first.prefix}"',
@@ -1104,11 +1104,11 @@ class Message(AbstractMessage):
                 proof = expr.TRUE.check(facts)
 
                 # Only check positions of reachable paths
-                if proof.result != expr.ProofResult.sat:
+                if proof.result != expr.ProofResult.SAT:
                     continue
 
                 proof = negative.check(facts)
-                if proof.result != expr.ProofResult.unsat:
+                if proof.result != expr.ProofResult.UNSAT:
                     path_message = " -> ".join([l.target.name for l in path])
                     self.error.append(
                         f'negative size for field "{f.name}" ({path_message})',
@@ -1119,7 +1119,7 @@ class Message(AbstractMessage):
                     return
 
                 proof = start.check(facts)
-                if proof.result != expr.ProofResult.sat:
+                if proof.result != expr.ProofResult.SAT:
                     path_message = " -> ".join([last.target.name for last in path])
                     self.error.append(
                         f'negative start for field "{f.name}" ({path_message})',
@@ -1148,7 +1148,7 @@ class Message(AbstractMessage):
                         )
                     )
                     proof = start_aligned.check([*facts, *self.type_constraints(start_aligned)])
-                    if proof.result != expr.ProofResult.unsat:
+                    if proof.result != expr.ProofResult.UNSAT:
                         path_message = " -> ".join([p.target.name for p in path])
                         self.error.append(
                             f'opaque field "{f.name}" not aligned to {element_size} bit boundary'
@@ -1169,7 +1169,7 @@ class Message(AbstractMessage):
                     proof = is_multiple_of_element_size.check(
                         [*facts, *self.type_constraints(is_multiple_of_element_size)]
                     )
-                    if proof.result != expr.ProofResult.unsat:
+                    if proof.result != expr.ProofResult.UNSAT:
                         path_message = " -> ".join([p.target.name for p in path])
                         self.error.append(
                             f'size of opaque field "{f.name}" not multiple of {element_size} bit'
@@ -1396,7 +1396,7 @@ class UnprovenMessage(AbstractMessage):
                                 inner_message.field_condition(final_link.source),
                             ]
                         )
-                        if proof.result != expr.ProofResult.unsat:
+                        if proof.result != expr.ProofResult.UNSAT:
                             structure.append(
                                 Link(
                                     final_link.source,

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Communications",
         "Topic :: Security",
         "Topic :: Software Development :: Build Tools",

--- a/tests/unit/expression_test.py
+++ b/tests/unit/expression_test.py
@@ -957,7 +957,7 @@ def test_aggregate_str() -> None:
 
 
 def test_aggregate_precedence() -> None:
-    assert Aggregate(Number(1), Number(2)).precedence == Precedence.literal
+    assert Aggregate(Number(1), Number(2)).precedence == Precedence.LITERAL
 
 
 @pytest.mark.parametrize("relation", [Less, LessEqual, Equal, GreaterEqual, Greater, NotEqual])


### PR DESCRIPTION
This will also disable the code duplication detection of pylint because of a bug in the new pylint version. I don't think it is a big loss. We can re-enable it at some time.

Closes #581