### PR TITLE
Improve time needed to determine test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,13 +191,6 @@ jobs:
         version: ${{ env.GNAT_VERSION }}
         ssh_key: ${{ secrets.MEMCACHED_SSH_KEY }}
         server: ${{ secrets.MEMCACHED_SERVER }}
-    - name: Install SPARK Pro
-      uses: ./.github/actions/install_spark_pro
-      if: ${{ needs.skip_check_python.outputs.should_skip != 'true' }}
-      with:
-        version: ${{ env.SPARK_VERSION }}
-        ssh_key: ${{ secrets.MEMCACHED_SSH_KEY }}
-        server: ${{ secrets.MEMCACHED_SERVER }}
     - name: Install dependencies
       if: ${{ needs.skip_check_python.outputs.should_skip != 'true' }}
       run: |
@@ -207,25 +200,6 @@ jobs:
         sudo apt install graphviz libgmp-dev patchelf
         python -m pip install --upgrade pip wheel
         make install_devel
-    - name: Connect to Memcached server
-      if: ${{ needs.skip_check_python.outputs.should_skip != 'true' }}
-      shell: bash
-      env:
-        SSH_KEY: ${{ secrets.MEMCACHED_SSH_KEY }}
-        SERVER: ${{ secrets.MEMCACHED_SERVER }}
-      run: |
-        eval $(ssh-agent -s)
-        echo "$SSH_KEY" | tr -d '\r' | ssh-add - &>/dev/null
-        mkdir -p ~/.ssh
-        chmod 700 ~/.ssh
-        ssh-keyscan $SERVER >> ~/.ssh/known_hosts
-        chmod 644 ~/.ssh/known_hosts
-        ssh -L 11211:localhost:11211 -N -T -f -o ExitOnForwardFailure=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=3 ci@$SERVER &>/dev/null
-        echo "stats" | nc -q 1 localhost 11211
-    - name: Configure kernel parameters
-      if: ${{ needs.skip_check_python.outputs.should_skip != 'true' }}
-      run: |
-        sudo /sbin/sysctl -w net.ipv4.ping_group_range="0 2147483647"
     - name: Test
       if: ${{ needs.skip_check_python.outputs.should_skip != 'true' }}
       run: |
@@ -550,6 +524,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        target:
+          - "tests"
         test:
           - "builtin_types"
           - "custom_types"
@@ -564,6 +540,8 @@ jobs:
           - "ipv4"
           - "sequence"
           - "tlv"
+        include:
+          - target: "python_tests"
     env:
       python-version: "3.8"
     steps:
@@ -633,8 +611,10 @@ jobs:
         echo "stats" | nc -q 1 localhost 11211
     - name: Verify
       if: ${{ needs.skip_check_spark.outputs.should_skip != 'true' }}
+      env:
+        TEST: ${{ matrix.test }}
       run: |
-        make prove_tests TEST=${{ matrix.test }}
+        make prove_${{ matrix.target }}
 
   skip_check_apps:
     name: Skip Check Apps

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test_python_optimized:
 	PYTHONOPTIMIZE=1 $(PYTEST) -m "not verification and not hypothesis" tests
 
 test_python_coverage:
-	$(PYTEST) --cov=rflx --cov-branch --cov-fail-under=100 --cov-report=term-missing:skip-covered -m "not hypothesis" tests
+	$(PYTEST) --cov=rflx --cov-branch --cov-fail-under=100 --cov-report=term-missing:skip-covered -m "not verification and not hypothesis" tests
 
 test_apps:
 	$(MAKE) -C examples/apps/ping test_python


### PR DESCRIPTION
This excludes all verification tests from the `test_python_coverage` target. This improves the time needed to determine the test coverage significantly (e.g., 1:30 min vs. 9:40 min on funafuti).