### PR TITLE
Add 'api' subtype for Ada code blocks

### DIFF
--- a/tests/tools/check_doc_test.py
+++ b/tests/tools/check_doc_test.py
@@ -117,6 +117,31 @@ def test_invalid_ada_code() -> None:
         )
 
 
+@pytest.mark.compilation
+def test_invalid_ada_api_style() -> None:
+    with pytest.raises(
+        CheckDocError,
+        match=(
+            r"^<stdin>:4: error in code block\n"
+            r"main.adb:2:25: \(style\) space required\n"
+            r"gprbuild: [*][*][*] compilation phase failed\n$"
+        ),
+    ):
+        check_file(
+            STDIN,
+            """\
+
+.. doc-check: ada,api
+.. code:: ada
+    :number-lines:
+
+    function Get_Tag (Ctx:Context) return RFLX.TLV.Tag_Type;
+
+Some more text...
+""",
+        )
+
+
 def test_invalid_rflx_spec() -> None:
     with pytest.raises(
         CheckDocError,
@@ -297,6 +322,30 @@ An Ada declaration looks as follows:
     :number-lines:
 
     I : Integer;
+
+Some more text...
+""",
+    )
+
+
+@pytest.mark.compilation
+def test_valid_ada_api() -> None:
+    check_file(
+        STDIN,
+        """\
+An Ada API looks as follows:
+
+.. doc-check: ada,api
+.. code:: ada
+    :number-lines:
+
+    function Get_Tag    (Ctx : Context) return RFLX.TLV.Tag_Type;
+    function Get_Length (Ctx : Context) return RFLX.TLV.Length_Type;
+    function Get_Value  (Ctx : Context) return RFLX_Types.Bytes;
+    procedure Get_Value (Ctx : Context; Data : out RFLX_Types.Bytes);
+    generic
+       with procedure Process_Value (Value : RFLX_Types.Bytes);
+    procedure Generic_Get_Value (Ctx : Context);
 
 Some more text...
 """,

--- a/tools/check_doc.py
+++ b/tools/check_doc.py
@@ -218,12 +218,17 @@ def check_rflx_code(block: str, subtype: str = None) -> None:
 
 
 def check_ada_code(block: str, subtype: str = None) -> None:
+    args = []
     unit = "main"
 
     if subtype is None:
         data = block
     elif subtype == "declaration":
         data = f"procedure {unit.title()} is {block} begin null; end {unit.title()};"
+    elif subtype == "api":
+        args = ["-gnats", "-gnaty", "-gnatwe"]
+        formated_block = textwrap.indent(textwrap.dedent(block), "   ")
+        data = f"package {unit.title()} is\n{formated_block}\nend {unit.title()};"
     else:
         raise CheckDocError(f"invalid Ada subtype '{subtype}'")
 
@@ -235,7 +240,7 @@ def check_ada_code(block: str, subtype: str = None) -> None:
         os.symlink(GENERATED_DIR.resolve(), tmpdir / "generated", target_is_directory=True)
 
         result = subprocess.run(
-            ["gprbuild", "-j0", "--no-project", "-q", "-u", "--src-subdirs=generated", unit],
+            ["gprbuild", "-j0", "--no-project", "-q", "-u", "--src-subdirs=generated", unit, *args],
             check=False,
             capture_output=True,
             encoding="utf-8",


### PR DESCRIPTION
Fixes #1240

I decided to add an `api` subtype to Ada code blocks, as this seems to be the main unsupported use case in the manual.

With the `api` subtype, code is only syntax checked (`-gnats`), but style checks are also enforced (`gnaty` + `gnatwe`).