### PR TITLE
Ensure creation of cache directory before running GNATprove and refactor make targets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,22 +109,22 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - "python_coverage"
+          - "coverage"
         python-version:
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
         include:
-          - target: "python_unit_coverage"
+          - target: "unit_coverage"
             python-version: "3.11"
-          - target: "python_property"
+          - target: "property"
             python-version: "3.8"
-          - target: "python_optimized"
+          - target: "optimized"
             python-version: "3.8"
-          - target: "python_tools"
+          - target: "tools"
             python-version: "3.8"
-          - target: "python_ide"
+          - target: "ide"
             python-version: "3.8"
     env:
       GNAT: "pro23.0w-20220723"
@@ -318,7 +318,7 @@ jobs:
         run: |
           make test_binary_size
 
-  verification_python_scheduled:
+  verification_property_tests:
     name: Verification
     if: github.event.schedule
     runs-on: ubuntu-20.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -325,7 +325,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["python_property_verification"]
+        target: ["property_tests"]
         python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
@@ -380,7 +380,7 @@ jobs:
           spark-${{ matrix.target }}-${{ runner.os }}-spark${{ env.SPARK_VERSION }}
     - name: Test
       run: |
-        make test_${{ matrix.target }}
+        make prove_${{ matrix.target }}
     - name: Save SPARK cache
       uses: actions/cache/save@v3.2.2
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ deinit:
 
 .PHONY: check check_packages check_dependencies check_black check_isort check_flake8 check_pylint check_mypy check_contracts check_pydocstyle check_doc \
 	format \
-	test test_python test_python_unit test_python_integration test_python_property test_python_property_verification test_python_optimized test_python_coverage test_apps test_compilation test_binary_size test_specs test_installation \
-	prove prove_tests prove_python_tests prove_apps \
+	test test_python test_python_unit test_python_integration test_python_property test_python_optimized test_python_coverage test_apps test_compilation test_binary_size test_specs test_installation \
+	prove prove_tests prove_python_tests prove_apps prove_property_tests \
 	install_devel install_devel_edge upgrade_devel install_gnat printenv_gnat \
 	generate \
 	doc \
@@ -144,9 +144,6 @@ test_python_tools:
 test_python_ide:
 	$(PYTEST) tests/ide
 
-test_python_property_verification:
-	$(PYTEST) tests/property_verification
-
 test_python_optimized:
 	PYTHONOPTIMIZE=1 $(PYTEST) tests/unit tests/integration tests/compilation
 
@@ -200,6 +197,9 @@ prove_python_tests: $(GNATPROVE_CACHE_DIR)
 prove_apps: $(GNATPROVE_CACHE_DIR)
 	$(MAKE) -C examples/apps/ping prove
 	$(MAKE) -C examples/apps/dhcp_client prove
+
+prove_property_tests: $(GNATPROVE_CACHE_DIR)
+	$(PYTEST) tests/property_verification
 
 $(GNATPROVE_CACHE_DIR):
 	mkdir -p $(GNATPROVE_CACHE_DIR)


### PR DESCRIPTION
- Fix missing creation of cache directory before running GNATprove in property tests
- Remove unused make targets
- Ensure all tests are executed for "test" target
- Make target names more concise
- Fix phony targets