### PR TITLE
Issue 568: Coverage

### DIFF
--- a/rflx/pyrflx/typevalue.py
+++ b/rflx/pyrflx/typevalue.py
@@ -376,7 +376,6 @@ class OpaqueValue(CompositeValue):
 
     @property
     def nested_message(self) -> Optional["MessageValue"]:
-        self._raise_initialized()
         return self._nested_message
 
     @property
@@ -509,6 +508,7 @@ class ArrayValue(CompositeValue):
 
 class MessageValue(TypeValue):
     # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-public-methods
 
     _type: Message
 
@@ -611,6 +611,10 @@ class MessageValue(TypeValue):
 
     def equal_type(self, other: Type) -> bool:
         return self.identifier == other.identifier
+
+    @property
+    def structure(self) -> Sequence[Link]:
+        return self._type.structure
 
     @property
     def path(self) -> Sequence[Link]:

--- a/rflx/pyrflx/typevalue.py
+++ b/rflx/pyrflx/typevalue.py
@@ -522,7 +522,7 @@ class MessageValue(TypeValue):
         super().__init__(model)
         self._skip_verification = skip_verification
         self._refinements = refinements or []
-        self._covered_links: List[Link] = []
+        self._path: List[Link] = []
 
         self._fields: Mapping[str, MessageValue.Field] = (
             state.fields
@@ -613,8 +613,8 @@ class MessageValue(TypeValue):
         return self.identifier == other.identifier
 
     @property
-    def covered_links(self) -> Sequence[Link]:
-        return self._covered_links
+    def path(self) -> Sequence[Link]:
+        return self._path
 
     def inner_messages(self) -> List["MessageValue"]:
         sdu_messages: List["MessageValue"] = []
@@ -646,7 +646,7 @@ class MessageValue(TypeValue):
 
         next_link = self._next_link(field_name)
         if coverage and next_link is not None:
-            self._covered_links.append(next_link)
+            self._path.append(next_link)
         if next_link is None and field_name == INITIAL.name:
             # the INITIAL field has no outgoing links in case of a NULL message
             return FINAL.name

--- a/rflx/pyrflx/typevalue.py
+++ b/rflx/pyrflx/typevalue.py
@@ -618,6 +618,11 @@ class MessageValue(TypeValue):
 
     @property
     def path(self) -> Sequence[Link]:
+        """
+        The returned path is only correct, if the parse() method is used to set the field values.
+        If fields are set manually using the set() method, path is empty. If the set() method is
+        used to manipulate fields that have already been set by parse(), path is incorrect.
+        """
         return self._path
 
     def inner_messages(self) -> List["MessageValue"]:

--- a/rflx/pyrflx/typevalue.py
+++ b/rflx/pyrflx/typevalue.py
@@ -645,13 +645,14 @@ class MessageValue(TypeValue):
                 return link
         return None
 
-    def _next_field(self, field_name: str, coverage: bool = False) -> str:
+    def _next_field(self, field_name: str, append_to_path: bool = False) -> str:
         if self._skip_verification and field_name != FINAL.name and self._fields[field_name].next:
             return self._fields[field_name].next
 
         next_link = self._next_link(field_name)
-        if coverage and next_link is not None:
+        if append_to_path and next_link is not None:
             self._path.append(next_link)
+
         if next_link is None and field_name == INITIAL.name:
             # the INITIAL field has no outgoing links in case of NULL message
             # ISSUE: Componolit/RecordFlux#643
@@ -784,7 +785,7 @@ class MessageValue(TypeValue):
                         f"Bitstring representing the message is too short - "
                         f"stopped while parsing field: {current_field_name}"
                     ) from None
