### PR TITLE
Issue 738: Rename `then` keyword to `goto` in state transitions

### DIFF
--- a/doc/Language-Reference.adoc
+++ b/doc/Language-Reference.adoc
@@ -350,11 +350,11 @@ begin
    begin
       X'Read (M);
    transition
-      then B
+      goto B
          with Desc => "rfc1149.txt+45:4-47:8"
          if Z = True
             and G (F) = True
-      then A
+      goto A
    end A;
 
    state B is null state;
@@ -613,10 +613,10 @@ is
 begin
    X'Read (M);
 transition
-   then B
+   goto B
       with Desc => "rfc1149.txt+45:4-47:8"
       if Z = True and G (F) = True
-   then A
+   goto A
 end A
 ----
 [source,ada,rflx,state]
@@ -685,7 +685,7 @@ State transitions define the conditions for the change to subsequent states. An 
       *if* conditional_xref:syntax-expression[expression]
 
 [[syntax-transition]]transition ::=
-   *then* state_xref:syntax-name[name]
+   *goto* state_xref:syntax-name[name]
     [ *with* xref:syntax-description_aspect[description_aspect] ]
 ----
 
@@ -715,7 +715,7 @@ State transitions define the conditions for the change to subsequent states. An 
 
 [source,ada,rflx,conditional_transition]
 ----
-then B
+goto B
    with Desc => "rfc1149.txt+45:4-47:8"
    if Z = True and G (F) = True
 ----
@@ -1596,9 +1596,9 @@ package Ethernet is
       begin
          Input'Read (Frame);
       transition
-         then Forward
+         goto Forward
             if Frame'Valid
-         then Validate
+         goto Validate
       end Validate;
 
       state Forward
@@ -1606,9 +1606,9 @@ package Ethernet is
       begin
          Output'Write (Frame);
       transition
-         then Validate
+         goto Validate
       exception
-         then Error
+         goto Error
       end Forward;
 
       state Error is null state;

--- a/examples/apps/dhcp_client/specs/dhcp_client.rflx
+++ b/examples/apps/dhcp_client/specs/dhcp_client.rflx
@@ -69,9 +69,9 @@ package DHCP_Client is
          );
          Channel'Write (Discover);
       transition
-         then Receive_Offer
+         goto Receive_Offer
       exception
-         then Failure
+         goto Failure
       end Send_Discover;
 
       state Receive_Offer is
@@ -82,11 +82,11 @@ package DHCP_Client is
          Offer_Message_Types := [for O in Offer.Options if O'Valid and O.Code = DHCP::DHCP_Message_Type_Option => O.DHCP_Message_Type];
          Offer_Message_Type := Offer_Message_Types'Head;
       transition
-         then Send_Request
+         goto Send_Request
             if Offer'Valid = True and Offer.Op = DHCP::BOOTREPLY and Offer_Message_Type = DHCP::DHCPOFFER
-         then Receive_Offer
+         goto Receive_Offer
       exception
-         then Failure
+         goto Failure
       end Receive_Offer;
 
       state Send_Request is
@@ -130,9 +130,9 @@ package DHCP_Client is
          );
          Channel'Write (Request);
       transition
-         then Receive_Ack
+         goto Receive_Ack
       exception
-         then Failure
+         goto Failure
       end Send_Request;
 
       state Receive_Ack is
