### PR TITLE
Fix GNAT Studio plugin

### DIFF
--- a/ide/gnatstudio/recordflux.py
+++ b/ide/gnatstudio/recordflux.py
@@ -364,7 +364,7 @@ def display_message_graph(filename):
     loc = GPS.EditorBuffer.get().current_view().cursor()
     column = loc.column()
     line = loc.line()
-    name = GPS.File(filename).base_name()
+    name = GPS.File(filename).name()
     message_name = get_message_name(locations, name, line, column)
     if not message_name:
         GPS.MDI.dialog(


### PR DESCRIPTION
For some reason I always get a `KeyError` in `get_message_name` when displaying a message graph with the current version of the plugin. The fix is simple, but it is not clear to me why the behavior changed. I have tested the plugin with GNAT Studio 21.1 and a recent wavefront as older versions are not supported anymore (#602), but IIRC I didn't see the issue with these versions before.