### PR TITLE
Issue 710: Fix recalculated checksum value set to field while parsing

### DIFF
--- a/tests/unit/pyrflx_test.py
+++ b/tests/unit/pyrflx_test.py
@@ -1014,6 +1014,13 @@ def test_checksum_parse_invalid(icmp_checksum_message_value: MessageValue) -> No
     assert not icmp_checksum_message_value.valid_message
 
 
+def test_checksum_parse_invalid_tlv(tlv_checksum_package: Package) -> None:
+    tlv_checksum_message = tlv_checksum_package["Message"]
+    tlv_checksum_message.set_checksum_function({"Checksum": checksum_function_255})
+    tlv_checksum_message.parse(b"\x01\x00\x02\xAB\xCD\x00\x00\x00\xF1")
+    assert not tlv_checksum_message.valid_message
+
+
 def test_checksum_message_first(icmp_checksum_message_first: MessageValue) -> None:
     test_data = (
         b"\x47\xb4\x67\x5e\x00\x00\x00\x00"


### PR DESCRIPTION
The solution required changes to the `set` method.

The value for the checksum field is set by using the `set` method and `preset_fields` is called inside `set`. There are 2 cases that need to be considered.

1 message generation: 
All fields are set manually and the checksum is calculated and **set automatically** if all fields that are needed for the checksum calculation have been set. `preset_fields` **must not be called inside** `set` when setting **the checksum value** after calculation. Calling `preset_fields` could lead to the message being invalid in case an Opaque field is located after the checksum field, as `preset_fields` clears the value of opaque fields if a predecessor field changes. This is required in case message fields are not set in the right order. In all other cases (i.e. setting fields that are not checksum fields) `preset_fields` needs to be called.

2 message parsing:
The checksum must **not** be set to the checksum field. While parsing, `set` is called to set the field values and `preset_fields`  **is needed**.

The current implementation has a boolean parameter `calculate_checksum` (True by default). If set to `False` the checksum is not calculated **and** preset_fields is not executed. That means, it does not work for parsing messages, only for generation. 

To solve that, I split the `set`method into a `set` method for parsing and one for generating messages.


Ref: #710