### PR TITLE
Issue 713: Add commandline option for location of rfi files

### DIFF
--- a/rflx/cli.py
+++ b/rflx/cli.py
@@ -6,7 +6,7 @@ import traceback
 from collections import defaultdict
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import librflxlang
 from pkg_resources import get_distribution
@@ -84,6 +84,9 @@ def main(argv: List[str]) -> Union[int, str]:
         "--ignore-unsupported-checksum",
         help="ignore checksum aspects during code generation",
         action="store_true",
+    )
+    parser_generate.add_argument(
+        "--integration-files-dir", help="directory for the .rfi files", type=Path
     )
     parser_generate.add_argument(
         "files", metavar="SPECIFICATION_FILE", type=Path, nargs="*", help="specification file"
@@ -249,7 +252,9 @@ def generate(args: argparse.Namespace) -> None:
     if not args.output_directory.is_dir():
         fail(f'directory not found: "{args.output_directory}"', Subsystem.CLI)
 
-    model, integration = parse(args.files, args.no_verification, args.workers)
+    model, integration = parse(
+        args.files, args.no_verification, args.workers, args.integration_files_dir
+    )
 
     generator = Generator(
         model,
@@ -267,9 +272,14 @@ def generate(args: argparse.Namespace) -> None:
 
 
 def parse(
-    files: Sequence[Path], skip_verification: bool = False, workers: int = 1
+    files: Sequence[Path],
+    skip_verification: bool = False,
+    workers: int = 1,
+    integration_files_dir: Optional[Path] = None,
 ) -> Tuple[Model, Integration]:
-    parser = Parser(skip_verification, cached=True, workers=workers)
+    parser = Parser(
+        skip_verification, cached=True, workers=workers, integration_files_dir=integration_files_dir
+    )
     error = RecordFluxError()
     present_files = []
 

--- a/rflx/integration.py
+++ b/rflx/integration.py
@@ -87,14 +87,6 @@ class Integration:
                 self._validate_globals(package, integration, session, error)
                 self._validate_states(package, integration, session, error)
 
-    def _add_integration_object(self, filename: Path, file: object, error: RecordFluxError) -> None:
-        try:
-            self._packages[filename.stem] = IntegrationFile.parse_obj(file)
-        except ValidationError as e:
-            error.extend(
-                [(f"{e}", Subsystem.PARSER, Severity.ERROR, self._to_location(filename.stem))]
-            )
-
     def get_size(self, session: ID, variable: ID, state: Optional[ID]) -> int:
         """
         Return the requested buffer size for a variable of a given session and state.
@@ -128,6 +120,14 @@ class Integration:
         ):
             return buffer_size.local_[state_name][variable_name]
         return default_size
+
+    def _add_integration_object(self, filename: Path, file: object, error: RecordFluxError) -> None:
+        try:
+            self._packages[filename.stem] = IntegrationFile.parse_obj(file)
+        except ValidationError as e:
+            error.extend(
+                [(f"{e}", Subsystem.PARSER, Severity.ERROR, self._to_location(filename.stem))]
+            )
 
     @staticmethod
     def _to_location(package: str) -> Location:

--- a/tests/unit/integration_test.py
+++ b/tests/unit/integration_test.py
@@ -172,8 +172,16 @@ def test_load_integration_path(tmp_path: Path) -> None:
     subfolder = tmp_path / "sub"
     subfolder.mkdir()
     test_rfi = subfolder / "test.rfi"
-    test_rfi.write_text("{ Session: { Session : { Buffer_Size : {} }}}")
+    test_rfi.write_text("{ Session: { Session : { Buffer_Size : 0 }}}")
     integration = Integration(integration_files_dir=subfolder)
     error = RecordFluxError()
-    integration.load_integration_file(tmp_path / "test.rflx", error)
-    error.propagate()
+    regex = re.compile(
+        (
+            r"test.rfi:0:0: parser: error: 1 validation error for IntegrationFile.*"
+            r"value is not a valid dict \(type=type_error.dict\)"
+        ),
+        re.DOTALL,
+    )
+    with pytest.raises(RecordFluxError, match=regex):
+        integration.load_integration_file(tmp_path / "test.rflx", error)
+        error.propagate()

--- a/tests/unit/specification/parser_test.py
+++ b/tests/unit/specification/parser_test.py
@@ -1,6 +1,5 @@
 # pylint: disable=too-many-lines
 
-import re
 from itertools import zip_longest
 from pathlib import Path
 from typing import Any, Dict, Sequence
@@ -2803,35 +2802,3 @@ def test_parse_reserved_word_as_channel_name() -> None:
         end Test;
         """
     )
-
-
-@pytest.mark.parametrize(
-    "content, error_msg, line, column",
-    [
-        ('"', ["while scanning a quoted scalar", "unexpected end of stream"], 1, 2),
-        ("Session: 1, Session : 1", ["mapping values are not allowed here"], 1, 21),
-        (
-            "Session: 1\nSession : 1",
-            ["while constructing a mapping", 'found duplicate key "Session" with value "1"'],
-            2,
-            1,
-        ),
-    ],
-)
-def test_load_integration_file(
-    tmp_path: Path, content: str, error_msg: Sequence[str], line: int, column: int
-) -> None:
-    test_rfi = tmp_path / "test.rfi"
-    test_rfi.write_text(content)
-    p = parser.Parser()
-    error = RecordFluxError()
-    regex = fr"^{test_rfi}:{line}:{column}: parser: error: "
-    for elt in error_msg:
-        regex += elt
-        regex += fr'.*in "{test_rfi}", line [0-9]+, column [0-9]+.*'
-    regex += "$"
-    compiled_regex = re.compile(regex, re.DOTALL)
-    with pytest.raises(RecordFluxError, match=compiled_regex):
-        # pylint: disable = protected-access
-        p._load_integration_file(test_rfi, error)
-        error.propagate()


### PR DESCRIPTION
- command line option for rfi files
- new argument of Parser and Integration for rfi files location
- move all rfi file handling to Integration class
- move testing accordingly
- new test for different location of rfi file

For #713