### PR TITLE
Issue 1183, 1183: Fix GNAT Studio plugin installation and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,13 @@ test_specs:
 	cd examples/specs && $(PYTEST) tests/test_specs.py
 
 test_installation:
-	rm -rf $(build-dir)/venv
+	rm -rf $(build-dir)/venv $(build-dir)/test_installation
+	mkdir -p $(build-dir)/test_installation
 	python3 -m venv $(build-dir)/venv
 	$(build-dir)/venv/bin/pip install .
 	$(build-dir)/venv/bin/rflx --version
+	HOME=$(build-dir)/test_installation $(build-dir)/venv/bin/rflx setup_ide
+	test -f $(build-dir)/test_installation/.gnatstudio/plug-ins/recordflux.py
 
 prove: prove_tests prove_python_tests prove_apps
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build-dir := build
 	format \
 	test test_python test_python_unit test_python_integration test_python_property test_python_property_verification test_python_optimized test_python_coverage test_apps test_compilation test_binary_size test_specs test_installation \
 	prove prove_tests prove_python_tests prove_apps \
-	install_gnatstudio install_devel install_devel_edge upgrade_devel install_gnat printenv_gnat \
+	install_devel install_devel_edge upgrade_devel install_gnat printenv_gnat \
 	generate \
 	doc \
 	dist \
@@ -119,9 +119,6 @@ prove_python_tests:
 prove_apps:
 	$(MAKE) -C examples/apps/ping prove
 	$(MAKE) -C examples/apps/dhcp_client prove
-
-install_gnatstudio:
-	install -m 644 ide/gnatstudio/recordflux.py ${HOME}/.gnatstudio/plug-ins/recordflux.py
 
 install_devel:
 	tools/check_pip_version.py

--- a/doc/development_guide/index.rst
+++ b/doc/development_guide/index.rst
@@ -41,7 +41,6 @@ Make targets for common development tasks are:
 - ``upgrade_devel`` Upgrade all development dependencies (note: ``install_devel`` must be executed before changes in ``setup.py`` take effect)
 - ``doc`` Generate HTML documentation
 - ``dist`` Create Python package
-- ``setup_ide`` Install files required for RecordFlux IDE integration
 
 Additional tools can be found in ``tools/``.
 

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -32,11 +32,11 @@ By default the following dependencies are installed:
 
 Optionally, the GNAT Studio IDE integration for RecordFlux can be installed.
 It enables syntax highlighting for RecordFlux specifications and allows for running RecordFlux from within GNAT Studio.
-In the RecordFlux source directory do:
+After installing RecordFlux do:
 
 .. code:: console
 
-   $ make install_gnatstudio
+   $ rflx setup_ide
 
 .. |GNAT Alire Crate| image:: https://img.shields.io/endpoint?url=https://alire.ada.dev/badges/gnat_native.json
    :target: https://alire.ada.dev/crates/gnat_native.html

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "Topic :: Software Development :: Code Generators",
         "Topic :: System :: Networking",
     ],
-    packages=find_packages(include=("rflx", "rflx.*")),
+    packages=find_packages(include=("rflx", "rflx.*", "ide")),
     package_data={"rflx": ["py.typed", "templates/*"], "ide": ["gnatstudio/*"]},
     python_requires=">=3.8",
     install_requires=[


### PR DESCRIPTION
I removed the `install_gnatstudio` (and it's bogus documentation) altogether as a properly installed `rflx` in a matching version is required for the plugin to work. Hence, it makes no sense to support installation from the source tree.

The installation should be fixed now. It happened to work when tested with `PYTHONPATH=. rflx setup_ide` in the source directory and we didn't test with the installed command. I added a respective test to the `test_installation` target.

Closes #1183 
Closes #1184