### PR TITLE
Use fully qualified type names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.testing.pytestArgs": ["tests"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
+}

--- a/rflx/generator/session.py
+++ b/rflx/generator/session.py
@@ -238,11 +238,11 @@ class SessionGenerator:  # pylint: disable = too-many-instance-attributes
         if model.is_builtin_type(identifier):
             return ID(identifier.name)
 
-        return ID(model.qualified_type_identifier(identifier, self._session.package))
+        return ID(model.internal_type_identifier(identifier, self._session.package))
 
     def _model_type(self, identifier: rid.ID) -> model.Type:
         return self._session.types[
-            model.qualified_type_identifier(identifier, self._session.package)
+            model.internal_type_identifier(identifier, self._session.package)
         ]
 
     def _create(self) -> None:

--- a/rflx/model/__init__.py
+++ b/rflx/model/__init__.py
@@ -36,7 +36,7 @@ from .type_ import (  # noqa: F401
     Scalar as Scalar,
     Sequence as Sequence,
     Type as Type,
+    internal_type_identifier as internal_type_identifier,
     is_builtin_type as is_builtin_type,
     is_internal_type as is_internal_type,
-    qualified_type_identifier as qualified_type_identifier,
 )

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -189,7 +189,7 @@ class AbstractMessage(mty.Type):
             [
                 f"{parameter_field.identifier} : {parameter_type_identifier}"
                 for parameter_field, parameter_type in self.parameter_types.items()
-                for parameter_type_identifier in (parameter_type.qualified_identifier)
+                for parameter_type_identifier in (parameter_type.qualified_identifier,)
             ]
         )
         if parameters:

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -202,7 +202,7 @@ class AbstractMessage(mty.Type):
         for i, f in enumerate(field_list):
             if f != INITIAL:
                 fields += "\n" if fields else ""
-                fields += f"{f.name} : {self.types[f].name}"
+                fields += f"{f.name} : {self.types[f].identifier}"
             outgoing = self.outgoing(f)
             if not (
                 len(outgoing) == 1

--- a/rflx/model/message.py
+++ b/rflx/model/message.py
@@ -190,7 +190,9 @@ class AbstractMessage(mty.Type):
                 f"{p.identifier} : {type_identifier}"
                 for p, t in self.parameter_types.items()
                 for type_identifier in (
-                    t.name if mty.is_builtin_type(t.identifier) else t.identifier,
+                    t.name
+                    if mty.is_builtin_type(t.identifier) or mty.is_internal_type(t.identifier)
+                    else t.identifier,
                 )
             ]
         )
@@ -202,7 +204,14 @@ class AbstractMessage(mty.Type):
         for i, f in enumerate(field_list):
             if f != INITIAL:
                 fields += "\n" if fields else ""