-            current_field_name = self._next_field(current_field_name, coverage=True)
+            current_field_name = self._next_field(current_field_name, append_to_path=True)
 
     def _set_unchecked(
         self, field_name: str, value: Union[bytes, int, str, Sequence[TypeValue]]

--- a/rflx/pyrflx/typevalue.py
+++ b/rflx/pyrflx/typevalue.py
@@ -727,7 +727,7 @@ class MessageValue(TypeValue):
         self._path.clear()
         if isinstance(value, bytes):
             value = Bitstring.from_bytes(value)
-        current_field_name = self._next_field(INITIAL.name)
+        current_field_name = self._next_field(INITIAL.name, append_to_path=True)
         last_field_first_in_bitstr = current_field_first_in_bitstr = 0
 
         def get_current_pos_in_bitstr(field_name: str) -> int:

--- a/rflx/pyrflx/typevalue.py
+++ b/rflx/pyrflx/typevalue.py
@@ -724,6 +724,7 @@ class MessageValue(TypeValue):
 
     def parse(self, value: Union[Bitstring, bytes], check: bool = True) -> None:
         assert not self._skip_verification
+        self._path.clear()
         if isinstance(value, bytes):
             value = Bitstring.from_bytes(value)
         current_field_name = self._next_field(INITIAL.name)

--- a/tests/data/fixtures/pyrflx.py
+++ b/tests/data/fixtures/pyrflx.py
@@ -25,7 +25,6 @@ def fixture_pyrflx() -> pyrflx.PyRFLX:
             f"{SPEC_DIR}/tlv_with_checksum.rflx",
             f"{SPEC_DIR}/message_size.rflx",
             f"{SPEC_DIR}/message_type_size_condition.rflx",
-            f"{SPEC_DIR}/in_array_message.rflx",
             f"{SPEC_DIR}/always_valid_aspect.rflx",
         ],
         skip_model_verification=True,
@@ -180,21 +179,16 @@ def fixture_array_message_package(pyrflx_: pyrflx.PyRFLX) -> pyrflx.Package:
     return pyrflx_["Array_Message"]
 
 
-@pytest.fixture(name="array_message_value")
+@pytest.fixture(name="message_array_value")
 def fixture_array_message_value(array_message_package: pyrflx.Package) -> pyrflx.MessageValue:
-    return array_message_package["Message"]
+    return array_message_package["Message_Array"]
 
 
-@pytest.fixture(name="in_array_message_package", scope="session")
-def fixture_in_array_message_package(pyrflx_: pyrflx.PyRFLX) -> pyrflx.Package:
-    return pyrflx_["Array_Message"]
-
-
-@pytest.fixture(name="array_message_with_sdu_value")
-def fixture_array_message_with_sdu_value(
-    in_array_message_package: pyrflx.Package,
+@pytest.fixture(name="message_array_refinement_value")
+def fixture_array_message_refinement_value(
+    array_message_package: pyrflx.Package,
 ) -> pyrflx.MessageValue:
-    return in_array_message_package["Message_With_SDU"]
+    return array_message_package["Message_Array_And_Refinement"]
 
 
 @pytest.fixture(name="message_size_package", scope="session")

--- a/tests/data/fixtures/pyrflx.py
+++ b/tests/data/fixtures/pyrflx.py
@@ -25,6 +25,7 @@ def fixture_pyrflx() -> pyrflx.PyRFLX:
             f"{SPEC_DIR}/tlv_with_checksum.rflx",
             f"{SPEC_DIR}/message_size.rflx",
             f"{SPEC_DIR}/message_type_size_condition.rflx",
+            f"{SPEC_DIR}/in_array_message.rflx",
             f"{SPEC_DIR}/always_valid_aspect.rflx",
         ],
         skip_model_verification=True,
@@ -182,6 +183,18 @@ def fixture_array_message_package(pyrflx_: pyrflx.PyRFLX) -> pyrflx.Package:
 @pytest.fixture(name="array_message_value")
 def fixture_array_message_value(array_message_package: pyrflx.Package) -> pyrflx.MessageValue:
     return array_message_package["Message"]
+
+
+@pytest.fixture(name="in_array_message_package", scope="session")
+def fixture_in_array_message_package(pyrflx_: pyrflx.PyRFLX) -> pyrflx.Package:
+    return pyrflx_["Array_Message"]
+
+
+@pytest.fixture(name="array_message_with_sdu_value")
+def fixture_array_message_with_sdu_value(
+    in_array_message_package: pyrflx.Package,
+) -> pyrflx.MessageValue:
+    return in_array_message_package["Message_With_SDU"]
 
 
 @pytest.fixture(name="message_size_package", scope="session")

--- a/tests/data/specs/array_message.rflx
+++ b/tests/data/specs/array_message.rflx
@@ -18,4 +18,15 @@ package Array_Message is
          Bar : Bar;
       end message;
 
+   type Message_With_SDU is
+      message
+         Length : Byte
+            then Bar
+               with Size => Length * 8;
+         Bar : Bar
+            then Payload
+               with Size => 8;
+         Payload : Opaque;
+      end message;
+
 end Array_Message;

--- a/tests/data/specs/array_message.rflx
+++ b/tests/data/specs/array_message.rflx
@@ -3,12 +3,12 @@ package Array_Message is
    type Byte is mod 256;
    type Bytes is array of Byte;
 
-   type Array_Member is
+   type Array_Element is
       message
          Byte : Byte;
       end message;
 
