### PR TITLE
Use quantifiers for successors/predecessors

### DIFF
--- a/rflx/ada.py
+++ b/rflx/ada.py
@@ -811,13 +811,17 @@ class ForSomeIn(QuantifiedExpr):
 
 
 class ValueRange(Expr):
-    def __init__(self, lower: Expr, upper: Expr):
+    def __init__(self, lower: Expr, upper: Expr, type_identifier: StrID = None):
         super().__init__()
         self.lower = lower
         self.upper = upper
+        self.type_id = type_identifier
 
     def _update_str(self) -> None:
-        self._str = intern(f"{self.lower} .. {self.upper}")
+        if self.type_id is None:
+            self._str = intern(f"{self.lower} .. {self.upper}")
+        else:
+            self._str = intern(f"{self.type_id} range {self.lower} .. {self.upper}")
 
     @property
     def precedence(self) -> Precedence:

--- a/rflx/generator/serializer.py
+++ b/rflx/generator/serializer.py
@@ -625,27 +625,7 @@ class SerializerGenerator:
                                     else []
                                 ),
                                 *self.public_setter_postconditions(message, f),
-                                *[
-                                    Equal(
-                                        Call(
-                                            "Context_Cursor",
-                                            [
-                                                Variable("Ctx"),
-                                                Variable(p.affixed_name),
-                                            ],
-                                        ),
-                                        Old(
-                                            Call(
-                                                "Context_Cursor",
-                                                [
-                                                    Variable("Ctx"),
-                                                    Variable(p.affixed_name),
-                                                ],
-                                            )
-                                        ),
-                                    )
-                                    for p in message.predecessors(f)
-                                ],
+                                *common.context_cursor_unchanged(message, f, predecessors=True),
                             )
                         ),
                     ],

--- a/tests/integration/messages/generated/rflx-universal-message.ads
+++ b/tests/integration/messages/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/messages/generated/rflx-universal-option.ads
+++ b/tests/integration/messages/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/messages_with_implict_size/generated/rflx-universal-message.ads
+++ b/tests/integration/messages_with_implict_size/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/messages_with_implict_size/generated/rflx-universal-option.ads
+++ b/tests/integration/messages_with_implict_size/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/parameterized_messages/generated/rflx-test-message.ads
+++ b/tests/integration/parameterized_messages/generated/rflx-test-message.ads
@@ -31,6 +31,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Data, F_Extension, F_Final);
 
    subtype Field is Virtual_Field range F_Data .. F_Extension;
@@ -616,6 +618,11 @@ is
        (GNATprove, Inline_For_Proof),
      Ghost;
 
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
 private
 
    type Cursor_State is (S_Valid, S_Structural_Valid, S_Invalid, S_Incomplete);
@@ -855,5 +862,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Test.Message;

--- a/tests/integration/session_append_unconstrained/generated/rflx-universal-message.ads
+++ b/tests/integration/session_append_unconstrained/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_append_unconstrained/generated/rflx-universal-option.ads
+++ b/tests/integration/session_append_unconstrained/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_binding/generated/rflx-universal-message.ads
+++ b/tests/integration/session_binding/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_binding/generated/rflx-universal-option.ads
+++ b/tests/integration/session_binding/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_channel_multiplexing/generated/rflx-universal-message.ads
+++ b/tests/integration/session_channel_multiplexing/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_channel_multiplexing/generated/rflx-universal-option.ads
+++ b/tests/integration/session_channel_multiplexing/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_channels/generated/rflx-universal-message.ads
+++ b/tests/integration/session_channels/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_channels/generated/rflx-universal-option.ads
+++ b/tests/integration/session_channels/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_comprehension_on_message_field/generated/rflx-universal-message.ads
+++ b/tests/integration/session_comprehension_on_message_field/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_comprehension_on_message_field/generated/rflx-universal-option.ads
+++ b/tests/integration/session_comprehension_on_message_field/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_comprehension_on_sequence/generated/rflx-universal-message.ads
+++ b/tests/integration/session_comprehension_on_sequence/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_comprehension_on_sequence/generated/rflx-universal-option.ads
+++ b/tests/integration/session_comprehension_on_sequence/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_conversion/generated/rflx-universal-message.ads
+++ b/tests/integration/session_conversion/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_conversion/generated/rflx-universal-option.ads
+++ b/tests/integration/session_conversion/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_endianness/generated/rflx-messages-msg.ads
+++ b/tests/integration/session_endianness/generated/rflx-messages-msg.ads
@@ -28,6 +28,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_A, F_B, F_Final);
 
    subtype Field is Virtual_Field range F_A .. F_B;
@@ -418,7 +420,8 @@ is
        and Predecessor (Ctx, F_B) = Predecessor (Ctx, F_B)'Old
        and Valid_Next (Ctx, F_B) = Valid_Next (Ctx, F_B)'Old
        and Get_A (Ctx) = Get_A (Ctx)'Old
-       and Context_Cursor (Ctx, F_A) = Context_Cursor (Ctx, F_A)'Old;
+       and (for all F in Field range F_A .. F_A =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    function Context_Cursor (Ctx : Context; Fld : Field) return Field_Cursor with
      Annotate =>
@@ -426,6 +429,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -683,5 +691,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Messages.Msg;

--- a/tests/integration/session_endianness/generated/rflx-messages-msg_le.ads
+++ b/tests/integration/session_endianness/generated/rflx-messages-msg_le.ads
@@ -28,6 +28,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_C, F_D, F_Final);
 
    subtype Field is Virtual_Field range F_C .. F_D;
@@ -418,7 +420,8 @@ is
        and Predecessor (Ctx, F_D) = Predecessor (Ctx, F_D)'Old
        and Valid_Next (Ctx, F_D) = Valid_Next (Ctx, F_D)'Old
        and Get_C (Ctx) = Get_C (Ctx)'Old
