### PR TITLE
Add precondition to inlined subp

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -350,6 +350,14 @@ def session_main(
             ),
             ada.CallStatement("Ada.Text_IO.New_Line"),
         ],
+        aspects=[
+            ada.Precondition(
+                ada.AndThen(
+                    ada.Equal(ada.First("Prefix"), ada.Number(1)),
+                    ada.LessEqual(ada.Length("Prefix"), ada.Number(1000)),
+                )
+            )
+        ],
     )
 
     read_procedure = ada.SubprogramBody(


### PR DESCRIPTION
This subprogram may or may not be inlined depending on the wavefront
date. It's better to add a contract so that it gets proved in both
cases.

For #955