### PR TITLE
Fix packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
+include SECURITY.md
 recursive-include doc *

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Topic :: Software Development :: Code Generators",
         "Topic :: System :: Networking",
     ],
-    packages=find_packages(exclude=("tests",)),
+    packages=find_packages(include=("rflx", "rflx.*")),
     package_data={"rflx": ["py.typed", "templates/*"]},
     python_requires=">=3.7",
     install_requires=[


### PR DESCRIPTION
Prevent adding of `bin`, `tests` and `tools` as packages and add `SECURITY.md` to package.