### PR TITLE
Fix type switch on `ID`'s initializing `identifier`

### DIFF
--- a/rflx/generator/session.py
+++ b/rflx/generator/session.py
@@ -2153,7 +2153,7 @@ class SessionGenerator:  # pylint: disable = too-many-instance-attributes
             )
 
         if isinstance(expression, expr.Call):
-            return self._assign_to_call(target, expression, exception_handler, is_global)
+            return self._assign_to_call(target, expression, exception_handler, is_global, state)
 
         if isinstance(expression, expr.Conversion):
             return self._assign_to_conversion(target, expression, exception_handler, is_global)
@@ -2702,6 +2702,7 @@ class SessionGenerator:  # pylint: disable = too-many-instance-attributes
         call_expr: expr.Call,
         exception_handler: ExceptionHandler,
         is_global: Callable[[ID], bool],
+        state: rid.ID,
     ) -> Sequence[Statement]:
         pre_call: list[Statement] = []
         post_call = []
@@ -2793,7 +2794,9 @@ class SessionGenerator:  # pylint: disable = too-many-instance-attributes
                                 First(const.TYPES_INDEX),
                                 Add(
                                     First(const.TYPES_INDEX),
-                                    Number(self._allocator.get_size() - 1),
+                                    Number(
+                                        self._allocator.get_size(a.prefix.identifier, state) - 1
+                                    ),
                                 ),
                             ),
                             NamedAggregate(("others", Number(0))),
@@ -2864,7 +2867,9 @@ class SessionGenerator:  # pylint: disable = too-many-instance-attributes
                                 First(const.TYPES_INDEX),
                                 Add(
                                     First(const.TYPES_INDEX),
-                                    Number(self._allocator.get_size() - 1),
+                                    Number(
+                                        self._allocator.get_size(a.prefix.identifier, state) - 1
+                                    ),
                                 ),
                             ),
                             NamedAggregate(("others", Number(0))),

--- a/rflx/identifier.py
+++ b/rflx/identifier.py
@@ -15,7 +15,7 @@ class ID:
 
         if isinstance(identifier, str):
             self._parts = re.split(r"\.|::", identifier)
-        elif isinstance(identifier, list):
+        elif isinstance(identifier, Sequence):
             self._parts = identifier
         elif isinstance(identifier, ID):
             self._parts = list(identifier.parts)


### PR DESCRIPTION
Given the following signature of `ID.__Init__`:

```py
class ID:
    def __init__(
        self,
        identifier: Union[str, Sequence[str], "ID"],
        location: Location = None
    ) -> None:
```

... the type switch on `identifier` should be matching against `Sequence` instead of `list`.