@@ -143,23 +143,23 @@ package DHCP_Client is
          Ack_Message_Types := [for O in Ack.Options if O'Valid and O.Code = DHCP::DHCP_Message_Type_Option => O.DHCP_Message_Type];
          Ack_Message_Type := Ack_Message_Types'Head;
       transition
-         then Success
+         goto Success
             if Ack'Valid = True and Ack.Op = DHCP::BOOTREPLY and Ack_Message_Type = DHCP::DHCPACK
-         then Failure
+         goto Failure
       exception
-         then Failure
+         goto Failure
       end Receive_Ack;
 
       state Success is
       begin
       transition
-         then Terminated
+         goto Terminated
       end Success;
 
       state Failure is
       begin
       transition
-         then Terminated
+         goto Terminated
       end Failure;
 
       state Terminated is null state;

--- a/rflx/model/session.py
+++ b/rflx/model/session.py
@@ -33,7 +33,7 @@ class Transition(Base):
         if_condition = (
             f"\n   if {indent_next(str(self.condition), 6)}" if self.condition != expr.TRUE else ""
         )
-        return f"then {self.target}{with_aspects}{if_condition}"
+        return f"goto {self.target}{with_aspects}{if_condition}"
 
 
 class State(Base):

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "pydotplus >=2, <3",
         "z3-solver >=4, <5",
         "RecordFlux-language@git+https://github.com/Componolit/RecordFlux-language.git"
-        "@v0.7.0#egg=RecordFlux-language",
+        "@v0.8.0#egg=RecordFlux-language",
     ],
     extras_require={
         "devel": [

--- a/tests/integration/parameterized_messages/test.rflx
+++ b/tests/integration/parameterized_messages/test.rflx
@@ -28,9 +28,9 @@ package Test is
          M'Reset (Length => 2, Extended => False);
          C'Read (M);
       transition
-         then Reply
+         goto Reply
             if M'Valid
-         then Terminated
+         goto Terminated
       end Receive;
 
       state Reply
@@ -38,16 +38,16 @@ package Test is
       begin
          C'Write (Message'(Length => M.Length, Extended => True, Data => M.Data, Extension => [3, 4]));
       transition
-         then Terminated
+         goto Terminated
       exception
-         then Error
+         goto Error
       end Reply;
 
       state Error
       is
       begin
-         transition
-            then Terminated
+      transition
+         goto Terminated
       end Error;
 
       state Terminated is null state;

--- a/tests/integration/session_append_unconstrained/test.rflx
+++ b/tests/integration/session_append_unconstrained/test.rflx
@@ -19,9 +19,9 @@ package Test is
          Message := Universal::Message'(Message_Type => Universal::MT_Unconstrained_Options, Options => Options);  --  §S-S-A-A-MA
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Start;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_binding/test.rflx
+++ b/tests/integration/session_binding/test.rflx
@@ -14,11 +14,11 @@ package Test is
       begin
          Channel'Read (Message);  --  §S-S-A-RD-V
       transition
-         then Reply
+         goto Reply
             if Message'Valid  --  §S-S-T-VAT, §S-E-AT-V-V
                and Message.Message_Type = Universal::MT_Data  --  §S-S-T-S, §S-E-S-V, §S-S-T-L
                and Message.Length = 1  --  §S-S-T-S, §S-E-S-V, §S-S-T-L
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       end Start;
 
       state Reply is
@@ -29,9 +29,9 @@ package Test is
                   Opaque = [2];  --  §S-S-A-A-B, §S-E-B-MA, §S-E-A-T-SC, §S-E-A-E-L
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_channels/test.rflx
+++ b/tests/integration/session_channels/test.rflx
@@ -13,9 +13,9 @@ package Test is
       state Start is
       begin
       transition
-         then Reply
+         goto Reply
             if Channel'Has_Data  --  §S-S-T-HDAT, §S-E-AT-HD-V
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       end Start;
 
       state Reply is
@@ -23,9 +23,9 @@ package Test is
          Channel'Read (Message);  --  §S-S-A-RD-V
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Start  --  §S-S-T-N
+         goto Start  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_comprehension_on_message_field/test.rflx
+++ b/tests/integration/session_comprehension_on_message_field/test.rflx
@@ -14,10 +14,10 @@ package Test is
       begin
          Channel'Read (Message);  --  §S-S-A-RD-V
       transition
-         then Reply
+         goto Reply
             if Message'Valid  --  §S-S-T-VAT, §S-E-AT-V-V
                and Message.Message_Type = Universal::MT_Options  --  §S-S-T-S, §S-E-S-V, §S-S-T-L
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       end Start;
 
       state Reply is
@@ -27,9 +27,9 @@ package Test is
          Message := Universal::Message'(Message_Type => Universal::MT_Option_Types, Length => Option_Types'Size / 8, Option_Types => Option_Types);  --  §S-S-A-A-MA
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_comprehension_on_sequence/test.rflx
+++ b/tests/integration/session_comprehension_on_sequence/test.rflx
@@ -16,9 +16,9 @@ package Test is
          Options'Append (Universal::Option'(Option_Type => Universal::OT_Null));  --  §S-S-A-AP-MA
          Options'Append (Universal::Option'(Option_Type => Universal::OT_Data, Length => 2, Data => [2, 3]));  --  §S-S-A-AP-MA, §S-E-A-T-SC, §S-E-A-E-L
       transition
