### PR TITLE
Deduplicate the `with` imports being generated

### DIFF
--- a/rflx/model/model.py
+++ b/rflx/model/model.py
@@ -46,14 +46,8 @@ class Model(Base):
         for ty in self.__types:
             if not type_.is_builtin_type(ty.name) and not type_.is_internal_type(ty.name):
                 pkg_name: ID = ty.package
-                pkg: Package = pkgs.setdefault(pkg_name, Package(pkg_name))
-                for dep in ty.direct_dependencies:
-                    if dep.package not in [
-                        pkg_name,
-                        const.BUILTINS_PACKAGE,
-                        const.INTERNAL_PACKAGE,
-                    ]:
-                        pkg.imports.append(dep.package)
+                pkg = pkgs.setdefault(pkg_name, Package(pkg_name))
+                pkg.imports |= {dep.package for dep in ty.direct_dependencies}
                 pkg.types.append(ty)
         for sess in self.__sessions:
             pkg_name = sess.package

--- a/rflx/model/package.py
+++ b/rflx/model/package.py
@@ -1,7 +1,8 @@
 import textwrap
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Set
 
+from rflx import const
 from rflx.identifier import ID
 
 from . import session, type_
@@ -10,13 +11,18 @@ from . import session, type_
 @dataclass
 class Package:
     name: ID
-    imports: List[ID] = field(default_factory=list)
+    imports: Set[ID] = field(default_factory=set)
     types: List[type_.Type] = field(default_factory=list)
     sessions: List[session.Session] = field(default_factory=list)
 
     @property
     def imports_str(self) -> str:
-        return "\n".join(f"with {i};" for i in self.imports)
+        explicit_imports = self.imports - {
+            self.name,
+            const.BUILTINS_PACKAGE,
+            const.INTERNAL_PACKAGE,
+        }
+        return "\n".join(f"with {i};" for i in sorted(explicit_imports))
 
     @property
     def begin_str(self) -> str:

--- a/tests/unit/model/model_test.py
+++ b/tests/unit/model/model_test.py
@@ -181,6 +181,7 @@ def test_write_specification_files(tmp_path: Path) -> None:
 def test_write_specification_file_multiple_packages(tmp_path: Path) -> None:
     t = ModularInteger("P::T", Number(256))
     u = mty.Sequence("Q::U", element_type=t)
+    u1 = mty.Sequence("Q::U1", element_type=t)
     v = ModularInteger("R::V", Number(65536))
     links = [
         Link(INITIAL, Field("Victor")),
@@ -189,7 +190,7 @@ def test_write_specification_file_multiple_packages(tmp_path: Path) -> None:
     ]
     fields = {Field("Victor"): v, Field("Uniform"): u}
     m = Message("R::M", links, fields)
-    Model([t, v, m, u]).write_specification_files(tmp_path)
+    Model([t, v, u1, m, u]).write_specification_files(tmp_path)
     p_path, q_path, r_path = (tmp_path / Path(pkg + ".rflx") for pkg in ("p", "q", "r"))
     assert set(tmp_path.glob("*.rflx")) == {p_path, q_path, r_path}
     assert p_path.read_text() == textwrap.dedent(
@@ -205,6 +206,8 @@ def test_write_specification_file_multiple_packages(tmp_path: Path) -> None:
         with P;
 
         package Q is
+
+           type U1 is sequence of P::T;
 
            type U is sequence of P::T;
 


### PR DESCRIPTION
This PR fixes potential duplicate `with` imports by using a `set` to represent all imports in a package (instead of a `list`), and the output is stablized by sorting all the imports alphabetically.