### PR TITLE
Simplify proof of Insert function

### DIFF
--- a/rflx/templates/rflx_generic_types.adb
+++ b/rflx/templates/rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/messages/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/messages/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/messages_with_implict_size/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/messages_with_implict_size/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/parameterized_messages/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/parameterized_messages/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_append_unconstrained/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_append_unconstrained/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_binding/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_binding/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_channel_multiplexing/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_channel_multiplexing/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_channels/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_channels/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_comprehension_on_message_field/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_comprehension_on_message_field/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_comprehension_on_sequence/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_comprehension_on_sequence/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_conversion/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_conversion/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_endianness/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_endianness/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_functions/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_functions/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_integration/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_integration/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_integration_multiple/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_integration_multiple/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_minimal/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_minimal/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_reuse_of_message/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_reuse_of_message/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_sequence_append_head/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_sequence_append_head/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_simple/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_simple/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/integration/session_variable_initialization/generated/rflx-rflx_generic_types.adb
+++ b/tests/integration/session_variable_initialization/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).

--- a/tests/spark/generated/rflx-rflx_generic_types.adb
+++ b/tests/spark/generated/rflx-rflx_generic_types.adb
@@ -223,7 +223,6 @@ is
 
       LME_Size   : constant Natural := (RME_Offset + Value_Size + Byte'Size - 1) mod Byte'Size + 1;
 
-      Bits : Natural;
       RV : U64;
    begin
 
@@ -261,17 +260,14 @@ is
 
          pragma Assert (RME_Size < Value_Size);
          pragma Assert (Fits_Into (RV, Value_Size - RME_Size));
-         Bits := Value_Size - RME_Size;
 
          --  The inner bytes are fully overwritten.
 
          for I in reverse LME_Index + 1 .. RME_Index - 1
          loop
             Data (I) := Byte'Val (RV mod 2**Byte'Size);
-            RV := Right_Shift (RV, Byte'Size, Bits);
-            Bits := Bits - Byte'Size;
-            pragma Loop_Invariant (Bits =  Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size
-                                   and then Fits_Into (RV, Bits));
+            RV := Right_Shift (RV, Byte'Size, Value_Size - RME_Size - Natural (RME_Index - I - 1) * Byte'Size);
+            pragma Loop_Invariant (Fits_Into (RV, Value_Size - RME_Size - Natural (RME_Index - I) * Byte'Size));
          end loop;
 
          --  The last byte (LME in network byte order).


### PR DESCRIPTION
- Remove unneeded Bits variable.
- This should prove with both SPARK Pro 23.0w and SPARK Community
  2021.