-         then Reply  --  §S-S-T-N
+         goto Reply  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Start;
 
       state Reply is
@@ -29,9 +29,9 @@ package Test is
          Message := Universal::Message'(Message_Type => Universal::MT_Option_Types, Length => Option_Types'Size / 8, Option_Types => Option_Types);  --  §S-S-A-A-MA
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_conversion/test.rflx
+++ b/tests/integration/session_conversion/test.rflx
@@ -14,10 +14,10 @@ package Test is
       begin
          Channel'Read (Message);  --  §S-S-A-RD-V
       transition
-         then Reply
+         goto Reply
             if Message'Valid  --  §S-S-T-VAT, §S-E-AT-V-V
                and Message.Message_Type = Universal::MT_Data  --  §S-S-T-S, §S-E-S-V
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       end Start;
 
       state Reply is
@@ -26,9 +26,9 @@ package Test is
          Inner_Message := Universal::Option (Message.Data);  --  §S-S-A-A-CV, §S-E-CV-V, §S-E-S-V
          Channel'Write (Inner_Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_functions/test.rflx
+++ b/tests/integration/session_functions/test.rflx
@@ -17,11 +17,11 @@ package Test is
       begin
          Channel'Read (Message);  --  §S-S-A-RD-V
       transition
-         then Reply
+         goto Reply
             if Message'Valid  --  §S-S-T-VAT, §S-E-AT-V-V
                and Message.Message_Type = Universal::MT_Data  --  §S-S-T-S, §S-E-S-V, §S-S-T-L
                and Message.Length = 3  --  §S-S-T-S, §S-E-S-V, §S-S-T-L
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       end Start;
 
       state Reply is
@@ -32,9 +32,9 @@ package Test is
          Fixed_Size_Message := Create_Message (Message_Type, Message.Data);  --  §S-S-A-A-CL, §S-E-CL-V, §S-E-CL-S
          Channel'Write (Fixed_Size_Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_minimal/test.rflx
+++ b/tests/integration/session_minimal/test.rflx
@@ -14,18 +14,18 @@ package Test is
       begin
          Channel'Read (Message);  --  §S-S-A-RD-V
       transition
-         then Reply
+         goto Reply
             if Message'Valid  --  §S-S-T-VAT, §S-E-AT-V-V
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       end Start;
 
       state Reply is
       begin
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_reuse_of_message/test.rflx
+++ b/tests/integration/session_reuse_of_message/test.rflx
@@ -14,20 +14,20 @@ package Test is
       begin
          Channel'Read (Message);  --  §S-S-A-RD-V
       transition
-         then Reply
+         goto Reply
             if Message'Valid = True  --  §S-S-T-VAT, §S-E-AT-V-V, §S-S-T-L
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       end Start;
 
       state Reply is
       begin
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Start
+         goto Start
             if Channel'Has_Data  --  §S-S-T-HDAT
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_sequence_append_head/test.rflx
+++ b/tests/integration/session_sequence_append_head/test.rflx
@@ -22,12 +22,12 @@ package Test is
          Message_Tag := Message.Tag;  --  §S-S-A-A-S, §S-E-S-V
          Tag := Tags'Head;  --  §S-S-A-A-HAT, §S-E-AT-H-V, §S-E-AT-H-SS
       transition