-   type Test_Array is array of Array_Member;
+   type Test_Array is array of Array_Element;
 
    type Message_Array is
       message
@@ -29,6 +29,6 @@ package Array_Message is
          Payload : Opaque;
       end message;
 
-   for Message_Array_And_Refinement use (Payload => Array_Member);
+   for Message_Array_And_Refinement use (Payload => Array_Element);
 
 end Array_Message;

--- a/tests/data/specs/array_message.rflx
+++ b/tests/data/specs/array_message.rflx
@@ -3,30 +3,32 @@ package Array_Message is
    type Byte is mod 256;
    type Bytes is array of Byte;
 
-   type Foo is
+   type Array_Member is
       message
          Byte : Byte;
       end message;
 
-   type Bar is array of Foo;
+   type Test_Array is array of Array_Member;
 
-   type Message is
+   type Message_Array is
       message
          Length : Byte
-            then Bar
+            then Array_Field
                with Size => Length * 8;
-         Bar : Bar;
+         Array_Field : Test_Array;
       end message;
 
-   type Message_With_SDU is
+   type Message_Array_And_Refinement is
       message
          Length : Byte
-            then Bar
+            then Array_Field
                with Size => Length * 8;
-         Bar : Bar
+         Array_Field : Test_Array
             then Payload
                with Size => 8;
          Payload : Opaque;
       end message;
+
+   for Message_Array_And_Refinement use (Payload => Array_Member);
 
 end Array_Message;

--- a/tests/data/specs/in_array_message.rflx
+++ b/tests/data/specs/in_array_message.rflx
@@ -1,0 +1,7 @@
+with Array_Message;
+
+package In_Array_Message is
+
+   for Array_Message::Message_With_SDU use (Payload => Array_Message::Foo);
+
+end In_Array_Message;

--- a/tests/data/specs/in_array_message.rflx
+++ b/tests/data/specs/in_array_message.rflx
@@ -1,7 +1,0 @@
-with Array_Message;
-
-package In_Array_Message is
-
-   for Array_Message::Message_With_SDU use (Payload => Array_Message::Foo);
-
-end In_Array_Message;

--- a/tests/integration/pyrflx_test.py
+++ b/tests/integration/pyrflx_test.py
@@ -264,9 +264,9 @@ def test_no_verification_ethernet(ethernet_frame_value: MessageValue) -> None:
 def test_no_verification_array_nested_messages(
     array_message_package: Package, message_array_value: MessageValue
 ) -> None:
-    array_message_one = array_message_package["Array_Member"]
+    array_message_one = array_message_package["Array_Element"]
     array_message_one.set("Byte", 5)
-    array_message_two = array_message_package["Array_Member"]
+    array_message_two = array_message_package["Array_Element"]
     array_message_two.set("Byte", 6)
     array: List[TypeValue] = [array_message_one, array_message_two]
     message_array_value.set("Length", 2)
@@ -280,11 +280,11 @@ def test_no_verification_array_nested_messages(
     )
     array_message_package_unv = pyrflx_["Array_Message"]
     array_message_unv = array_message_package_unv["Message_Array"]
-    array_member_one_unv = array_message_package_unv["Array_Member"]
-    array_member_one_unv.set("Byte", 5)
-    array_member_two_unv = array_message_package_unv["Array_Member"]
-    array_member_two_unv.set("Byte", 6)
-    array_unv: List[TypeValue] = [array_member_one_unv, array_member_two_unv]
+    array_element_one_unv = array_message_package_unv["Array_Element"]
+    array_element_one_unv.set("Byte", 5)
+    array_element_two_unv = array_message_package_unv["Array_Element"]
+    array_element_two_unv.set("Byte", 6)
+    array_unv: List[TypeValue] = [array_element_one_unv, array_element_two_unv]
     array_message_unv.set("Length", 2)
     array_message_unv.set("Array_Field", array_unv)
     assert array_message_unv.valid_message

--- a/tests/integration/pyrflx_test.py
+++ b/tests/integration/pyrflx_test.py
@@ -262,16 +262,16 @@ def test_no_verification_ethernet(ethernet_frame_value: MessageValue) -> None:
 
 
 def test_no_verification_array_nested_messages(
-    array_message_package: Package, array_message_value: MessageValue
+    array_message_package: Package, message_array_value: MessageValue
 ) -> None:
-    array_message_one = array_message_package["Foo"]
+    array_message_one = array_message_package["Array_Member"]
     array_message_one.set("Byte", 5)
