### PR TITLE
Issue 748: Fail-fast mode

### DIFF
--- a/rflx/cli.py
+++ b/rflx/cli.py
@@ -11,7 +11,7 @@ import librflxlang
 from pkg_resources import get_distribution
 
 from rflx import __version__
-from rflx.error import RecordFluxError, Severity, Subsystem, fail
+from rflx.error import FAIL_AFTER_VALUE, RecordFluxError, Severity, Subsystem, fail
 from rflx.generator import Generator
 from rflx.graph import Graph
 from rflx.model import Message, Model, Session
@@ -33,6 +33,13 @@ def main(argv: List[str]) -> Union[int, str]:
         action="store_true",
         help=("skip time-consuming verification of model"),
     )
+    parser.add_argument(
+        "--max-errors",
+        type=int,
+        default=0,
+        metavar=("NUM"),
+        help="exit after at most NUM errors",
+    )
 
     subparsers = parser.add_subparsers(dest="subcommand")
 
@@ -47,8 +54,8 @@ def main(argv: List[str]) -> Union[int, str]:
         "-p",
         "--prefix",
         type=str,
-        default="RFLX",
-        help=("add prefix to generated packages " f"(default: {DEFAULT_PREFIX})"),
+        default=DEFAULT_PREFIX,
+        help="add prefix to generated packages (default: %(default)s)",
     )
     parser_generate.add_argument(
         "-n", "--no-library", help="omit generating library files", action="store_true"
@@ -98,6 +105,8 @@ def main(argv: List[str]) -> Union[int, str]:
 
     if args.quiet:
         logging.disable(logging.CRITICAL)
+
+    FAIL_AFTER_VALUE.v = args.max_errors
 
     try:
         args.func(args)

--- a/rflx/cli.py
+++ b/rflx/cli.py
@@ -11,7 +11,7 @@ import librflxlang
 from pkg_resources import get_distribution
 
 from rflx import __version__
-from rflx.error import FAIL_AFTER_VALUE, RecordFluxError, Severity, Subsystem, fail
+from rflx.error import ERROR_CONFIG, RecordFluxError, Severity, Subsystem, fail
 from rflx.generator import Generator
 from rflx.graph import Graph
 from rflx.model import Message, Model, Session
@@ -106,7 +106,7 @@ def main(argv: List[str]) -> Union[int, str]:
     if args.quiet:
         logging.disable(logging.CRITICAL)
 
-    FAIL_AFTER_VALUE.v = args.max_errors
+    ERROR_CONFIG.fail_after_value = args.max_errors
 
     try:
         args.func(args)

--- a/rflx/cli.py
+++ b/rflx/cli.py
@@ -186,7 +186,7 @@ def parse(files: Sequence[Path], skip_verification: bool = False) -> Model:
 
     for f in files:
         if not f.is_file():
-            error.append(f'file not found: "{f}"', Subsystem.CLI, Severity.ERROR)
+            error.extend([(f'file not found: "{f}"', Subsystem.CLI, Severity.ERROR, None)])
             continue
 
         present_files.append(Path(f))

--- a/rflx/declaration.py
+++ b/rflx/declaration.py
@@ -147,18 +147,22 @@ class RenamingDeclaration(TypeCheckableDeclaration, BasicDeclaration):
             if ID(r.field) == self.expression.selector and r.sdu.is_compatible(declaration_type):
                 break
         else:
-            error.append(
-                f'invalid renaming to "{self.identifier}"',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
-            )
-            error.append(
-                f'refinement for message "{self.expression.prefix.type_.identifier}"'
-                " would make operation legal",
-                Subsystem.MODEL,
-                Severity.INFO,
-                self.location,
+            error.extend(
+                [
+                    (
+                        f'invalid renaming to "{self.identifier}"',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    ),
+                    (
+                        f'refinement for message "{self.expression.prefix.type_.identifier}"'
+                        " would make operation legal",
+                        Subsystem.MODEL,
+                        Severity.INFO,
+                        self.location,
+                    ),
+                ],
             )
         return error + self.expression.check_type(rty.OPAQUE)
 

--- a/rflx/error.py
+++ b/rflx/error.py
@@ -138,20 +138,6 @@ class BaseError(Exception, Base):
     def errors(self) -> Deque["BaseError.Entry"]:
         return self.__errors
 
-    def append(
-        self, message: str, subsystem: Subsystem, severity: Severity, location: Location = None
-    ) -> None:
-        self.__errors.append(BaseError.Entry(message, subsystem, severity, location))
-        if get_fail_after() > 0 and len(self.__errors) >= get_fail_after():
-            raise self
-
-    def appendleft(
-        self, message: str, subsystem: Subsystem, severity: Severity, location: Location = None
-    ) -> None:
-        self.__errors.appendleft(BaseError.Entry(message, subsystem, severity, location))
-        if get_fail_after() > 0 and len(self.__errors) >= get_fail_after():
-            raise self
-
     def extend(
         self,
         entries: Union[List[Tuple[str, Subsystem, Severity, Optional[Location]]], "BaseError"],
@@ -220,7 +206,7 @@ def _fail(
     severity: Severity = Severity.ERROR,
     location: Location = None,
 ) -> NoReturn:
-    error.append(message, subsystem, severity, location)
+    error.extend([(message, subsystem, severity, location)])
     error.propagate()
     assert False
 
@@ -232,5 +218,5 @@ def warn(
     location: Location = None,
 ) -> None:
     e = RecordFluxError()
-    e.append(message, subsystem, severity, location)
+    e.extend([(message, subsystem, severity, location)])
     print(e)

--- a/rflx/error.py
+++ b/rflx/error.py
@@ -7,8 +7,8 @@ from typing import Deque, List, NoReturn, Optional, Tuple, TypeVar, Union
 
 from rflx.common import Base, verbose_repr
 
-FAIL_AFTER_VALUE = local()
-FAIL_AFTER_VALUE.v = 0
+ERROR_CONFIG = local()
+ERROR_CONFIG.fail_after_value = 0
 
 
 class Location(Base):
@@ -143,7 +143,7 @@ class BaseError(Exception, Base):
         entries: Union[List[Tuple[str, Subsystem, Severity, Optional[Location]]], "BaseError"],
     ) -> None:
         # pylint: disable = global-statement
-        global FAIL_AFTER_VALUE
+        global ERROR_CONFIG
         if isinstance(entries, BaseError):
             self.__errors.extend(entries.errors)
         else:
@@ -152,7 +152,7 @@ class BaseError(Exception, Base):
         num_errors = len(
             list(e for e in self.__errors if e.severity in (Severity.WARNING, Severity.ERROR))
         )
-        if 0 < FAIL_AFTER_VALUE.v <= num_errors:
+        if 0 < ERROR_CONFIG.fail_after_value <= num_errors:
             raise self
 
     def check(self) -> bool:

--- a/rflx/identifier.py
+++ b/rflx/identifier.py
@@ -25,19 +25,23 @@ class ID:
 
         error = RecordFluxError()
         if not self._parts:
-            error.append("empty identifier", Subsystem.ID, Severity.ERROR, location)
+            error.extend([("empty identifier", Subsystem.ID, Severity.ERROR, location)])
         elif "" in self._parts:
-            error.append(
-                f'empty part in identifier "{self}"', Subsystem.ID, Severity.ERROR, location
+            error.extend(
+                [(f'empty part in identifier "{self}"', Subsystem.ID, Severity.ERROR, location)]
             )
         else:
             for c in [" ", ".", ":"]:
                 if any(c in part for part in self._parts):
-                    error.append(
-                        f'"{c}" in identifier parts of "{self}"',
-                        Subsystem.ID,
-                        Severity.ERROR,
-                        location,
+                    error.extend(
+                        [
+                            (
+                                f'"{c}" in identifier parts of "{self}"',
+                                Subsystem.ID,
+                                Severity.ERROR,
+                                location,
+                            )
+                        ],
                     )
         error.propagate()
 

--- a/rflx/model/model.py
+++ b/rflx/model/model.py
@@ -55,39 +55,48 @@ class Model(Base):
 
         for t in self.__types:
             if t.identifier in types:
-                error.append(
-                    f'conflicting refinement of "{t.pdu.identifier}" with "{t.sdu.identifier}"'
-                    if isinstance(t, message.Refinement)
-                    else f'name conflict for type "{t.identifier}"',
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    t.location,
-                )
-                error.append(
-                    "previous occurrence of refinement"
-                    if isinstance(t, message.Refinement)
-                    else f'previous occurrence of "{t.identifier}"',
-                    Subsystem.MODEL,
-                    Severity.INFO,
-                    types[t.identifier].location,
+                error.extend(
+                    [
+                        (
+                            f'conflicting refinement of "{t.pdu.identifier}" with'
+                            f' "{t.sdu.identifier}"'
+                            if isinstance(t, message.Refinement)
+                            else f'name conflict for type "{t.identifier}"',
+                            Subsystem.MODEL,
+                            Severity.ERROR,
+                            t.location,
+                        ),
+                        (
+                            "previous occurrence of refinement"
+                            if isinstance(t, message.Refinement)
+                            else f'previous occurrence of "{t.identifier}"',
+                            Subsystem.MODEL,
+                            Severity.INFO,
+                            types[t.identifier].location,
+                        ),
+                    ],
                 )
             types[t.identifier] = t
 
         for s in self.__sessions:
             if s.identifier in types or s.identifier in sessions:
-                error.append(
-                    f'name conflict for session "{s.identifier}"',
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    s.location,
-                )
-                error.append(
-                    f'previous occurrence of "{s.identifier}"',
-                    Subsystem.MODEL,
-                    Severity.INFO,
-                    types[s.identifier].location
-                    if s.identifier in types
-                    else sessions[s.identifier].location,
+                error.extend(
+                    [
+                        (
+                            f'name conflict for session "{s.identifier}"',
+                            Subsystem.MODEL,
+                            Severity.ERROR,
+                            s.location,
+                        ),
+                        (
+                            f'previous occurrence of "{s.identifier}"',
+                            Subsystem.MODEL,
+                            Severity.INFO,
+                            types[s.identifier].location
+                            if s.identifier in types
+                            else sessions[s.identifier].location,
+                        ),
+                    ],
                 )
             sessions[s.identifier] = s
 
@@ -115,22 +124,24 @@ class Model(Base):
 
             if identical_literals:
                 literals_message = ", ".join([f"{l}" for l in sorted(identical_literals)])
-                error.append(
-                    f"conflicting literals: {literals_message}",
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    e2.location,
-                )
                 error.extend(
                     [
                         (
-                            f'previous occurrence of "{l}"',
+                            f"conflicting literals: {literals_message}",
                             Subsystem.MODEL,
-                            Severity.INFO,
-                            l.location,
-                        )
-                        for l in sorted(identical_literals)
-                    ]
+                            Severity.ERROR,
+                            e2.location,
+                        ),
+                        *[
+                            (
+                                f'previous occurrence of "{l}"',
+                                Subsystem.MODEL,
+                                Severity.INFO,
+                                l.location,
+                            )
+                            for l in sorted(identical_literals)
+                        ],
+                    ],
                 )
 
         literals = [
@@ -147,17 +158,21 @@ class Model(Base):
             and l.name == t.identifier.name
         ]
         for literal, conflicting_type in name_conflicts:
-            error.append(
-                f'literal "{literal.name}" conflicts with type declaration',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                literal.location,
-            )
-            error.append(
-                f'conflicting type "{conflicting_type.identifier}"',
-                Subsystem.MODEL,
-                Severity.INFO,
-                conflicting_type.location,
+            error.extend(
+                [
+                    (
+                        f'literal "{literal.name}" conflicts with type declaration',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        literal.location,
+                    ),
+                    (
+                        f'conflicting type "{conflicting_type.identifier}"',
+                        Subsystem.MODEL,
+                        Severity.INFO,
+                        conflicting_type.location,
+                    ),
+                ],
             )
 
         return error

--- a/rflx/model/type_.py
+++ b/rflx/model/type_.py
@@ -19,11 +19,15 @@ class Type(Base):
         self.error = error or RecordFluxError()
 
         if len(identifier.parts) != 2:
-            self.error.append(
-                f'invalid format of type identifier "{identifier}"',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                location,
+            self.error.extend(
+                [
+                    (
+                        f'invalid format of type identifier "{identifier}"',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        location,
+                    )
+                ],
             )
 
         self.identifier = identifier
@@ -111,29 +115,41 @@ class ModularInteger(Integer):
         modulus_num = modulus.simplified()
 
         if not isinstance(modulus_num, expr.Number):
-            self.error.append(
-                f'modulus of "{self.name}" contains variable',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'modulus of "{self.name}" contains variable',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
             return
 
         modulus_int = int(modulus_num)
 
         if modulus_int > 2 ** 64:
-            self.error.append(
-                f'modulus of "{self.name}" exceeds limit (2**64)',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                modulus.location,
+            self.error.extend(
+                [
+                    (
+                        f'modulus of "{self.name}" exceeds limit (2**64)',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        modulus.location,
+                    )
+                ],
             )
         if modulus_int == 0 or (modulus_int & (modulus_int - 1)) != 0:
-            self.error.append(
-                f'modulus of "{self.name}" not power of two',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'modulus of "{self.name}" not power of two',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
 
         self.__modulus = modulus
@@ -187,35 +203,51 @@ class RangeInteger(Integer):
         size_num = size.simplified()
 
         if not isinstance(first_num, expr.Number):
-            self.error.append(
-                f'first of "{self.name}" contains variable',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'first of "{self.name}" contains variable',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
 
         if not isinstance(last_num, expr.Number):
-            self.error.append(
-                f'last of "{self.name}" contains variable',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'last of "{self.name}" contains variable',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
             return
         if int(last_num) >= 2 ** 63:
-            self.error.append(
-                f'last of "{self.name}" exceeds limit (2**63 - 1)',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'last of "{self.name}" exceeds limit (2**63 - 1)',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
 
         if not isinstance(size_num, expr.Number):
-            self.error.append(
-                f'size of "{self.name}" contains variable',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'size of "{self.name}" contains variable',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
 
         if self.error.check():
@@ -226,33 +258,49 @@ class RangeInteger(Integer):
         assert isinstance(size_num, expr.Number)
 
         if first_num < expr.Number(0):
-            self.error.append(
-                f'first of "{self.name}" negative',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'first of "{self.name}" negative',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
         if first_num > last_num:
-            self.error.append(
-                f'range of "{self.name}" negative',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'range of "{self.name}" negative',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
 
         if int(last_num).bit_length() > int(size_num):
-            self.error.append(
-                f'size of "{self.name}" too small',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'size of "{self.name}" too small',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
         if int(size_num) > 64:
-            self.error.append(
-                f'size of "{self.name}" exceeds limit (2**64)',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'size of "{self.name}" exceeds limit (2**64)',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
 
         self.__first_expr = first
@@ -329,27 +377,35 @@ class Enumeration(Scalar):
         for i1, e1 in enumerate(literals):
             for i2, e2 in enumerate(literals):
                 if i2 < i1 and e1[0] == e2[0]:
-                    self.error.append(
-                        f'duplicate literal "{e1[0]}"',
-                        Subsystem.MODEL,
-                        Severity.ERROR,
-                        e1[0].location if isinstance(e1[0], ID) else self.location,
-                    )
-                    self.error.append(
-                        "previous occurrence",
-                        Subsystem.MODEL,
-                        Severity.INFO,
-                        e2[0].location if isinstance(e2[0], ID) else self.location,
+                    self.error.extend(
+                        [
+                            (
+                                f'duplicate literal "{e1[0]}"',
+                                Subsystem.MODEL,
+                                Severity.ERROR,
+                                e1[0].location if isinstance(e1[0], ID) else self.location,
+                            ),
+                            (
+                                "previous occurrence",
+                                Subsystem.MODEL,
+                                Severity.INFO,
+                                e2[0].location if isinstance(e2[0], ID) else self.location,
+                            ),
+                        ],
                     )
 
         self.literals = {}
         for k, v in literals:
             if " " in str(k) or "." in str(k):
-                self.error.append(
-                    f'invalid literal name "{k}" in "{self.name}"',
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    self.location,
+                self.error.extend(
+                    [
+                        (
+                            f'invalid literal name "{k}" in "{self.name}"',
+                            Subsystem.MODEL,
+                            Severity.ERROR,
+                            self.location,
+                        )
+                    ],
                 )
                 continue
             self.literals[ID(k)] = v
@@ -357,11 +413,15 @@ class Enumeration(Scalar):
         size_num = size.simplified()
 
         if not isinstance(size_num, expr.Number):
-            self.error.append(
-                f'size of "{self.name}" contains variable',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'size of "{self.name}" contains variable',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
             return
 
@@ -369,46 +429,64 @@ class Enumeration(Scalar):
             min_literal_value = min(map(int, self.literals.values()))
             max_literal_value = max(map(int, self.literals.values()))
             if min_literal_value < 0 or max_literal_value > 2 ** 63 - 1:
-                self.error.append(
-                    f'enumeration value of "{self.name}"'
-                    " outside of permitted range (0 .. 2**63 - 1)",
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    self.location,
+                self.error.extend(
+                    [
+                        (
+                            f'enumeration value of "{self.name}"'
+                            " outside of permitted range (0 .. 2**63 - 1)",
+                            Subsystem.MODEL,
+                            Severity.ERROR,
+                            self.location,
+                        )
+                    ],
                 )
             if max_literal_value.bit_length() > int(size_num):
-                self.error.append(
-                    f'size of "{self.name}" too small',
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    self.location,
+                self.error.extend(
+                    [
+                        (
+                            f'size of "{self.name}" too small',
+                            Subsystem.MODEL,
+                            Severity.ERROR,
+                            self.location,
+                        )
+                    ],
                 )
         if int(size_num) > 64:
-            self.error.append(
-                f'size of "{self.name}" exceeds limit (2**64)',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'size of "{self.name}" exceeds limit (2**64)',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
         for i1, v1 in enumerate(self.literals.values()):
             for i2, v2 in enumerate(self.literals.values()):
                 if i1 < i2 and v1 == v2:
-                    self.error.append(
-                        f'duplicate enumeration value "{v1}" in "{self.name}"',
-                        Subsystem.MODEL,
-                        Severity.ERROR,
-                        v2.location,
-                    )
-                    self.error.append(
-                        "previous occurrence", Subsystem.MODEL, Severity.INFO, v1.location
+                    self.error.extend(
+                        [
+                            (
+                                f'duplicate enumeration value "{v1}" in "{self.name}"',
+                                Subsystem.MODEL,
+                                Severity.ERROR,
+                                v2.location,
+                            ),
+                            ("previous occurrence", Subsystem.MODEL, Severity.INFO, v1.location),
+                        ]
                     )
 
         if always_valid and len(self.literals) == 2 ** int(size_num):
-            self.error.append(
-                f'unnecessary always-valid aspect on "{self.name}"',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                self.location,
+            self.error.extend(
+                [
+                    (
+                        f'unnecessary always-valid aspect on "{self.name}"',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        self.location,
+                    )
+                ],
             )
 
         self.always_valid = always_valid
@@ -476,34 +554,42 @@ class Sequence(Composite):
         if not isinstance(element_type, Scalar) and not (
             isinstance(element_type, message.Message) and element_type.structure
         ):
-            self.error.append(
-                f'invalid element type of sequence "{self.name}"',
-                Subsystem.MODEL,
-                Severity.ERROR,
-                location,
-            )
-            self.error.append(
-                f'type "{element_type.name}" must be scalar or non-null message',
-                Subsystem.MODEL,
-                Severity.INFO,
-                element_type.location,
+            self.error.extend(
+                [
+                    (
+                        f'invalid element type of sequence "{self.name}"',
+                        Subsystem.MODEL,
+                        Severity.ERROR,
+                        location,
+                    ),
+                    (
+                        f'type "{element_type.name}" must be scalar or non-null message',
+                        Subsystem.MODEL,
+                        Severity.INFO,
+                        element_type.location,
+                    ),
+                ],
             )
 
         if isinstance(element_type, Scalar):
             element_type_size = element_type.size.simplified()
             if not isinstance(element_type_size, expr.Number) or int(element_type_size) % 8 != 0:
-                self.error.append(
-                    f'unsupported element type size of sequence "{self.name}"',
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    location,
-                )
-                self.error.append(
-                    f'type "{element_type.name}" has size {element_type_size},'
-                    r" must be multiple of 8",
-                    Subsystem.MODEL,
-                    Severity.INFO,
-                    element_type.location,
+                self.error.extend(
+                    [
+                        (
+                            f'unsupported element type size of sequence "{self.name}"',
+                            Subsystem.MODEL,
+                            Severity.ERROR,
+                            location,
+                        ),
+                        (
+                            f'type "{element_type.name}" has size {element_type_size},'
+                            r" must be multiple of 8",
+                            Subsystem.MODEL,
+                            Severity.INFO,
+                            element_type.location,
+                        ),
+                    ],
                 )
 
     def __repr__(self) -> str:

--- a/rflx/pyrflx/error.py
+++ b/rflx/pyrflx/error.py
@@ -4,4 +4,4 @@ from rflx.error import RecordFluxError, Severity, Subsystem
 class PyRFLXError(RecordFluxError):
     def __init__(self, message: str) -> None:
         super().__init__()
-        self.append(message, Subsystem.PYRFLX, Severity.ERROR)
+        self.extend([(message, Subsystem.PYRFLX, Severity.ERROR, None)])

--- a/rflx/statement.py
+++ b/rflx/statement.py
@@ -106,17 +106,21 @@ class Append(ListAttributeStatement):
             if isinstance(statement_type.element, rty.Message) and isinstance(
                 self.parameter, Variable
             ):
-                error.append(
-                    "appending independently created message not supported",
-                    Subsystem.MODEL,
-                    Severity.ERROR,
-                    self.parameter.location,
-                )
-                error.append(
-                    "message aggregate should be used instead",
-                    Subsystem.MODEL,
-                    Severity.INFO,
-                    self.parameter.location,
+                error.extend(
+                    [
+                        (
+                            "appending independently created message not supported",
+                            Subsystem.MODEL,
+                            Severity.ERROR,
+                            self.parameter.location,
+                        ),
+                        (
+                            "message aggregate should be used instead",
+                            Subsystem.MODEL,
+                            Severity.INFO,
+                            self.parameter.location,
+                        ),
+                    ],
                 )
         return error
 

--- a/rflx/typing_.py
+++ b/rflx/typing_.py
@@ -346,17 +346,11 @@ def check_type(
         desc = (
             " or ".join(map(str, expected_types)) if isinstance(expected, tuple) else str(expected)
         )
-        error.append(
-            f"expected {desc}",
-            Subsystem.MODEL,
-            Severity.ERROR,
-            location,
-        )
-        error.append(
-            f"found {actual}",
-            Subsystem.MODEL,
-            Severity.INFO,
-            location,
+        error.extend(
+            [
+                (f"expected {desc}", Subsystem.MODEL, Severity.ERROR, location),
+                (f"found {actual}", Subsystem.MODEL, Severity.INFO, location),
+            ],
         )
 
     return error
@@ -381,17 +375,11 @@ def check_type_instance(
             if isinstance(expected, tuple)
             else expected.DESCRIPTIVE_NAME
         )
-        error.append(
-            f"expected {desc}",
-            Subsystem.MODEL,
-            Severity.ERROR,
-            location,
-        )
-        error.append(
-            f"found {actual}",
-            Subsystem.MODEL,
-            Severity.INFO,
-            location,
+        error.extend(
+            [
+                (f"expected {desc}", Subsystem.MODEL, Severity.ERROR, location),
+                (f"found {actual}", Subsystem.MODEL, Severity.INFO, location),
+            ],
         )
 
     return error
@@ -399,10 +387,14 @@ def check_type_instance(
 
 def _undefined_type(location: ty.Optional[Location], description: str = "") -> RecordFluxError:
     error = RecordFluxError()
-    error.append(
-        "undefined" + (f" {description}" if description else ""),
-        Subsystem.MODEL,
-        Severity.ERROR,
-        location,
+    error.extend(
+        [
+            (
+                "undefined" + (f" {description}" if description else ""),
+                Subsystem.MODEL,
+                Severity.ERROR,
+                location,
+            )
+        ],
     )
     return error

--- a/tests/data/specs/multiple_errors.rflx
+++ b/tests/data/specs/multiple_errors.rflx
@@ -1,0 +1,12 @@
+package Multiple_Errors is
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+   type INVALID is mod 2**8;
+end Multiple_Errors;

--- a/tests/property/strategies.py
+++ b/tests/property/strategies.py
@@ -301,10 +301,15 @@ def messages(
     try:
         return message.proven()
     except error.RecordFluxError as e:
-        e.append(
-            f"incorrectly generated message:\n {message!r}",
-            error.Subsystem.MODEL,
-            error.Severity.INFO,
+        e.extend(
+            [
+                (
+                    f"incorrectly generated message:\n {message!r}",
+                    error.Subsystem.MODEL,
+                    error.Severity.INFO,
+                    None,
+                )
+            ],
         )
         raise e
 

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -160,3 +160,22 @@ def test_main_unexpected_exception(monkeypatch: Any, tmp_path: Path) -> None:
         str(cli.main(["rflx", "generate", "-d", str(tmp_path), SPEC_FILE])),
         re.DOTALL,
     )
+
+
+def test_fail_fast() -> None:
+    assert (
+        len(
+            str(
+                cli.main(
+                    [
+                        "rflx",
+                        "--max-errors",
+                        "5",
+                        "check",
+                        str(SPEC_DIR / "multiple_errors.rflx"),
+                    ]
+                )
+            ).split("\n")
+        )
+        == 10
+    )


### PR DESCRIPTION
A `--max-errors` switch now allows for limiting the number of errors printed before `rflx` exits. The `append` methods of the error class was removed and replaced by `extend` to avoid situations where RecordFlux exits due to an error before additional information was added to the error object (this still can happen when multiple `extend` calls are used, but it's less likely now).

~~Note that the global variable is not thread safe and thus unit tests changing the number of errors to report may influence other tests (resulting in truncated error messages and failed tests). Consequently, the new CLI test uses a large number of errors and a large `--max-errors` value (which exceed the maximum number of errors we test for in the other unit tests) such that other tests are not influenced.~~ EDIT: Change to thread-local storage.