-         then Reply
+         goto Reply
             if Message_Tag = TLV::Msg_Data  --  §S-S-T-V, §S-S-T-L
                and Tag = TLV::Msg_Error  --  §S-S-T-V, §S-S-T-L
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Start;
 
       state Reply is
@@ -36,9 +36,9 @@ package Test is
          Message := Messages'Head;  --  §S-S-A-A-HAT, §S-E-AT-H-V, §S-E-AT-H-MS
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_simple/test.rflx
+++ b/tests/integration/session_simple/test.rflx
@@ -14,11 +14,11 @@ package Test is
       begin
          Channel'Read (Message);  --  §S-S-A-RD-V
       transition
-         then Reply
+         goto Reply
             if Message'Valid = True  --  §S-S-T-VAT, §S-E-AT-V-V, §S-S-T-L
                and Message.Message_Type = Universal::MT_Data  --  §S-S-T-S, §S-E-S-V, §S-S-T-L
                and Message.Length = 1  --  §S-S-T-S, §S-E-S-V, §S-S-T-L
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       end Start;
 
       state Reply is
@@ -26,9 +26,9 @@ package Test is
          Message := Universal::Message'(Message_Type => Universal::MT_Data, Length => 1, Data => [2]);  --  §S-S-A-A-MA, §S-E-A-T-SC, §S-E-A-E-L
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/session_variable_initialization/test.rflx
+++ b/tests/integration/session_variable_initialization/test.rflx
@@ -18,11 +18,11 @@ package Test is
          Local := Local + Message.Value;  --  §S-S-A-A-ME, §S-S-A-A-L, §S-S-A-A-S, §S-S-A-A-V, §S-E-S-V
          Global := Local + 20;  --  §S-S-A-A-ME, §S-S-A-A-L, §S-S-A-A-V
       transition
-         then Reply
+         goto Reply
             if Local < Global  --  §S-S-T-V
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Start;
 
       state Reply is
@@ -31,9 +31,9 @@ package Test is
          Message := Universal::Message'(Message_Type => Universal::MT_Value, Length => Universal::Value'Size / 8, Value => Global);  --  §S-S-A-A-MA
          Channel'Write (Message);  --  §S-S-A-WR-V
       transition
-         then Terminated  --  §S-S-T-N
+         goto Terminated  --  §S-S-T-N
       exception
-         then Terminated  --  §S-S-E
+         goto Terminated  --  §S-S-E
       end Reply;
 
       state Terminated is null state;  --  §S-S-N

--- a/tests/integration/specification_model_generator_test.py
+++ b/tests/integration/specification_model_generator_test.py
@@ -496,9 +496,9 @@ def test_session_type_conversion_in_assignment(tmp_path: Path) -> None:
               begin
                  Transport'Read (Packet);
               transition
-                 then Send
+                 goto Send
                     if Packet'Valid
-                 then Error
+                 goto Error
               end Receive;
 
               state Send
@@ -509,9 +509,9 @@ def test_session_type_conversion_in_assignment(tmp_path: Path) -> None:
                  Transport'Write (Packet'(Length => Send_Size,
                                           Payload => Packet'Opaque));
               transition
-                 then Receive
+                 goto Receive
               exception
-                 then Error
+                 goto Error
               end Send;
 
               state Error is null state;
@@ -559,9 +559,9 @@ def test_session_move_content_of_opaque_field(tmp_path: Path) -> None:
                 Outgoing := M2'(Size => Incoming'Size, Payload => Incoming.Payload);
                 Output'Write(Outgoing);
               transition
-                 then Last
+                 goto Last
               exception