-    array_message_two = array_message_package["Foo"]
+    array_message_two = array_message_package["Array_Member"]
     array_message_two.set("Byte", 6)
-    foos: List[TypeValue] = [array_message_one, array_message_two]
-    array_message_value.set("Length", 2)
-    array_message_value.set("Bar", foos)
-    assert array_message_value.valid_message
+    array: List[TypeValue] = [array_message_one, array_message_two]
+    message_array_value.set("Length", 2)
+    message_array_value.set("Array_Field", array)
+    assert message_array_value.valid_message
 
     pyrflx_ = PyRFLX.from_specs(
         [f"{SPEC_DIR}/array_message.rflx"],
@@ -279,16 +279,16 @@ def test_no_verification_array_nested_messages(
         skip_message_verification=True,
     )
     array_message_package_unv = pyrflx_["Array_Message"]
-    array_message_unv = array_message_package_unv["Message"]
-    array_message_one_unv = array_message_package_unv["Foo"]
-    array_message_one_unv.set("Byte", 5)
-    array_message_two_unv = array_message_package_unv["Foo"]
-    array_message_two_unv.set("Byte", 6)
-    foos_unv: List[TypeValue] = [array_message_one_unv, array_message_two_unv]
+    array_message_unv = array_message_package_unv["Message_Array"]
+    array_member_one_unv = array_message_package_unv["Array_Member"]
+    array_member_one_unv.set("Byte", 5)
+    array_member_two_unv = array_message_package_unv["Array_Member"]
+    array_member_two_unv.set("Byte", 6)
+    array_unv: List[TypeValue] = [array_member_one_unv, array_member_two_unv]
     array_message_unv.set("Length", 2)
-    array_message_unv.set("Bar", foos_unv)
+    array_message_unv.set("Array_Field", array_unv)
     assert array_message_unv.valid_message
-    assert array_message_unv.bytestring == array_message_value.bytestring
+    assert array_message_unv.bytestring == message_array_value.bytestring
 
 
 def icmp_checksum_function(message: bytes, **kwargs: object) -> int:

--- a/tests/unit/pyrflx_test.py
+++ b/tests/unit/pyrflx_test.py
@@ -1253,4 +1253,4 @@ def test_get_covered_links(icmp_message_value: MessageValue) -> None:
 
 
 def test_get_structure(icmp_message_value: MessageValue) -> None:
-    assert len(icmp_message_value.structure) == 25
+    assert isinstance(icmp_message_value.model, Message)

--- a/tests/unit/pyrflx_test.py
+++ b/tests/unit/pyrflx_test.py
@@ -1237,7 +1237,7 @@ def test_get_covered_links(icmp_message_value: MessageValue) -> None:
         b"\x30\x31\x32\x33\x34\x35\x36\x37"
     )
     icmp_message_value.parse(test_bytes)
