### PR TITLE
Deploy to PyPI using GitHub workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to PyPI
+on:
+  release:
+    types:
+      - published
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Set up environment
+      run: |
+        python -m pip install build
+        make init
+    - name: Build distribution
+      run: |
+        python -m build --sdist
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ doc: check_doc
 	$(MAKE) -C doc html
 
 dist:
-	python3 setup.py sdist
+	python3 -m build --sdist
 
 clean:
 	rm -rf $(BUILD_DIR) .coverage .hypothesis .mypy_cache .pytest_cache

--- a/doc/development_guide/index.rst
+++ b/doc/development_guide/index.rst
@@ -153,8 +153,6 @@ Checklist for releasing new versions
     - [ ] Check project on TestPyPI
     - [ ] Test installation from TestPyPI
        - `pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ RecordFlux`
-    - [ ] Upload to PyPI
-       - `twine upload dist/RecordFlux-X.Y.Z.tar.gz`
+    - [ ] Publish release on GitHub
     - [ ] Test installation from PyPI
        - `pip3 install RecordFlux`
-    - [ ] Publish release notes on GitHub

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     ],
     extras_require={
         "devel": [
+            "build >= 0.9.0, <1",
             "furo == 2022.4.7",
             "hypothesis >=6.14, <6.24",
             "pyicontract-lint >=2.1.2, <2.2",


### PR DESCRIPTION
Fixes #1162

It's not completely unlikely that this change will automatically deploy to PyPI next time we publish a release. Tested with a copy of RecordFlux on TestPyPI, but obviously not the real thing.