-       and Context_Cursor (Ctx, F_C) = Context_Cursor (Ctx, F_C)'Old;
+       and (for all F in Field range F_C .. F_C =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    function Context_Cursor (Ctx : Context; Fld : Field) return Field_Cursor with
      Annotate =>
@@ -426,6 +429,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -683,5 +691,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Messages.Msg_LE;

--- a/tests/integration/session_functions/generated/rflx-fixed_size-simple_message.ads
+++ b/tests/integration/session_functions/generated/rflx-fixed_size-simple_message.ads
@@ -32,6 +32,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Data;
@@ -517,6 +519,11 @@ is
        (GNATprove, Inline_For_Proof),
      Ghost;
 
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
    type Structure is
       record
          Message_Type : RFLX.Universal.Option_Type;
@@ -767,5 +774,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Fixed_Size.Simple_Message;

--- a/tests/integration/session_functions/generated/rflx-universal-message.ads
+++ b/tests/integration/session_functions/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_functions/generated/rflx-universal-option.ads
+++ b/tests/integration/session_functions/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_integration/generated/rflx-universal-message.ads
+++ b/tests/integration/session_integration/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_integration/generated/rflx-universal-option.ads
+++ b/tests/integration/session_integration/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_integration_multiple/generated/rflx-universal-message.ads
+++ b/tests/integration/session_integration_multiple/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_integration_multiple/generated/rflx-universal-option.ads
+++ b/tests/integration/session_integration_multiple/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_minimal/generated/rflx-universal-message.ads
+++ b/tests/integration/session_minimal/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_minimal/generated/rflx-universal-option.ads
+++ b/tests/integration/session_minimal/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_reuse_of_message/generated/rflx-universal-message.ads
+++ b/tests/integration/session_reuse_of_message/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_reuse_of_message/generated/rflx-universal-option.ads
+++ b/tests/integration/session_reuse_of_message/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_sequence_append_head/generated/rflx-tlv-message.ads
+++ b/tests/integration/session_sequence_append_head/generated/rflx-tlv-message.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Tag, F_Length, F_Value, F_Final);
 
    subtype Field is Virtual_Field range F_Tag .. F_Value;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old;
