### PR TITLE
Issue 1003: Determine package version based on SCM metadata

### DIFF
--- a/rflx/__init__.py
+++ b/rflx/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "0.6.0-pre"
+from pkg_resources import get_distribution
+
+__version__ = get_distribution("RecordFlux").version

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import re
 import site
 
 from setuptools import find_packages, setup
@@ -7,17 +6,11 @@ from setuptools import find_packages, setup
 # PEP517 workaround
 site.ENABLE_USER_SITE = True
 
-with open("rflx/__init__.py", encoding="utf-8") as f:
-    match = re.search(r'__version__ = "(.*?)"', f.read())
-    assert match
-    version = match.group(1)
-
 with open("README.md", encoding="utf-8") as f:
     readme = f.read()
 
 setup(
     name="RecordFlux",
-    version=version,
     description=(
         "A toolset for the formal specification of messages and the generation of "
         "verifiable binary parsers and message generators."
@@ -63,6 +56,7 @@ setup(
             "pyicontract-lint >=2.1.2, <2.2",
             "tqdm >=4.61.1, <4.63",
             "types-pkg_resources >=0.1.3, <0.2",
+            "setuptools_scm >=6.2, <8",
         ]
     },
     scripts=["bin/rflx"],


### PR DESCRIPTION
With this change, a distinct version is determined based on the tags of the git repository. This approach has some limitations:

1.  The current version can be shown inside the repository using `python -m setuptools_scm`. If the project is installed in editable/development mode, the version shown by `rflx --version` might be incorrect. `rflx --version` shows the version of the last `pip install -e .`. A workaround could be executing `pip install --no-deps -e .` after creating a commit (e.g., as post-commit hook).

```console
$ python -m setuptools_scm
0.5.1.dev402+g479641262.d20220708
$ rflx --version          
RecordFlux 0.5.1.dev402+g479641262
[...]
$ pip install --no-deps -e .
[...]
$ rflx --version
RecordFlux 0.5.1.dev402+g479641262.d20220708
[...]
```

2. The git metadata is required for determining the version when creating a package. Thus, just providing the repository content (as we do for SPDM) is not sufficient. We could provide a Python package (source distribution or wheel) instead.

Closes #1003