-                fields += f"{f.name} : {self.types[f].identifier}"
+                f_ty = self.types[f]
+                f_ident: StrID = f_ty.identifier
+                f_ident = (
+                    f_ty.name
+                    if mty.is_builtin_type(f_ident) or mty.is_internal_type(f_ident)
+                    else f_ident
+                )
+                fields += f"{f.name} : {f_ident}"
             outgoing = self.outgoing(f)
             if not (
                 len(outgoing) == 1

--- a/rflx/model/model.py
+++ b/rflx/model/model.py
@@ -48,7 +48,11 @@ class Model(Base):
                 pkg_name: ID = ty.package
                 pkg: Package = pkgs.setdefault(pkg_name, Package(pkg_name))
                 for dep in ty.dependencies:
-                    if dep.package != pkg_name:
+                    if dep.package not in [
+                        pkg_name,
+                        const.BUILTINS_PACKAGE,
+                        const.INTERNAL_PACKAGE,
+                    ]:
                         pkg.imports.append(dep.package)
                 pkg.types.append(ty)
         for sess in self.__sessions:

--- a/rflx/model/model.py
+++ b/rflx/model/model.py
@@ -47,7 +47,7 @@ class Model(Base):
             if not type_.is_builtin_type(ty.name) and not type_.is_internal_type(ty.name):
                 pkg_name: ID = ty.package
                 pkg: Package = pkgs.setdefault(pkg_name, Package(pkg_name))
-                for dep in ty.dependencies:
+                for dep in ty.direct_dependencies:
                     if dep.package not in [
                         pkg_name,
                         const.BUILTINS_PACKAGE,
@@ -62,9 +62,7 @@ class Model(Base):
 
     def write_specification_files(self, output_dir: Path) -> None:
         """
-        Write corresponding specification files into given directory.
-
-        Limitation: Potentially necessary with-clauses are not generated.
+        Write corresponding specification files (one per package) into given directory.
         """
         for package, specification in self.create_specifications().items():
             (output_dir / f"{package.flat.lower()}.rflx").write_text(specification)

--- a/rflx/model/model.py
+++ b/rflx/model/model.py
@@ -61,9 +61,7 @@ class Model(Base):
         return {id: str(pkg) for id, pkg in pkgs.items()}
 
     def write_specification_files(self, output_dir: Path) -> None:
-        """
-        Write corresponding specification files (one per package) into given directory.
-        """
+        """Write corresponding specification files (one per package) into given directory."""
         for package, specification in self.create_specifications().items():
             (output_dir / f"{package.flat.lower()}.rflx").write_text(specification)
 

--- a/rflx/model/package.py
+++ b/rflx/model/package.py
@@ -1,0 +1,45 @@
+import textwrap
+from dataclasses import dataclass, field
+from typing import List
+
+from rflx.identifier import ID
+
+from . import session, type_
+
+
+@dataclass
+class Package:
+    name: ID
+    imports: List[ID] = field(default_factory=list)
+    types: List[type_.Type] = field(default_factory=list)
+    sessions: List[session.Session] = field(default_factory=list)
+
+    @property
+    def imports_str(self) -> str:
+        return "\n".join(f"with {i};" for i in self.imports)
+
+    @property
+    def begin_str(self) -> str:
+        return f"package {self.name} is"
+
+    @property
+    def end_str(self) -> str:
+        return f"end {self.name};"
+
+    @property
+    def types_str(self) -> str:
+        raw = "\n\n".join(f"{t};" for t in self.types)
+        return textwrap.indent(raw, " " * 3)
+
+    @property
+    def sessions_str(self) -> str:
+        raw = "\n\n".join(f"{s};" for s in self.sessions)
+        return textwrap.indent(raw, " " * 3)
+
+    def __str__(self) -> str:
+        return "\n\n".join(
+            filter(
+                None,
+                [self.imports_str, self.begin_str, self.types_str, self.sessions_str, self.end_str],
+            )
+        )

--- a/rflx/model/package.py
+++ b/rflx/model/package.py
@@ -37,9 +37,5 @@ class Package:
         return textwrap.indent(raw, " " * 3)
 
     def __str__(self) -> str:
-        return "\n\n".join(
-            filter(
-                None,
-                [self.imports_str, self.begin_str, self.types_str, self.sessions_str, self.end_str],
-            )
-        )
+        pieces = [self.imports_str, self.begin_str, self.types_str, self.sessions_str, self.end_str]
+        return "\n\n".join(filter(None, pieces))

--- a/rflx/model/session.py
+++ b/rflx/model/session.py
@@ -416,7 +416,7 @@ class Session(AbstractSession):
             self.__reference_variable_declaration(d.variables(), visible_declarations)
 
             if isinstance(d, decl.TypeDeclaration):
-                type_identifier = mty.qualified_type_identifier(k, self.package)
+                type_identifier = mty.internal_type_identifier(k, self.package)
                 if type_identifier in self.types:
                     self.error.extend(
                         [(f'type "{k}" shadows type', Subsystem.MODEL, Severity.ERROR, d.location)],
@@ -424,7 +424,7 @@ class Session(AbstractSession):
                 self.types[type_identifier] = d.type_definition
 
             elif isinstance(d, decl.TypeCheckableDeclaration):
-                type_identifier = mty.qualified_type_identifier(d.type_identifier, self.package)
+                type_identifier = mty.internal_type_identifier(d.type_identifier, self.package)
                 if type_identifier in self.types:
                     self.error.extend(
                         d.check_type(
@@ -438,7 +438,7 @@ class Session(AbstractSession):
 
                 if isinstance(d, decl.FunctionDeclaration):
                     for a in d.arguments:
-                        type_identifier = mty.qualified_type_identifier(
+                        type_identifier = mty.internal_type_identifier(
                             a.type_identifier, self.package
                         )
                         if type_identifier in self.types:
@@ -643,7 +643,7 @@ class Session(AbstractSession):
                         if isinstance(t, Refinement) and t.sdu.identifier == identifier
                     ]
             if isinstance(expression, expr.MessageAggregate):
-                type_identifier = mty.qualified_type_identifier(identifier, self.package)
+                type_identifier = mty.internal_type_identifier(identifier, self.package)
                 if type_identifier in self.types:
                     expression.type_ = self.types[type_identifier].type_
 

--- a/rflx/model/type_.py
+++ b/rflx/model/type_.py
@@ -17,6 +17,17 @@ class Type(BasicDeclaration):
         return rty.Undefined()
 
     @property
+    def direct_dependencies(self) -> ty.List["Type"]:
+        """
+        Return a list consisting of the type and all the types on which the
+        type directly depends.
+
+        The dependencies are not determined recursively, i.e. the dependencies
+        of dependencies are not considered.
+        """
+        return [self]
+
+    @property
     def dependencies(self) -> ty.List["Type"]:
         """
         Return a list consisting of the type and all types on which the type depends.
@@ -24,6 +35,19 @@ class Type(BasicDeclaration):
         The dependencies are determined recursively.
         """
         return [self]
+
+    @property
+    def qualified_identifier(self) -> ID:
+        """
+        Return the
+        """
+        # TODO: Handle name collision with `type_.qualified_type_identifier`.
+        identifier = self.identifier
+        return (
+            ID(self.name, location=identifier.location)
+            if is_builtin_type(identifier) or is_internal_type(identifier)
+            else identifier
+        )
 
 
 class Scalar(Type):
@@ -591,7 +615,7 @@ class Sequence(Composite):
         return verbose_repr(self, ["identifier", "element_type"])
 
     def __str__(self) -> str:
-        return f"type {self.name} is sequence of {self.element_type.name}"
+        return f"type {self.name} is sequence of {self.element_type.qualified_identifier}"
 
     @property
     def type_(self) -> rty.Type:
@@ -600,6 +624,10 @@ class Sequence(Composite):
     @property
     def element_size(self) -> expr.Expr:
         return expr.Size(self.element_type.name)
+
+    @property
+    def direct_dependencies(self) -> ty.List["Type"]:
+        return [self, self.element_type]
 
     @property
     def dependencies(self) -> ty.List["Type"]:

--- a/rflx/model/type_.py
+++ b/rflx/model/type_.py
@@ -19,8 +19,7 @@ class Type(BasicDeclaration):
     @property
     def direct_dependencies(self) -> ty.List["Type"]:
         """
-        Return a list consisting of the type and all the types on which the
-        type directly depends.
+        Return a list consisting of the type and all the types on which the type directly depends.
 
         The dependencies are not determined recursively, i.e. the dependencies
         of dependencies are not considered.
@@ -39,9 +38,12 @@ class Type(BasicDeclaration):
     @property
     def qualified_identifier(self) -> ID:
         """
-        Return the
+        Return the qualified identifier of this type.
+
+        The qualified identifier of a type is defined as its complete package
+        path followed by the type name, or just the type name if the type is
+        builtin or internal.
         """
-        # TODO: Handle name collision with `type_.qualified_type_identifier`.
         identifier = self.identifier
         return (
             ID(self.name, location=identifier.location)
@@ -704,7 +706,14 @@ def is_builtin_type(identifier: StrID) -> bool:
     )
 
 
-def qualified_type_identifier(identifier: ID, package: ID = None) -> ID:
+def internal_type_identifier(identifier: ID, package: ID = None) -> ID:
+    """
+    Return the internal identifier of a type.
+
+    The internal identifier is defined as its complete package path
+    (`__BUILTINS__` for builtin types, and `__INTERNAL__` for internal types)
+    followed by the type name.
+    """
     if is_builtin_type(identifier):
         return ID(const.BUILTINS_PACKAGE * identifier.name, location=identifier.location)
 

--- a/rflx/specification/parser.py
+++ b/rflx/specification/parser.py
@@ -259,7 +259,7 @@ def create_sequence(
     filename: Path,
 ) -> model.Type:
     assert isinstance(sequence, lang.SequenceTypeDef)
-    element_identifier = model.qualified_type_identifier(
+    element_identifier = model.internal_type_identifier(
         create_id(sequence.f_element_type, filename), identifier.parent
     )
 
@@ -507,9 +507,7 @@ def create_variable_decl(
     )
     return decl.VariableDeclaration(
         create_id(declaration.f_identifier, filename),
-        model.qualified_type_identifier(
-            create_id(declaration.f_type_identifier, filename), package
-        ),
+        model.internal_type_identifier(create_id(declaration.f_type_identifier, filename), package),
         initializer,
         location=node_location(declaration, filename),
     )
@@ -521,7 +519,7 @@ def create_private_type_decl(
     assert isinstance(declaration, lang.FormalPrivateTypeDecl)
     return decl.TypeDeclaration(
         model.Private(
-            model.qualified_type_identifier(create_id(declaration.f_identifier, filename), package),
+            model.internal_type_identifier(create_id(declaration.f_identifier, filename), package),
             location=node_location(declaration, filename),
         )
     )
@@ -558,9 +556,7 @@ def create_renaming_decl(
     assert isinstance(selected, expr.Selected)
     return decl.RenamingDeclaration(
         create_id(declaration.f_identifier, filename),
-        model.qualified_type_identifier(
-            create_id(declaration.f_type_identifier, filename), package
-        ),
+        model.internal_type_identifier(create_id(declaration.f_type_identifier, filename), package),
         selected,
         location=node_location(declaration, filename),
     )
@@ -578,7 +574,7 @@ def create_function_decl(
             arguments.append(
                 decl.Argument(
                     create_id(p.f_identifier, filename),
-                    model.qualified_type_identifier(
+                    model.internal_type_identifier(
                         create_id(p.f_type_identifier, filename), package
                     ),
                 )
@@ -586,7 +582,7 @@ def create_function_decl(
     return decl.FunctionDeclaration(
         create_id(declaration.f_identifier, filename),
         arguments,
-        model.qualified_type_identifier(
+        model.internal_type_identifier(
             create_id(declaration.f_return_type_identifier, filename), package
         ),
         location=node_location(declaration, filename),
@@ -868,7 +864,7 @@ def create_message_types(
             for field in fields.f_fields
         ),
     ):
-        qualified_type_identifier = model.qualified_type_identifier(
+        qualified_type_identifier = model.internal_type_identifier(
             create_id(type_identifier, filename), identifier.parent
         )
         field_type = next((t for t in types if t.identifier == qualified_type_identifier), None)
@@ -1207,7 +1203,7 @@ def create_derived_message(
     # pylint: disable=too-many-arguments
     assert isinstance(derivation, lang.TypeDerivationDef)
     base_id = create_id(derivation.f_base, filename)
-    base_name = model.qualified_type_identifier(base_id, identifier.parent)
+    base_name = model.internal_type_identifier(base_id, identifier.parent)
 
     base_types: Sequence[model.Type] = [t for t in types if t.identifier == base_name]
 
@@ -1346,7 +1342,7 @@ def create_refinement(
 ) -> model.Refinement:
     messages = {t.identifier: t for t in types if isinstance(t, model.Message)}
 
-    pdu = model.qualified_type_identifier(create_id(refinement.f_pdu, filename), package)
+    pdu = model.internal_type_identifier(create_id(refinement.f_pdu, filename), package)
     if pdu not in messages:
         fail(
             f'undefined type "{pdu}" in refinement',
@@ -1355,7 +1351,7 @@ def create_refinement(
             node_location(refinement, filename),
         )
 
-    sdu = model.qualified_type_identifier(create_id(refinement.f_sdu, filename), package)
+    sdu = model.internal_type_identifier(create_id(refinement.f_sdu, filename), package)
     if sdu not in messages:
         fail(
             f'undefined type "{sdu}" in refinement of "{pdu}"',
@@ -1639,7 +1635,7 @@ class Parser:
 
         for t in spec.f_package_declaration.f_declarations:
             if isinstance(t, lang.TypeDecl):
-                identifier = model.qualified_type_identifier(
+                identifier = model.internal_type_identifier(
                     create_id(t.f_identifier, filename), package_id
                 )
                 try:

--- a/tests/unit/model/message_test.py
+++ b/tests/unit/model/message_test.py
@@ -3622,14 +3622,14 @@ def test_message_str() -> None:
         multilinestr(
             """type M (A : Boolean) is
                   message
-                     L : Modular
+                     L : P::Modular
                         then O
                            if L > 100
                         then P
                            if L <= 100;
-                     O : Modular
+                     O : P::Modular
                         then null;
-                     P : Modular;
+                     P : P::Modular;
                   end message"""
         ),
     )

--- a/tests/unit/model/model_test.py
+++ b/tests/unit/model/model_test.py
@@ -210,5 +210,5 @@ def test_write_specification_file_multiple_packages(tmp_path: Path) -> None:
 
            type U is mod 65536;
 
-        end P;"""
+        end Q;"""
     )

--- a/tests/unit/model/model_test.py
+++ b/tests/unit/model/model_test.py
@@ -5,6 +5,7 @@ from typing import Sequence
 
 import pytest
 
+import rflx.model.type_ as mty
 from rflx.error import Location, RecordFluxError
 from rflx.expression import Number
 from rflx.identifier import ID
@@ -18,7 +19,6 @@ from rflx.model import (
     Type,
 )
 from rflx.model.message import FINAL, INITIAL, Field, Link
-from rflx.model.type_ import Sequence as MSequence
 from tests.data import models
 
 
@@ -156,7 +156,7 @@ def test_invalid_enumeration_type_identical_literals() -> None:
 
 def test_write_specification_files(tmp_path: Path) -> None:
     t = ModularInteger("P::T", Number(256))
-    v = MSequence("P::V", element_type=t)
+    v = mty.Sequence("P::V", element_type=t)
     m = Message("P::M", [Link(INITIAL, Field("Foo")), Link(Field("Foo"), FINAL)], {Field("Foo"): t})
     Model([t, v, m]).write_specification_files(tmp_path)
     expected_path = tmp_path / Path("p.rflx")
@@ -180,7 +180,7 @@ def test_write_specification_files(tmp_path: Path) -> None:
 
 def test_write_specification_file_multiple_packages(tmp_path: Path) -> None:
     t = ModularInteger("P::T", Number(256))
-    u = MSequence("Q::U", element_type=t)
+    u = mty.Sequence("Q::U", element_type=t)
     v = ModularInteger("R::V", Number(65536))
     links = [
         Link(INITIAL, Field("Victor")),

--- a/tests/unit/model/model_test.py
+++ b/tests/unit/model/model_test.py
@@ -162,13 +162,13 @@ def test_write_specification_files(tmp_path: Path) -> None:
     assert expected_path.read_text() == textwrap.dedent(
         """\
         package P is
-        
+
            type T is mod 256;
-        
+
            type M is
               message
                  Foo : P::T;
               end message;
-        
+
         end P;"""
     )


### PR DESCRIPTION
Supersedes #1007.

---

- [x] Use fully qualified type names in message fields
- [x] Add necessary `with` clauses to resolve imports  