-    covered_links = icmp_message_value.covered_links
+    covered_links = icmp_message_value.path
     field_pairs = [
         ("Tag", "Code_Zero"),
         ("Code_Zero", "Checksum"),

--- a/tests/unit/pyrflx_test.py
+++ b/tests/unit/pyrflx_test.py
@@ -1250,3 +1250,7 @@ def test_get_covered_links(icmp_message_value: MessageValue) -> None:
     assert len(covered_links) == 6
     for link, field_pair in zip(covered_links, field_pairs):
         assert link.source.name == field_pair[0] and link.target.name == field_pair[1]
+
+
+def test_get_structure(icmp_message_value: MessageValue) -> None:
+    assert len(icmp_message_value.structure) == 25

--- a/tests/unit/pyrflx_test.py
+++ b/tests/unit/pyrflx_test.py
@@ -1229,8 +1229,7 @@ def test_get_inner_messages(
     assert {m.get("Byte") for m in inner_messages} == {5, 6, 7}
 
 
-
-def test_get_covered_links(icmp_message_value: MessageValue) -> None:
+def test_get_path(icmp_message_value: MessageValue) -> None:
     test_bytes = (
         b"\x08\x00\xe1\x1e\x00\x11\x00\x01\x4a\xfc\x0d\x00\x00\x00\x00\x00"
         b"\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f"

--- a/tests/unit/pyrflx_test.py
+++ b/tests/unit/pyrflx_test.py
@@ -689,11 +689,11 @@ def test_invalid_value() -> None:
 
 
 def test_array_messages(message_array_value: MessageValue, array_message_package: Package) -> None:
-    array_member_one = array_message_package["Array_Member"]
-    array_member_one.set("Byte", 5)
-    array_member_two = array_message_package["Array_Member"]
-    array_member_two.set("Byte", 6)
-    array = [array_member_one, array_member_two]
+    array_element_one = array_message_package["Array_Element"]
+    array_element_one.set("Byte", 5)
+    array_element_two = array_message_package["Array_Element"]
+    array_element_two.set("Byte", 6)
+    array = [array_element_one, array_element_two]
     message_array_value.set("Length", 2)
     message_array_value.set("Array_Field", array)
     assert message_array_value.valid_message
@@ -1209,21 +1209,20 @@ def test_always_valid_aspect(  # pylint: disable=invalid-name
 def test_get_inner_messages(
     array_message_package: Package, message_array_refinement_value: MessageValue
 ) -> None:
-    array_message_one = array_message_package["Array_Member"]
-    array_message_one.set("Byte", 5)
-    array_message_two = array_message_package["Array_Member"]
-    array_message_two.set("Byte", 6)
-    sdu_message = array_message_package["Array_Member"]
-    sdu_message.set("Byte", 7)
+    array_element_one = array_message_package["Array_Element"]
+    array_element_one.set("Byte", 5)
+    array_element_two = array_message_package["Array_Element"]
+    array_element_two.set("Byte", 6)
+    array_element_three = array_message_package["Array_Element"]
+    array_element_three.set("Byte", 7)
 
-    message_foo_value = message_array_refinement_value
-    array_contents: Sequence[TypeValue] = [array_message_one, array_message_two]
-    message_foo_value.set("Length", 2)
-    message_foo_value.set("Array_Field", array_contents)
-    message_foo_value.set("Payload", sdu_message.bytestring)
-    assert message_foo_value.valid_message
+    array_contents: Sequence[TypeValue] = [array_element_one, array_element_two]
+    message_array_refinement_value.set("Length", 2)
+    message_array_refinement_value.set("Array_Field", array_contents)
+    message_array_refinement_value.set("Payload", array_element_three.bytestring)
+    assert message_array_refinement_value.valid_message
 
-    inner_messages = message_foo_value.inner_messages()
+    inner_messages = message_array_refinement_value.inner_messages()
     assert len(inner_messages) == 3
     assert all(isinstance(m, MessageValue) for m in inner_messages)
     assert {m.get("Byte") for m in inner_messages} == {5, 6, 7}
@@ -1237,7 +1236,7 @@ def test_get_path(icmp_message_value: MessageValue) -> None:
         b"\x30\x31\x32\x33\x34\x35\x36\x37"
     )
     icmp_message_value.parse(test_bytes)
-    covered_links = icmp_message_value.path
+    path = icmp_message_value.path
     field_pairs = [
         ("Tag", "Code_Zero"),
         ("Code_Zero", "Checksum"),
@@ -1247,10 +1246,9 @@ def test_get_path(icmp_message_value: MessageValue) -> None:
         ("Data", "Final"),
     ]
 
-    assert len(covered_links) == 6
-    for link, field_pair in zip(covered_links, field_pairs):
-        assert link.source.name == field_pair[0] and link.target.name == field_pair[1]
+    assert len(path) == 6
+    assert [(l.source.name, l.target.name) for l in path] == field_pairs
 
 
-def test_get_structure(icmp_message_value: MessageValue) -> None:
+def test_get_model(icmp_message_value: MessageValue) -> None:
     assert isinstance(icmp_message_value.model, Message)

--- a/tests/unit/pyrflx_test.py
+++ b/tests/unit/pyrflx_test.py
@@ -1238,6 +1238,7 @@ def test_get_path(icmp_message_value: MessageValue) -> None:
     icmp_message_value.parse(test_bytes)
     path = icmp_message_value.path
     field_pairs = [
+        ("Initial", "Tag"),
         ("Tag", "Code_Zero"),
         ("Code_Zero", "Checksum"),
         ("Checksum", "Identifier"),
@@ -1245,8 +1246,6 @@ def test_get_path(icmp_message_value: MessageValue) -> None:
         ("Sequence_Number", "Data"),
         ("Data", "Final"),
     ]
-
-    assert len(path) == 6
     assert [(l.source.name, l.target.name) for l in path] == field_pairs
 
 


### PR DESCRIPTION
This PR should discuss the changes introduced to pyrflx to enable the coverage check for messages.

A boolean flag is added to the `_next_field` method. This is needed in order to determine when the covered link should be stored, as the `next_field` method is used during message initialization where the used link must not be stored.
In addition to this, a method is added to return all inner messages of a `MessageValue`. This is needed so that the coverage information of any nested messages can be obtained.

Closes #568