### PR TITLE
Fix failing DHCP Client test in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -724,6 +724,9 @@ jobs:
           - dhcp_client
     env:
       python-version: 3.7
+      # SPARK requires more than the available 7 GB of RAM for proving the DHCP client, if multiple
+      # processes are used.
+      GNATPROVE_PROCS: 1
     steps:
     - uses: actions/checkout@v2
       if: ${{ needs.skip_check_apps.outputs.should_skip != 'true' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.0
         with:
-          paths: '["rflx/**", "tests/**"]'
+          paths: '[".github/workflows/**", "rflx/**", "tests/**"]'
           paths_ignore: '["tests/spark/**"]'
 
   tests_python:
@@ -242,7 +242,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.0
         with:
-          paths: '["defaults.gpr", "examples/apps/**", "rflx/**", "tests/**"]'
+          paths: '[".github/workflows/**", "defaults.gpr", "examples/apps/**", "rflx/**", "tests/**"]'
 
   compilation:
     name: Compilation
@@ -483,7 +483,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.0
         with:
-          paths: '["*.gpr", "tests/spark/**"]'
+          paths: '[".github/workflows/**", "*.gpr", "tests/spark/**"]'
 
   runtime_compatibility:
     name: Runtime compatibility
@@ -626,7 +626,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.0
         with:
-          paths: '["defaults.gpr", "examples/apps/**", "rflx/**"]'
+          paths: '[".github/workflows/**", "defaults.gpr", "examples/apps/**", "rflx/**"]'
 
   tests_apps:
     name: App Tests
@@ -807,7 +807,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.0
         with:
-          paths: '["defaults.gpr", "examples/specs/**", "rflx/**"]'
+          paths: '[".github/workflows/**", "defaults.gpr", "examples/specs/**", "rflx/**"]'
 
   tests_specs:
     name: Specification Tests


### PR DESCRIPTION
This also improves the workflow to ensure that all tests are executed if the workflow was modified.

@kanigsson Proving the DHCP client still needs too much memory for using multiprocessing: https://github.com/Componolit/RecordFlux/runs/7090258097?check_suite_focus=true.