+       and (for all F in Field range F_Tag .. F_Tag =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.TLV.Message;

--- a/tests/integration/session_simple/generated/rflx-universal-message.ads
+++ b/tests/integration/session_simple/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_simple/generated/rflx-universal-option.ads
+++ b/tests/integration/session_simple/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/integration/session_variable_initialization/generated/rflx-universal-message.ads
+++ b/tests/integration/session_variable_initialization/generated/rflx-universal-message.ads
@@ -33,6 +33,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Length, F_Data, F_Option_Types, F_Options, F_Value, F_Values, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Values;
@@ -520,7 +522,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old;
+       and (for all F in Field range F_Message_Type .. F_Message_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value (Ctx : in out Context; Val : RFLX.Universal.Value) with
      Pre =>
@@ -544,11 +547,8 @@ is
        and Valid_Next (Ctx, F_Value) = Valid_Next (Ctx, F_Value)'Old
        and Get_Message_Type (Ctx) = Get_Message_Type (Ctx)'Old
        and Get_Length (Ctx) = Get_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old;
+       and (for all F in Field range F_Message_Type .. F_Options =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -922,14 +922,12 @@ is
        and Predecessor (Ctx, F_Option_Types) = Predecessor (Ctx, F_Option_Types)'Old
        and Path_Condition (Ctx, F_Option_Types) = Path_Condition (Ctx, F_Option_Types)'Old
        and Field_Last (Ctx, F_Option_Types) = Field_Last (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old,
+       and (for all F in Field range F_Message_Type .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Option_Types) =>
-           Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-           and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Options .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Options)
            and Invalid (Ctx, F_Value)
@@ -962,14 +960,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old,
+       and (for all F in Field range F_Message_Type .. F_Option_Types =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old
-           and Context_Cursor (Ctx, F_Values) = Context_Cursor (Ctx, F_Values)'Old,
+           (for all F in Field range F_Value .. F_Values =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            Invalid (Ctx, F_Value)
            and Invalid (Ctx, F_Values));
@@ -1001,12 +997,8 @@ is
        and Predecessor (Ctx, F_Values) = Predecessor (Ctx, F_Values)'Old
        and Path_Condition (Ctx, F_Values) = Path_Condition (Ctx, F_Values)'Old
        and Field_Last (Ctx, F_Values) = Field_Last (Ctx, F_Values)'Old
-       and Context_Cursor (Ctx, F_Message_Type) = Context_Cursor (Ctx, F_Message_Type)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Option_Types) = Context_Cursor (Ctx, F_Option_Types)'Old
-       and Context_Cursor (Ctx, F_Options) = Context_Cursor (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Value) = Context_Cursor (Ctx, F_Value)'Old,
+       and (for all F in Field range F_Message_Type .. F_Value =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Values) =>
            True,
@@ -1124,6 +1116,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1615,5 +1612,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Message;

--- a/tests/integration/session_variable_initialization/generated/rflx-universal-option.ads
+++ b/tests/integration/session_variable_initialization/generated/rflx-universal-option.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Option_Type, F_Length, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Option_Type .. F_Data;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Option_Type (Ctx) = Get_Option_Type (Ctx)'Old
-       and Context_Cursor (Ctx, F_Option_Type) = Context_Cursor (Ctx, F_Option_Type)'Old;
+       and (for all F in Field range F_Option_Type .. F_Option_Type =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Universal.Option;

--- a/tests/spark/generated/rflx-derivation-message.ads
+++ b/tests/spark/generated/rflx-derivation-message.ads
@@ -32,6 +32,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Tag, F_Length, F_Value, F_Final);
 
    subtype Field is Virtual_Field range F_Tag .. F_Value;
@@ -469,7 +471,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old;
+       and (for all F in Field range F_Tag .. F_Tag =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value_Empty (Ctx : in out Context) with
      Pre =>
@@ -575,6 +578,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -847,5 +855,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Derivation.Message;

--- a/tests/spark/generated/rflx-enumeration-message.ads
+++ b/tests/spark/generated/rflx-enumeration-message.ads
@@ -28,6 +28,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Priority, F_Final);
 
    subtype Field is Virtual_Field range F_Priority .. F_Priority;
@@ -400,6 +402,11 @@ is
        (GNATprove, Inline_For_Proof),
      Ghost;
 
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
    type Structure is
       record
          Priority : RFLX.Enumeration.Priority;
@@ -632,5 +639,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Enumeration.Message;

--- a/tests/spark/generated/rflx-ethernet-frame.ads
+++ b/tests/spark/generated/rflx-ethernet-frame.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Destination, F_Source, F_Type_Length_TPID, F_TPID, F_TCI, F_Type_Length, F_Payload, F_Final);
 
    subtype Field is Virtual_Field range F_Destination .. F_Payload;
@@ -495,7 +497,8 @@ is
        and Predecessor (Ctx, F_Source) = Predecessor (Ctx, F_Source)'Old
        and Valid_Next (Ctx, F_Source) = Valid_Next (Ctx, F_Source)'Old
        and Get_Destination (Ctx) = Get_Destination (Ctx)'Old
-       and Context_Cursor (Ctx, F_Destination) = Context_Cursor (Ctx, F_Destination)'Old;
+       and (for all F in Field range F_Destination .. F_Destination =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Type_Length_TPID (Ctx : in out Context; Val : RFLX.Ethernet.Type_Length) with
      Pre =>
@@ -531,8 +534,8 @@ is
        and Valid_Next (Ctx, F_Type_Length_TPID) = Valid_Next (Ctx, F_Type_Length_TPID)'Old
        and Get_Destination (Ctx) = Get_Destination (Ctx)'Old
        and Get_Source (Ctx) = Get_Source (Ctx)'Old
-       and Context_Cursor (Ctx, F_Destination) = Context_Cursor (Ctx, F_Destination)'Old
-       and Context_Cursor (Ctx, F_Source) = Context_Cursor (Ctx, F_Source)'Old;
+       and (for all F in Field range F_Destination .. F_Source =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_TPID (Ctx : in out Context; Val : RFLX.Ethernet.TPID) with
      Pre =>
@@ -559,9 +562,8 @@ is
        and Get_Destination (Ctx) = Get_Destination (Ctx)'Old
        and Get_Source (Ctx) = Get_Source (Ctx)'Old
        and Get_Type_Length_TPID (Ctx) = Get_Type_Length_TPID (Ctx)'Old
-       and Context_Cursor (Ctx, F_Destination) = Context_Cursor (Ctx, F_Destination)'Old
-       and Context_Cursor (Ctx, F_Source) = Context_Cursor (Ctx, F_Source)'Old
-       and Context_Cursor (Ctx, F_Type_Length_TPID) = Context_Cursor (Ctx, F_Type_Length_TPID)'Old;
+       and (for all F in Field range F_Destination .. F_Type_Length_TPID =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_TCI (Ctx : in out Context; Val : RFLX.Ethernet.TCI) with
      Pre =>
@@ -588,10 +590,8 @@ is
        and Get_Destination (Ctx) = Get_Destination (Ctx)'Old
        and Get_Source (Ctx) = Get_Source (Ctx)'Old
        and Get_Type_Length_TPID (Ctx) = Get_Type_Length_TPID (Ctx)'Old
-       and Context_Cursor (Ctx, F_Destination) = Context_Cursor (Ctx, F_Destination)'Old
-       and Context_Cursor (Ctx, F_Source) = Context_Cursor (Ctx, F_Source)'Old
-       and Context_Cursor (Ctx, F_Type_Length_TPID) = Context_Cursor (Ctx, F_Type_Length_TPID)'Old
-       and Context_Cursor (Ctx, F_TPID) = Context_Cursor (Ctx, F_TPID)'Old;
+       and (for all F in Field range F_Destination .. F_TPID =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Type_Length (Ctx : in out Context; Val : RFLX.Ethernet.Type_Length) with
      Pre =>
@@ -625,11 +625,8 @@ is
        and Get_Destination (Ctx) = Get_Destination (Ctx)'Old
        and Get_Source (Ctx) = Get_Source (Ctx)'Old
        and Get_Type_Length_TPID (Ctx) = Get_Type_Length_TPID (Ctx)'Old
-       and Context_Cursor (Ctx, F_Destination) = Context_Cursor (Ctx, F_Destination)'Old
-       and Context_Cursor (Ctx, F_Source) = Context_Cursor (Ctx, F_Source)'Old
-       and Context_Cursor (Ctx, F_Type_Length_TPID) = Context_Cursor (Ctx, F_Type_Length_TPID)'Old
-       and Context_Cursor (Ctx, F_TPID) = Context_Cursor (Ctx, F_TPID)'Old
-       and Context_Cursor (Ctx, F_TCI) = Context_Cursor (Ctx, F_TCI)'Old;
+       and (for all F in Field range F_Destination .. F_TCI =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Initialize_Payload (Ctx : in out Context; Length : RFLX_Types.Length) with
      Pre =>
@@ -719,6 +716,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1171,5 +1173,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Ethernet.Frame;

--- a/tests/spark/generated/rflx-expression-message.ads
+++ b/tests/spark/generated/rflx-expression-message.ads
@@ -28,6 +28,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Payload, F_Final);
 
    subtype Field is Virtual_Field range F_Payload .. F_Payload;
@@ -486,6 +488,11 @@ is
        (GNATprove, Inline_For_Proof),
      Ghost;
 
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
    type Structure is
       record
          Payload : RFLX_Types.Bytes (RFLX_Types.Index'First .. RFLX_Types.Index'First + 1);
@@ -721,5 +728,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Expression.Message;

--- a/tests/spark/generated/rflx-fixed_size-simple_message.ads
+++ b/tests/spark/generated/rflx-fixed_size-simple_message.ads
@@ -32,6 +32,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Message_Type, F_Data, F_Final);
 
    subtype Field is Virtual_Field range F_Message_Type .. F_Data;
@@ -517,6 +519,11 @@ is
        (GNATprove, Inline_For_Proof),
      Ghost;
 
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
    type Structure is
       record
          Message_Type : RFLX.Universal.Option_Type;
@@ -767,5 +774,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Fixed_Size.Simple_Message;

--- a/tests/spark/generated/rflx-icmp-message.ads
+++ b/tests/spark/generated/rflx-icmp-message.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Tag, F_Code_Destination_Unreachable, F_Code_Redirect, F_Code_Time_Exceeded, F_Code_Zero, F_Checksum, F_Gateway_Internet_Address, F_Identifier, F_Pointer, F_Unused_32, F_Sequence_Number, F_Unused_24, F_Originate_Timestamp, F_Data, F_Receive_Timestamp, F_Transmit_Timestamp, F_Final);
 
    subtype Field is Virtual_Field range F_Tag .. F_Transmit_Timestamp;
@@ -592,7 +594,8 @@ is
        and Predecessor (Ctx, F_Code_Destination_Unreachable) = Predecessor (Ctx, F_Code_Destination_Unreachable)'Old
        and Valid_Next (Ctx, F_Code_Destination_Unreachable) = Valid_Next (Ctx, F_Code_Destination_Unreachable)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old;
+       and (for all F in Field range F_Tag .. F_Tag =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Code_Redirect (Ctx : in out Context; Val : RFLX.ICMP.Code_Redirect) with
      Pre =>
@@ -628,8 +631,8 @@ is
        and Predecessor (Ctx, F_Code_Redirect) = Predecessor (Ctx, F_Code_Redirect)'Old
        and Valid_Next (Ctx, F_Code_Redirect) = Valid_Next (Ctx, F_Code_Redirect)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old;
+       and (for all F in Field range F_Tag .. F_Code_Destination_Unreachable =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Code_Time_Exceeded (Ctx : in out Context; Val : RFLX.ICMP.Code_Time_Exceeded) with
      Pre =>
@@ -664,9 +667,8 @@ is
        and Predecessor (Ctx, F_Code_Time_Exceeded) = Predecessor (Ctx, F_Code_Time_Exceeded)'Old
        and Valid_Next (Ctx, F_Code_Time_Exceeded) = Valid_Next (Ctx, F_Code_Time_Exceeded)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old;
+       and (for all F in Field range F_Tag .. F_Code_Redirect =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Code_Zero (Ctx : in out Context; Val : RFLX.ICMP.Code_Zero) with
      Pre =>
@@ -699,10 +701,8 @@ is
        and Predecessor (Ctx, F_Code_Zero) = Predecessor (Ctx, F_Code_Zero)'Old
        and Valid_Next (Ctx, F_Code_Zero) = Valid_Next (Ctx, F_Code_Zero)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old;
+       and (for all F in Field range F_Tag .. F_Code_Time_Exceeded =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Checksum (Ctx : in out Context; Val : RFLX.ICMP.Checksum) with
      Pre =>
@@ -760,11 +760,8 @@ is
        and Predecessor (Ctx, F_Checksum) = Predecessor (Ctx, F_Checksum)'Old
        and Valid_Next (Ctx, F_Checksum) = Valid_Next (Ctx, F_Checksum)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old;
+       and (for all F in Field range F_Tag .. F_Code_Zero =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Gateway_Internet_Address (Ctx : in out Context; Val : RFLX.ICMP.Gateway_Internet_Address) with
      Pre =>
@@ -797,12 +794,8 @@ is
        and Valid_Next (Ctx, F_Gateway_Internet_Address) = Valid_Next (Ctx, F_Gateway_Internet_Address)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
        and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old;
+       and (for all F in Field range F_Tag .. F_Checksum =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Identifier (Ctx : in out Context; Val : RFLX.ICMP.Identifier) with
      Pre =>
@@ -834,13 +827,8 @@ is
        and Valid_Next (Ctx, F_Identifier) = Valid_Next (Ctx, F_Identifier)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
        and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
-       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old;
+       and (for all F in Field range F_Tag .. F_Gateway_Internet_Address =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Pointer (Ctx : in out Context; Val : RFLX.ICMP.Pointer) with
      Pre =>
@@ -871,14 +859,8 @@ is
        and Valid_Next (Ctx, F_Pointer) = Valid_Next (Ctx, F_Pointer)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
        and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
-       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
-       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old;
+       and (for all F in Field range F_Tag .. F_Identifier =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Unused_32 (Ctx : in out Context; Val : RFLX.ICMP.Unused_32) with
      Pre =>
@@ -907,15 +889,8 @@ is
        and Valid_Next (Ctx, F_Unused_32) = Valid_Next (Ctx, F_Unused_32)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
        and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
-       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
-       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
-       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old;
+       and (for all F in Field range F_Tag .. F_Pointer =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Sequence_Number (Ctx : in out Context; Val : RFLX.ICMP.Sequence_Number) with
      Pre =>
@@ -956,16 +931,8 @@ is
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
        and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
        and Get_Identifier (Ctx) = Get_Identifier (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
-       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
-       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
-       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
-       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old;
+       and (for all F in Field range F_Tag .. F_Unused_32 =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Unused_24 (Ctx : in out Context; Val : RFLX.ICMP.Unused_24) with
      Pre =>
@@ -993,17 +960,8 @@ is
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
        and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
        and Get_Pointer (Ctx) = Get_Pointer (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
-       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
-       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
-       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
-       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old
-       and Context_Cursor (Ctx, F_Sequence_Number) = Context_Cursor (Ctx, F_Sequence_Number)'Old;
+       and (for all F in Field range F_Tag .. F_Sequence_Number =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Originate_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) with
      Pre =>
@@ -1032,18 +990,8 @@ is
        and Get_Checksum (Ctx) = Get_Checksum (Ctx)'Old
        and Get_Identifier (Ctx) = Get_Identifier (Ctx)'Old
        and Get_Sequence_Number (Ctx) = Get_Sequence_Number (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
-       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
-       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
-       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
-       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old
-       and Context_Cursor (Ctx, F_Sequence_Number) = Context_Cursor (Ctx, F_Sequence_Number)'Old
-       and Context_Cursor (Ctx, F_Unused_24) = Context_Cursor (Ctx, F_Unused_24)'Old;
+       and (for all F in Field range F_Tag .. F_Unused_24 =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Receive_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) with
      Pre =>
@@ -1071,20 +1019,8 @@ is
        and Get_Identifier (Ctx) = Get_Identifier (Ctx)'Old
        and Get_Sequence_Number (Ctx) = Get_Sequence_Number (Ctx)'Old
        and Get_Originate_Timestamp (Ctx) = Get_Originate_Timestamp (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
-       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
-       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
-       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
-       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old
-       and Context_Cursor (Ctx, F_Sequence_Number) = Context_Cursor (Ctx, F_Sequence_Number)'Old
-       and Context_Cursor (Ctx, F_Unused_24) = Context_Cursor (Ctx, F_Unused_24)'Old
-       and Context_Cursor (Ctx, F_Originate_Timestamp) = Context_Cursor (Ctx, F_Originate_Timestamp)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old;
+       and (for all F in Field range F_Tag .. F_Data =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Transmit_Timestamp (Ctx : in out Context; Val : RFLX.ICMP.Timestamp) with
      Pre =>
@@ -1111,21 +1047,8 @@ is
        and Get_Sequence_Number (Ctx) = Get_Sequence_Number (Ctx)'Old
        and Get_Originate_Timestamp (Ctx) = Get_Originate_Timestamp (Ctx)'Old
        and Get_Receive_Timestamp (Ctx) = Get_Receive_Timestamp (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old
-       and Context_Cursor (Ctx, F_Code_Destination_Unreachable) = Context_Cursor (Ctx, F_Code_Destination_Unreachable)'Old
-       and Context_Cursor (Ctx, F_Code_Redirect) = Context_Cursor (Ctx, F_Code_Redirect)'Old
-       and Context_Cursor (Ctx, F_Code_Time_Exceeded) = Context_Cursor (Ctx, F_Code_Time_Exceeded)'Old
-       and Context_Cursor (Ctx, F_Code_Zero) = Context_Cursor (Ctx, F_Code_Zero)'Old
-       and Context_Cursor (Ctx, F_Checksum) = Context_Cursor (Ctx, F_Checksum)'Old
-       and Context_Cursor (Ctx, F_Gateway_Internet_Address) = Context_Cursor (Ctx, F_Gateway_Internet_Address)'Old
-       and Context_Cursor (Ctx, F_Identifier) = Context_Cursor (Ctx, F_Identifier)'Old
-       and Context_Cursor (Ctx, F_Pointer) = Context_Cursor (Ctx, F_Pointer)'Old
-       and Context_Cursor (Ctx, F_Unused_32) = Context_Cursor (Ctx, F_Unused_32)'Old
-       and Context_Cursor (Ctx, F_Sequence_Number) = Context_Cursor (Ctx, F_Sequence_Number)'Old
-       and Context_Cursor (Ctx, F_Unused_24) = Context_Cursor (Ctx, F_Unused_24)'Old
-       and Context_Cursor (Ctx, F_Originate_Timestamp) = Context_Cursor (Ctx, F_Originate_Timestamp)'Old
-       and Context_Cursor (Ctx, F_Data) = Context_Cursor (Ctx, F_Data)'Old
-       and Context_Cursor (Ctx, F_Receive_Timestamp) = Context_Cursor (Ctx, F_Receive_Timestamp)'Old;
+       and (for all F in Field range F_Tag .. F_Receive_Timestamp =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Data_Empty (Ctx : in out Context) with
      Pre =>
@@ -1241,6 +1164,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -2291,5 +2219,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.ICMP.Message;

--- a/tests/spark/generated/rflx-ipv4-packet.ads
+++ b/tests/spark/generated/rflx-ipv4-packet.ads
@@ -34,6 +34,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Version, F_IHL, F_DSCP, F_ECN, F_Total_Length, F_Identification, F_Flag_R, F_Flag_DF, F_Flag_MF, F_Fragment_Offset, F_TTL, F_Protocol, F_Header_Checksum, F_Source, F_Destination, F_Options, F_Payload, F_Final);
 
    subtype Field is Virtual_Field range F_Version .. F_Payload;
@@ -571,7 +573,8 @@ is
        and Ctx.Last = Ctx.Last'Old
        and Predecessor (Ctx, F_IHL) = Predecessor (Ctx, F_IHL)'Old
        and Valid_Next (Ctx, F_IHL) = Valid_Next (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old;
+       and (for all F in Field range F_Version .. F_Version =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_DSCP (Ctx : in out Context; Val : RFLX.IPv4.DCSP) with
      Pre =>
@@ -608,8 +611,8 @@ is
        and Predecessor (Ctx, F_DSCP) = Predecessor (Ctx, F_DSCP)'Old
        and Valid_Next (Ctx, F_DSCP) = Valid_Next (Ctx, F_DSCP)'Old
        and Get_IHL (Ctx) = Get_IHL (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old;
+       and (for all F in Field range F_Version .. F_IHL =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_ECN (Ctx : in out Context; Val : RFLX.IPv4.ECN) with
      Pre =>
@@ -646,9 +649,8 @@ is
        and Valid_Next (Ctx, F_ECN) = Valid_Next (Ctx, F_ECN)'Old
        and Get_IHL (Ctx) = Get_IHL (Ctx)'Old
        and Get_DSCP (Ctx) = Get_DSCP (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old;
+       and (for all F in Field range F_Version .. F_DSCP =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Total_Length (Ctx : in out Context; Val : RFLX.IPv4.Total_Length) with
      Pre =>
@@ -688,10 +690,8 @@ is
        and Get_IHL (Ctx) = Get_IHL (Ctx)'Old
        and Get_DSCP (Ctx) = Get_DSCP (Ctx)'Old
        and Get_ECN (Ctx) = Get_ECN (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old;
+       and (for all F in Field range F_Version .. F_ECN =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Identification (Ctx : in out Context; Val : RFLX.IPv4.Identification) with
      Pre =>
@@ -728,11 +728,8 @@ is
        and Get_DSCP (Ctx) = Get_DSCP (Ctx)'Old
        and Get_ECN (Ctx) = Get_ECN (Ctx)'Old
        and Get_Total_Length (Ctx) = Get_Total_Length (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old;
+       and (for all F in Field range F_Version .. F_Total_Length =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Flag_R (Ctx : in out Context; Val : Boolean) with
      Pre =>
@@ -772,12 +769,8 @@ is
        and Get_ECN (Ctx) = Get_ECN (Ctx)'Old
        and Get_Total_Length (Ctx) = Get_Total_Length (Ctx)'Old
        and Get_Identification (Ctx) = Get_Identification (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old;
+       and (for all F in Field range F_Version .. F_Identification =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Flag_DF (Ctx : in out Context; Val : Boolean) with
      Pre =>
@@ -814,13 +807,8 @@ is
        and Get_Total_Length (Ctx) = Get_Total_Length (Ctx)'Old
        and Get_Identification (Ctx) = Get_Identification (Ctx)'Old
        and Get_Flag_R (Ctx) = Get_Flag_R (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old;
+       and (for all F in Field range F_Version .. F_Flag_R =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Flag_MF (Ctx : in out Context; Val : Boolean) with
      Pre =>
@@ -857,14 +845,8 @@ is
        and Get_Identification (Ctx) = Get_Identification (Ctx)'Old
        and Get_Flag_R (Ctx) = Get_Flag_R (Ctx)'Old
        and Get_Flag_DF (Ctx) = Get_Flag_DF (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old
-       and Context_Cursor (Ctx, F_Flag_DF) = Context_Cursor (Ctx, F_Flag_DF)'Old;
+       and (for all F in Field range F_Version .. F_Flag_DF =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Fragment_Offset (Ctx : in out Context; Val : RFLX.IPv4.Fragment_Offset) with
      Pre =>
@@ -901,15 +883,8 @@ is
        and Get_Flag_R (Ctx) = Get_Flag_R (Ctx)'Old
        and Get_Flag_DF (Ctx) = Get_Flag_DF (Ctx)'Old
        and Get_Flag_MF (Ctx) = Get_Flag_MF (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old
-       and Context_Cursor (Ctx, F_Flag_DF) = Context_Cursor (Ctx, F_Flag_DF)'Old
-       and Context_Cursor (Ctx, F_Flag_MF) = Context_Cursor (Ctx, F_Flag_MF)'Old;
+       and (for all F in Field range F_Version .. F_Flag_MF =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_TTL (Ctx : in out Context; Val : RFLX.IPv4.TTL) with
      Pre =>
@@ -946,16 +921,8 @@ is
        and Get_Flag_DF (Ctx) = Get_Flag_DF (Ctx)'Old
        and Get_Flag_MF (Ctx) = Get_Flag_MF (Ctx)'Old
        and Get_Fragment_Offset (Ctx) = Get_Fragment_Offset (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old
-       and Context_Cursor (Ctx, F_Flag_DF) = Context_Cursor (Ctx, F_Flag_DF)'Old
-       and Context_Cursor (Ctx, F_Flag_MF) = Context_Cursor (Ctx, F_Flag_MF)'Old
-       and Context_Cursor (Ctx, F_Fragment_Offset) = Context_Cursor (Ctx, F_Fragment_Offset)'Old;
+       and (for all F in Field range F_Version .. F_Fragment_Offset =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Protocol (Ctx : in out Context; Val : RFLX.IPv4.Protocol_Enum) with
      Pre =>
@@ -992,17 +959,8 @@ is
        and Get_Flag_MF (Ctx) = Get_Flag_MF (Ctx)'Old
        and Get_Fragment_Offset (Ctx) = Get_Fragment_Offset (Ctx)'Old
        and Get_TTL (Ctx) = Get_TTL (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old
-       and Context_Cursor (Ctx, F_Flag_DF) = Context_Cursor (Ctx, F_Flag_DF)'Old
-       and Context_Cursor (Ctx, F_Flag_MF) = Context_Cursor (Ctx, F_Flag_MF)'Old
-       and Context_Cursor (Ctx, F_Fragment_Offset) = Context_Cursor (Ctx, F_Fragment_Offset)'Old
-       and Context_Cursor (Ctx, F_TTL) = Context_Cursor (Ctx, F_TTL)'Old;
+       and (for all F in Field range F_Version .. F_TTL =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Header_Checksum (Ctx : in out Context; Val : RFLX.IPv4.Header_Checksum) with
      Pre =>
@@ -1039,18 +997,8 @@ is
        and Get_Fragment_Offset (Ctx) = Get_Fragment_Offset (Ctx)'Old
        and Get_TTL (Ctx) = Get_TTL (Ctx)'Old
        and Get_Protocol (Ctx) = Get_Protocol (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old
-       and Context_Cursor (Ctx, F_Flag_DF) = Context_Cursor (Ctx, F_Flag_DF)'Old
-       and Context_Cursor (Ctx, F_Flag_MF) = Context_Cursor (Ctx, F_Flag_MF)'Old
-       and Context_Cursor (Ctx, F_Fragment_Offset) = Context_Cursor (Ctx, F_Fragment_Offset)'Old
-       and Context_Cursor (Ctx, F_TTL) = Context_Cursor (Ctx, F_TTL)'Old
-       and Context_Cursor (Ctx, F_Protocol) = Context_Cursor (Ctx, F_Protocol)'Old;
+       and (for all F in Field range F_Version .. F_Protocol =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Source (Ctx : in out Context; Val : RFLX.IPv4.Address) with
      Pre =>
@@ -1087,19 +1035,8 @@ is
        and Get_TTL (Ctx) = Get_TTL (Ctx)'Old
        and Get_Protocol (Ctx) = Get_Protocol (Ctx)'Old
        and Get_Header_Checksum (Ctx) = Get_Header_Checksum (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old
-       and Context_Cursor (Ctx, F_Flag_DF) = Context_Cursor (Ctx, F_Flag_DF)'Old
-       and Context_Cursor (Ctx, F_Flag_MF) = Context_Cursor (Ctx, F_Flag_MF)'Old
-       and Context_Cursor (Ctx, F_Fragment_Offset) = Context_Cursor (Ctx, F_Fragment_Offset)'Old
-       and Context_Cursor (Ctx, F_TTL) = Context_Cursor (Ctx, F_TTL)'Old
-       and Context_Cursor (Ctx, F_Protocol) = Context_Cursor (Ctx, F_Protocol)'Old
-       and Context_Cursor (Ctx, F_Header_Checksum) = Context_Cursor (Ctx, F_Header_Checksum)'Old;
+       and (for all F in Field range F_Version .. F_Header_Checksum =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Destination (Ctx : in out Context; Val : RFLX.IPv4.Address) with
      Pre =>
@@ -1136,20 +1073,8 @@ is
        and Get_Protocol (Ctx) = Get_Protocol (Ctx)'Old
        and Get_Header_Checksum (Ctx) = Get_Header_Checksum (Ctx)'Old
        and Get_Source (Ctx) = Get_Source (Ctx)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old
-       and Context_Cursor (Ctx, F_Flag_DF) = Context_Cursor (Ctx, F_Flag_DF)'Old
-       and Context_Cursor (Ctx, F_Flag_MF) = Context_Cursor (Ctx, F_Flag_MF)'Old
-       and Context_Cursor (Ctx, F_Fragment_Offset) = Context_Cursor (Ctx, F_Fragment_Offset)'Old
-       and Context_Cursor (Ctx, F_TTL) = Context_Cursor (Ctx, F_TTL)'Old
-       and Context_Cursor (Ctx, F_Protocol) = Context_Cursor (Ctx, F_Protocol)'Old
-       and Context_Cursor (Ctx, F_Header_Checksum) = Context_Cursor (Ctx, F_Header_Checksum)'Old
-       and Context_Cursor (Ctx, F_Source) = Context_Cursor (Ctx, F_Source)'Old;
+       and (for all F in Field range F_Version .. F_Source =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Options_Empty (Ctx : in out Context) with
      Pre =>
@@ -1439,24 +1364,12 @@ is
        and Predecessor (Ctx, F_Options) = Predecessor (Ctx, F_Options)'Old
        and Path_Condition (Ctx, F_Options) = Path_Condition (Ctx, F_Options)'Old
        and Field_Last (Ctx, F_Options) = Field_Last (Ctx, F_Options)'Old
-       and Context_Cursor (Ctx, F_Version) = Context_Cursor (Ctx, F_Version)'Old
-       and Context_Cursor (Ctx, F_IHL) = Context_Cursor (Ctx, F_IHL)'Old
-       and Context_Cursor (Ctx, F_DSCP) = Context_Cursor (Ctx, F_DSCP)'Old
-       and Context_Cursor (Ctx, F_ECN) = Context_Cursor (Ctx, F_ECN)'Old
-       and Context_Cursor (Ctx, F_Total_Length) = Context_Cursor (Ctx, F_Total_Length)'Old
-       and Context_Cursor (Ctx, F_Identification) = Context_Cursor (Ctx, F_Identification)'Old
-       and Context_Cursor (Ctx, F_Flag_R) = Context_Cursor (Ctx, F_Flag_R)'Old
-       and Context_Cursor (Ctx, F_Flag_DF) = Context_Cursor (Ctx, F_Flag_DF)'Old
-       and Context_Cursor (Ctx, F_Flag_MF) = Context_Cursor (Ctx, F_Flag_MF)'Old
-       and Context_Cursor (Ctx, F_Fragment_Offset) = Context_Cursor (Ctx, F_Fragment_Offset)'Old
-       and Context_Cursor (Ctx, F_TTL) = Context_Cursor (Ctx, F_TTL)'Old
-       and Context_Cursor (Ctx, F_Protocol) = Context_Cursor (Ctx, F_Protocol)'Old
-       and Context_Cursor (Ctx, F_Header_Checksum) = Context_Cursor (Ctx, F_Header_Checksum)'Old
-       and Context_Cursor (Ctx, F_Source) = Context_Cursor (Ctx, F_Source)'Old
-       and Context_Cursor (Ctx, F_Destination) = Context_Cursor (Ctx, F_Destination)'Old,
+       and (for all F in Field range F_Version .. F_Destination =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Options) =>
-           Context_Cursor (Ctx, F_Payload) = Context_Cursor (Ctx, F_Payload)'Old,
+           (for all F in Field range F_Payload .. F_Payload =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            (Predecessor (Ctx, F_Payload) = F_Options
             and Valid_Next (Ctx, F_Payload))
@@ -1513,6 +1426,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -2087,5 +2005,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.IPv4.Packet;

--- a/tests/spark/generated/rflx-sequence-inner_message.ads
+++ b/tests/spark/generated/rflx-sequence-inner_message.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Length, F_Payload, F_Final);
 
    subtype Field is Virtual_Field range F_Length .. F_Payload;
@@ -538,6 +540,11 @@ is
        (GNATprove, Inline_For_Proof),
      Ghost;
 
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
    type Structure is
       record
          Length : RFLX.Sequence.Length;
@@ -788,5 +795,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Sequence.Inner_Message;

--- a/tests/spark/generated/rflx-sequence-message.ads
+++ b/tests/spark/generated/rflx-sequence-message.ads
@@ -34,6 +34,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Length, F_Modular_Vector, F_Range_Vector, F_Enumeration_Vector, F_AV_Enumeration_Vector, F_Final);
 
    subtype Field is Virtual_Field range F_Length .. F_AV_Enumeration_Vector;
@@ -684,12 +686,12 @@ is
        and Predecessor (Ctx, F_Modular_Vector) = Predecessor (Ctx, F_Modular_Vector)'Old
        and Path_Condition (Ctx, F_Modular_Vector) = Path_Condition (Ctx, F_Modular_Vector)'Old
        and Field_Last (Ctx, F_Modular_Vector) = Field_Last (Ctx, F_Modular_Vector)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old,
+       and (for all F in Field range F_Length .. F_Length =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Modular_Vector) =>
-           Context_Cursor (Ctx, F_Range_Vector) = Context_Cursor (Ctx, F_Range_Vector)'Old
-           and Context_Cursor (Ctx, F_Enumeration_Vector) = Context_Cursor (Ctx, F_Enumeration_Vector)'Old
-           and Context_Cursor (Ctx, F_AV_Enumeration_Vector) = Context_Cursor (Ctx, F_AV_Enumeration_Vector)'Old,
+           (for all F in Field range F_Range_Vector .. F_AV_Enumeration_Vector =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            (Predecessor (Ctx, F_Range_Vector) = F_Modular_Vector
             and Valid_Next (Ctx, F_Range_Vector))
@@ -724,12 +726,12 @@ is
        and Predecessor (Ctx, F_Range_Vector) = Predecessor (Ctx, F_Range_Vector)'Old
        and Path_Condition (Ctx, F_Range_Vector) = Path_Condition (Ctx, F_Range_Vector)'Old
        and Field_Last (Ctx, F_Range_Vector) = Field_Last (Ctx, F_Range_Vector)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Modular_Vector) = Context_Cursor (Ctx, F_Modular_Vector)'Old,
+       and (for all F in Field range F_Length .. F_Modular_Vector =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Range_Vector) =>
-           Context_Cursor (Ctx, F_Enumeration_Vector) = Context_Cursor (Ctx, F_Enumeration_Vector)'Old
-           and Context_Cursor (Ctx, F_AV_Enumeration_Vector) = Context_Cursor (Ctx, F_AV_Enumeration_Vector)'Old,
+           (for all F in Field range F_Enumeration_Vector .. F_AV_Enumeration_Vector =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            (Predecessor (Ctx, F_Enumeration_Vector) = F_Range_Vector
             and Valid_Next (Ctx, F_Enumeration_Vector))
@@ -763,12 +765,12 @@ is
        and Predecessor (Ctx, F_Enumeration_Vector) = Predecessor (Ctx, F_Enumeration_Vector)'Old
        and Path_Condition (Ctx, F_Enumeration_Vector) = Path_Condition (Ctx, F_Enumeration_Vector)'Old
        and Field_Last (Ctx, F_Enumeration_Vector) = Field_Last (Ctx, F_Enumeration_Vector)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Modular_Vector) = Context_Cursor (Ctx, F_Modular_Vector)'Old
-       and Context_Cursor (Ctx, F_Range_Vector) = Context_Cursor (Ctx, F_Range_Vector)'Old,
+       and (for all F in Field range F_Length .. F_Range_Vector =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Enumeration_Vector) =>
-           Context_Cursor (Ctx, F_AV_Enumeration_Vector) = Context_Cursor (Ctx, F_AV_Enumeration_Vector)'Old,
+           (for all F in Field range F_AV_Enumeration_Vector .. F_AV_Enumeration_Vector =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
         others =>
            (Predecessor (Ctx, F_AV_Enumeration_Vector) = F_Enumeration_Vector
             and Valid_Next (Ctx, F_AV_Enumeration_Vector))
@@ -801,10 +803,8 @@ is
        and Predecessor (Ctx, F_AV_Enumeration_Vector) = Predecessor (Ctx, F_AV_Enumeration_Vector)'Old
        and Path_Condition (Ctx, F_AV_Enumeration_Vector) = Path_Condition (Ctx, F_AV_Enumeration_Vector)'Old
        and Field_Last (Ctx, F_AV_Enumeration_Vector) = Field_Last (Ctx, F_AV_Enumeration_Vector)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old
-       and Context_Cursor (Ctx, F_Modular_Vector) = Context_Cursor (Ctx, F_Modular_Vector)'Old
-       and Context_Cursor (Ctx, F_Range_Vector) = Context_Cursor (Ctx, F_Range_Vector)'Old
-       and Context_Cursor (Ctx, F_Enumeration_Vector) = Context_Cursor (Ctx, F_Enumeration_Vector)'Old,
+       and (for all F in Field range F_Length .. F_Enumeration_Vector =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_AV_Enumeration_Vector) =>
            True,
@@ -949,6 +949,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -1245,5 +1250,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Sequence.Message;

--- a/tests/spark/generated/rflx-sequence-messages_message.ads
+++ b/tests/spark/generated/rflx-sequence-messages_message.ads
@@ -31,6 +31,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Length, F_Messages, F_Final);
 
    subtype Field is Virtual_Field range F_Length .. F_Messages;
@@ -509,7 +511,8 @@ is
        and Predecessor (Ctx, F_Messages) = Predecessor (Ctx, F_Messages)'Old
        and Path_Condition (Ctx, F_Messages) = Path_Condition (Ctx, F_Messages)'Old
        and Field_Last (Ctx, F_Messages) = Field_Last (Ctx, F_Messages)'Old
-       and Context_Cursor (Ctx, F_Length) = Context_Cursor (Ctx, F_Length)'Old,
+       and (for all F in Field range F_Length .. F_Length =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Messages) =>
            True,
@@ -552,6 +555,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -789,5 +797,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Sequence.Messages_Message;

--- a/tests/spark/generated/rflx-sequence-sequence_size_defined_by_message_size.ads
+++ b/tests/spark/generated/rflx-sequence-sequence_size_defined_by_message_size.ads
@@ -31,6 +31,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Header, F_Vector, F_Final);
 
    subtype Field is Virtual_Field range F_Header .. F_Vector;
@@ -511,7 +513,8 @@ is
        and Predecessor (Ctx, F_Vector) = Predecessor (Ctx, F_Vector)'Old
        and Path_Condition (Ctx, F_Vector) = Path_Condition (Ctx, F_Vector)'Old
        and Field_Last (Ctx, F_Vector) = Field_Last (Ctx, F_Vector)'Old
-       and Context_Cursor (Ctx, F_Header) = Context_Cursor (Ctx, F_Header)'Old,
+       and (for all F in Field range F_Header .. F_Header =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F)),
      Contract_Cases =>
        (Structural_Valid (Ctx, F_Vector) =>
            True,
@@ -554,6 +557,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -797,5 +805,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.Sequence.Sequence_Size_Defined_By_Message_Size;

--- a/tests/spark/generated/rflx-tlv-message.ads
+++ b/tests/spark/generated/rflx-tlv-message.ads
@@ -30,6 +30,8 @@ is
 
    pragma Warnings (On, "use clause for type ""U64"" * has no effect");
 
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Virtual_Field is (F_Initial, F_Tag, F_Length, F_Value, F_Final);
 
    subtype Field is Virtual_Field range F_Tag .. F_Value;
@@ -467,7 +469,8 @@ is
        and Predecessor (Ctx, F_Length) = Predecessor (Ctx, F_Length)'Old
        and Valid_Next (Ctx, F_Length) = Valid_Next (Ctx, F_Length)'Old
        and Get_Tag (Ctx) = Get_Tag (Ctx)'Old
-       and Context_Cursor (Ctx, F_Tag) = Context_Cursor (Ctx, F_Tag)'Old;
+       and (for all F in Field range F_Tag .. F_Tag =>
+               Context_Cursors_Index (Context_Cursors (Ctx), F) = Context_Cursors_Index (Context_Cursors (Ctx)'Old, F));
 
    procedure Set_Value_Empty (Ctx : in out Context) with
      Pre =>
@@ -573,6 +576,11 @@ is
      Ghost;
 
    function Context_Cursors (Ctx : Context) return Field_Cursors with
+     Annotate =>
+       (GNATprove, Inline_For_Proof),
+     Ghost;
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor with
      Annotate =>
        (GNATprove, Inline_For_Proof),
      Ghost;
@@ -845,5 +853,8 @@ private
 
    function Context_Cursors (Ctx : Context) return Field_Cursors is
      (Ctx.Cursors);
+
+   function Context_Cursors_Index (Cursors : Field_Cursors; Fld : Field) return Field_Cursor is
+     (Cursors (Fld));
 
 end RFLX.TLV.Message;


### PR DESCRIPTION
Uses of message.successors/predecessors to generate expressions
result in code size linear to the number of fields. It is better to
generate a quantified expression which is constant in size.

* new Context_Cursors_Index function. This function enables indexing
  of a Field_Cursors object. This is needed to avoid using 'Old on
  the quantified variable.
* move 'Old further inside expression for Context_Cursor comparison
  new function context_cursor_unchanged to express predicate which
  is used in several places
* use quantifiers to express invalid successors