-                 then Last
+                 goto Last
               end First;
 
               state Last is null state;

--- a/tests/unit/model/session_test.py
+++ b/tests/unit/model/session_test.py
@@ -88,11 +88,11 @@ def test_str() -> None:
                   begin
                      X'Read (M);
                   transition
-                     then B
+                     goto B
                         with Desc => "rfc1149.txt+45:4-47:8"
                         if Z = True
                            and G (F) = True
-                     then A
+                     goto A
                   end A;
 
                   state B is null state;

--- a/tests/unit/specification/grammar_test.py
+++ b/tests/unit/specification/grammar_test.py
@@ -658,7 +658,7 @@ def test_attribute_statement(string: str, expected: stmt.Statement) -> None:
                state A is
                begin
                transition
-                  then B
+                  goto B
                end A
          """,
             model.State("A", transitions=[model.Transition("B")]),
@@ -668,9 +668,9 @@ def test_attribute_statement(string: str, expected: stmt.Statement) -> None:
                state A is
                begin
                transition
-                  then B
+                  goto B
                      if X = Y
-                  then C
+                  goto C
                end A
          """,
             model.State(
@@ -686,10 +686,10 @@ def test_attribute_statement(string: str, expected: stmt.Statement) -> None:
                state A is
                begin
                transition
-                  then B
+                  goto B
                      with Desc => "rfc2549.txt+12:3-45:6"
                      if X = Y
-                  then C
+                  goto C
                      with Desc => "rfc2549.txt+123:45-678:9"
                end A
          """,
@@ -711,7 +711,7 @@ def test_attribute_statement(string: str, expected: stmt.Statement) -> None:
                   Z : Boolean := Y;
                begin
                transition
-                  then B
+                  goto B
                end A
          """,
             model.State(
@@ -728,9 +728,9 @@ def test_attribute_statement(string: str, expected: stmt.Statement) -> None:
                state A is
                begin
                transition
-                  then B
+                  goto B
                exception
-                  then C
+                  goto C
                end A
          """,
             model.State(
@@ -746,9 +746,9 @@ def test_attribute_statement(string: str, expected: stmt.Statement) -> None:
                state A is
                begin
                transition
-                  then B
+                  goto B
                exception
-                  then C
+                  goto C
                      with Desc => "rfc2549.txt+12:3-45:6"
                end A
          """,
@@ -777,7 +777,7 @@ def test_state(string: str, expected: decl.Declaration) -> None:
                state A is
                begin
                transition
-                  then B
+                  goto B
                end C
          """,
             "<stdin>:2:16: parser: error: inconsistent state identifier: A /= C.*",
@@ -810,9 +810,9 @@ def test_state_error(string: str, error: str) -> None:
                   begin
                      Z := False;
                   transition
-                     then B
+                     goto B
                         if Z = False
-                     then A
+                     goto A
                   end A;
 
                   state B is null state;
@@ -898,13 +898,13 @@ def test_session() -> None:
                   state A is
                   begin
                   transition
-                     then B
+                     goto B
                   end A;
 
                   state B is
                   begin
                   transition
-                     then C
+                     goto C
                   end B;
 
                   state C is null state;

--- a/tests/unit/specification/parser_test.py
+++ b/tests/unit/specification/parser_test.py
@@ -2181,9 +2181,9 @@ def test_create_model_session_locations() -> None:
                   begin
                      Z := False;
                   transition
-                     then B
+                     goto B
                         if Z = False
-                     then A
+                     goto A
                   end A;
 
                   state B is null state;
@@ -2790,8 +2790,8 @@ def test_parse_reserved_word_as_channel_name() -> None:
                  Avail : Boolean := Channel'Has_Data;
               begin
               transition
-                 then A if Avail
-                 then B
+                 goto A if Avail
+                 goto B
               end A;
 
               state B is null state;


### PR DESCRIPTION
Closes #738